### PR TITLE
chore: add workflow YAML lint job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,34 @@ jobs:
       - run: cd ${{ matrix.site }} && bun install --frozen-lockfile
       - run: cd ${{ matrix.site }} && bun run typecheck
       - run: cd ${{ matrix.site }} && bun run build
+
+  # Catches invalid YAML in workflow files before it gets merged and breaks
+  # the CI/release pipeline. actionlint alone is not sufficient here — it
+  # silently accepted the invalid release.yml that motivated this job (PR #23).
+  workflow-lint:
+    name: Workflow Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Validate workflow YAML with strict parser
+        run: |
+          python3 - <<'PY'
+          import glob, sys, yaml
+          files = sorted(
+              glob.glob('.github/workflows/*.yml')
+              + glob.glob('.github/workflows/*.yaml')
+          )
+          failed = []
+          for f in files:
+              try:
+                  with open(f) as fh:
+                      yaml.safe_load(fh)
+                  print(f'  ok  {f}')
+              except yaml.YAMLError as e:
+                  failed.append((f, str(e)))
+                  print(f'FAIL  {f}:\n{e}\n', file=sys.stderr)
+          if failed:
+              print(f'\n{len(failed)} workflow file(s) failed YAML validation', file=sys.stderr)
+              sys.exit(1)
+          print(f'\n{len(files)} workflow file(s) parsed cleanly')
+          PY


### PR DESCRIPTION
## Summary

Adds a new `workflow-lint` job to `.github/workflows/ci.yml` that runs a strict YAML parser (PyYAML) against every `.github/workflows/*.yml` file on every PR. If any workflow file fails to parse, the job fails and the PR is blocked.

## Motivation

PR #23 fixed an invalid `if:` expression in `release.yml` that had been causing every release workflow run to startup-fail with *"Invalid workflow file"* since PR #11 re-enabled the gate. Every push to main for several days produced a red X on `release.yml` before the root cause was found.

This class of bug is especially hard to catch:

| Signal | Why it failed us |
|---|---|
| Local parse | Nothing runs until you push |
| `actionlint` v1.7.12 | Silently accepted the broken file — its YAML parser is more lenient than GitHub's |
| Actions API | The "Invalid workflow file" error is only in the web UI HTML, not any API response |
| CI | We had no workflow file lint job at all |

The specific YAML trap: flow-scalar values can contain what look like single-quoted substrings, but YAML still interprets `: ` inside those substrings as a mapping separator unless the **entire** value is wrapped in quotes. PyYAML (which matches GitHub's parser for this case) catches it; actionlint doesn't.

## The fix

One new job at the end of `ci.yml`:

```yaml
  workflow-lint:
    name: Workflow Lint
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
      - name: Validate workflow YAML with strict parser
        run: |
          python3 - <<'PY'
          import glob, sys, yaml
          files = sorted(
              glob.glob('.github/workflows/*.yml')
              + glob.glob('.github/workflows/*.yaml')
          )
          failed = []
          for f in files:
              try:
                  with open(f) as fh:
                      yaml.safe_load(fh)
                  print(f'  ok  {f}')
              except yaml.YAMLError as e:
                  failed.append((f, str(e)))
                  print(f'FAIL  {f}:\n{e}\n', file=sys.stderr)
          if failed:
              print(f'\n{len(failed)} workflow file(s) failed YAML validation', file=sys.stderr)
              sys.exit(1)
          print(f'\n{len(files)} workflow file(s) parsed cleanly')
          PY
```

No new dependencies: `python3` and PyYAML are pre-installed on GitHub-hosted `ubuntu-latest` runners. The job has no `needs:` chain so it runs in parallel with SDK/CLI/Providers/Websites and completes in well under a second.

## Regression test (did it locally)

Ran the same parser against the pre-PR-#23 state of `release.yml`:

```
PASS: check would catch bug -> mapping values are not allowed here
```

So if someone reintroduces the same bug (or a similar one in another workflow), this job fails the PR instead of letting it land.

## What this PR explicitly does NOT do

- Does not remove `actionlint` from anything — `actionlint` is still useful for catching action-specific issues that a pure YAML parser cannot see (unknown action inputs, deprecated fields, etc.). This job is additive.
- Does not add a pre-commit hook. Pre-commit hooks require local setup and are easier to bypass. CI is the durable enforcement point.
- Does not validate the `on:`-block schema, job dependency graph, or anything else beyond YAML parseability. Smaller scope = easier to reason about and less likely to break.

## Test plan

- [ ] CI on this PR goes green (including the new `workflow-lint` job which validates itself and the other 6 workflows)
- [ ] The new job runs in under a few seconds
- [ ] After merge, any future PR that introduces invalid YAML in `.github/workflows/` is blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)