### PR TITLE
chore: realign linked changeset to release all four packages at 0.2.0

### DIFF
--- a/.changeset/align-package-versions.md
+++ b/.changeset/align-package-versions.md
@@ -1,6 +1,0 @@
----
-"@launchfile/macos-dev": minor
-"launchfile": patch
----
-
-Aligned all package versions and dependency ranges. Updated macos-dev from 0.1.4 to match the rest of the monorepo, and pinned CLI dependency ranges to ^0.1.10.

--- a/.changeset/linked-release-0.2.0.md
+++ b/.changeset/linked-release-0.2.0.md
@@ -1,0 +1,17 @@
+---
+"@launchfile/sdk": minor
+"@launchfile/docker": minor
+"@launchfile/macos-dev": minor
+"launchfile": patch
+---
+
+## Features
+
+- **sdk**: `$app.*` resolver context (D-33) — platform-injected app properties (`$app.url`, `$app.host`, `$app.port`) now resolve alongside `$resources` in Launchfile expressions.
+- **sdk**: pipe transforms for encoding (D-32) — secrets and refs can be piped through `|base64`, e.g. `${secrets.app-key|base64}`, required for Laravel-style `APP_KEY` formats.
+- **docker provider**: populates `$app.*` in the resolver context so docker-compose generation can reference app properties (D-33).
+- **macos-dev provider**: populates `$app.*` in the resolver context so local macOS runs can reference app properties (D-33).
+
+## Alignment
+
+All four packages release together at 0.2.0 via the linked group in `.changeset/config.json`. `@launchfile/macos-dev` catches up from 0.1.4 and the CLI advances from 0.1.9. Internal dependency ranges (sdk, docker) are pinned to `^0.2.0` in every consumer.


### PR DESCRIPTION
## Summary

Follow-up to #11. The linked group in `.changeset/config.json` keeps `@launchfile/sdk`, `@launchfile/docker`, `@launchfile/macos-dev`, and `launchfile` at the same version — but PR #11's changeset only marked macos-dev and the CLI, which would produce a **misaligned** release via the pending Version Packages PR (#18):

| Package | Before | After #18 (as-is) | After this fix |
|---------|--------|-------------------|----------------|
| `@launchfile/sdk` | 0.1.10 | 0.1.10 | **0.2.0** |
| `@launchfile/docker` | 0.1.10 | 0.1.10 | **0.2.0** |
| `@launchfile/macos-dev` | 0.1.4 | 0.2.0 | 0.2.0 |
| `launchfile` (CLI) | 0.1.9 | 0.2.0 | 0.2.0 |

That is the opposite of what PR #11's changeset body claimed ("aligned all package versions").

## What this PR does

Replaces `.changeset/align-package-versions.md` with `.changeset/linked-release-0.2.0.md`, which marks all four linked packages for release and tells the real unreleased-feature story instead of the alignment chore story:

- **sdk**: `$app.*` resolver context (D-33) + pipe transforms for encoding (D-32, e.g. `${secrets.app-key|base64}`)
- **docker provider**: `$app.*` in resolver context (D-33)
- **macos-dev provider**: `$app.*` in resolver context (D-33)

**That's it — one file swap.** Internal dependency ranges are NOT touched in this PR.

## Why not bump `^0.1.10` → `^0.2.0` here too?

Earlier revision of this commit did. CI failed:

```
error: No version matching "^0.2.0" found for specifier "@launchfile/sdk" (but package exists)
error: No version matching "^0.2.0" found for specifier "@launchfile/docker" (but package exists)
```

Bun's workspace resolution requires the dep range to satisfy the declared version in the local workspace package — it does not behave like `workspace:*`. The sources still say `0.1.10` / `0.1.9` / `0.1.4`, so a `^0.2.0` range falls through to npm, finds nothing, and `bun install --frozen-lockfile` aborts.

The clean path is to let the changesets action handle both source version bumps and internal dep-range rewrites atomically in #18. The `updateInternalDependencies: "patch"` setting in `.changeset/config.json` exists exactly for this — it rewrites caret ranges across a 0.1 → 0.2 boundary when it consumes the changeset.

## After merge

1. The changesets GitHub Action regenerates #18 against this commit. All four packages should appear at **0.2.0**, with `^0.1.10` → `^0.2.0` dep range updates in the CLI and providers, and CHANGELOG.md entries describing D-32/D-33.
2. Merge #18 → release workflow fires (commit headline matches `chore: version packages`) → all four packages publish to npm as 0.2.0.
3. Re-run smoke tests against the freshly published 0.2.0 set.

## Test plan

- [ ] CI green on this PR (SDK, providers, CLI, websites, CodeQL)
- [ ] After merge, #18 is regenerated with all four packages at 0.2.0
- [ ] After merge, #18 includes caret-range updates to `^0.2.0` in CLI + docker + macos-dev package.json
- [ ] After merge, #18's CHANGELOG.md for sdk mentions D-32 and D-33
- [ ] After merge, #18's CHANGELOG.md for docker/macos-dev mentions D-33

## Out of scope

- Monica `type: mariadb` regression and missing `health:` on catalog apps (tracked as follow-up to #10 / #11 in a separate issue).
- Automating "changeset must cover all linked-group packages" as a CI check. Worth doing, but belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)