### PR TITLE
chore: fix invalid YAML in release.yml if: condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,9 @@ permissions: {}
 
 jobs:
   release:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'chore: version packages')
+    # Value is double-quoted because 'chore: version packages' contains a
+    # colon-space, which YAML otherwise interprets as a mapping separator.
+    if: "github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'chore: version packages')"
     name: Publish to npm
     runs-on: ubuntu-latest
     environment: npm-publish


### PR DESCRIPTION
## Summary

The release workflow's `if:` condition is **invalid YAML**. GitHub Actions has been rejecting `.github/workflows/release.yml` on every push since PR #11 re-enabled the gate, with the classic "workflow file issue" startup failure (0 jobs, 0s duration). This PR fixes the syntax with one double-quote pair.

## Root cause

Line 15 of `release.yml` was:

```yaml
    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'chore: version packages')
```

The value is unquoted, and it contains the substring `'chore: version packages'`. YAML's flow-scalar parser sees the `: ` inside that substring as a mapping key-value separator — even though a human reader sees it as a single-quoted string literal inside a GitHub Actions expression. YAML's quoting rules require the **entire value** to be wrapped in quotes for inner punctuation to be protected; inner single quotes alone are not enough.

Reproduced locally with PyYAML:

```
yaml.scanner.ScannerError: mapping values are not allowed here
  in "<unicode string>", line 3, column 104:
     ... .head_commit.message, 'chore: version packages')
                                         ^
```

Column 104 is exactly the colon inside `'chore: version packages'`.

## Fix

Wrap the whole `if:` value in double quotes:

```yaml
    # Value is double-quoted because 'chore: version packages' contains a
    # colon-space, which YAML otherwise interprets as a mapping separator.
    if: "github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'chore: version packages')"
```

Expression semantics are unchanged — double-quoting a YAML scalar does not alter its string content, and GitHub Actions strips the outer quotes before evaluating the expression. A comment explains the quoting so no one accidentally removes it later.

## Verified

| Check | Result |
|---|---|
| PyYAML parses the new file cleanly | ✅ |
| `on:` block contains both `workflow_dispatch` and `push` triggers | ✅ |
| `jobs.release.if` value is preserved byte-for-byte | ✅ |
| `actionlint` clean | ✅ (also passed the broken version — see "Detection gap" below) |

## Impact

Before this fix, 29 of the last 30 runs of `release.yml` failed at startup:

- Every push to `main` (including the merges of #11, #15, #13, #10, #19) produced a red X in Actions
- Even the pending `chore: version packages` merge from #18 would have failed to publish, because the workflow cannot validate → cannot run its `if:` gate → cannot reach the publish steps
- The one successful run (2026-04-08, commit `ff9168b`) worked only because the `if:` line was commented out entirely at that time, so the invalid YAML wasn't present

After this fix:

- The workflow file becomes valid, so GitHub Actions can parse it
- On non-`chore: version packages` commits the `if:` gate evaluates false and the job is cleanly **skipped** (not failed), which is what was intended
- On the next `chore: version packages` merge (which will be #18, after this lands), the `if:` gate matches, the job runs, and npm publishing actually happens

## Detection gap worth noting

`actionlint` (v1.7.12) passed this file **both before and after** the fix. Its YAML parser is more lenient than GitHub's own parser and silently accepts the unquoted value. We cannot rely on `actionlint` alone to catch this class of bug in pre-commit or CI. Adding a `python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` check (or equivalent) to CI would have caught this.

Filing that as a follow-up is out of scope for this PR, but worth tracking.

## Test plan

- [ ] CI on this PR green
- [ ] After merge, pushing to `main` no longer produces red Xs on `.github/workflows/release.yml`
- [ ] The next `chore: version packages` merge (#18 once the changesets action reopens it post-merge) actually runs the release job instead of startup-failing
- [ ] npm trusted publishing succeeds for `@launchfile/sdk`, `@launchfile/docker`, `@launchfile/macos-dev`, and `launchfile` at 0.2.0 when #18 is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)