### PR TITLE
chore: re-enable release condition and align package versions

### DIFF
--- a/.changeset/align-package-versions.md
+++ b/.changeset/align-package-versions.md
@@ -1,0 +1,6 @@
+---
+"@launchfile/macos-dev": minor
+"launchfile": patch
+---
+
+Aligned all package versions and dependency ranges. Updated macos-dev from 0.1.4 to match the rest of the monorepo, and pinned CLI dependency ranges to ^0.1.10.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,7 @@ permissions: {}
 
 jobs:
   release:
-    # TODO: re-enable condition after first successful run
-    # if: github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'chore: version packages')
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'chore: version packages')
     name: Publish to npm
     runs-on: ubuntu-latest
     environment: npm-publish

--- a/packages/launchfile/package.json
+++ b/packages/launchfile/package.json
@@ -38,8 +38,8 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@launchfile/sdk": "^0.1.8",
-    "@launchfile/docker": "^0.1.8"
+    "@launchfile/sdk": "^0.1.10",
+    "@launchfile/docker": "^0.1.10"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.10",

--- a/providers/macos-dev/package.json
+++ b/providers/macos-dev/package.json
@@ -33,7 +33,7 @@
     "directory": "providers/macos-dev"
   },
   "dependencies": {
-    "@launchfile/sdk": "^0.1.4",
+    "@launchfile/sdk": "^0.1.10",
     "semver": "^7.7.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Re-enable the `if:` condition on the release workflow (was commented out during debugging)
- Align dependency ranges: macos-dev SDK dep `^0.1.4` → `^0.1.10`, CLI deps `^0.1.8` → `^0.1.10`
- Changeset to bump `@launchfile/macos-dev` to match the rest of the monorepo

## Test plan

- [x] CI passes (SDK, providers, websites)
- [ ] After merge, release workflow should NOT fire (commit message won't match)
- [ ] Changesets workflow opens a Version Packages PR for the macos-dev bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)