### PR TITLE
www-dev: add interactive Learn Launchfile course

### DIFF
--- a/www-dev/src/components/learn/BeforeAfter.astro
+++ b/www-dev/src/components/learn/BeforeAfter.astro
@@ -1,0 +1,26 @@
+---
+import { Code } from "astro:components";
+
+interface Pane {
+  title: string;
+  yaml: string;
+}
+
+interface Props {
+  before: Pane;
+  after: Pane;
+}
+
+const { before, after } = Astro.props;
+---
+
+<div class="before-after">
+  <div class="before-after-pane">
+    <div class="before-after-label">{before.title}</div>
+    <Code code={before.yaml} lang="yaml" theme="github-dark" />
+  </div>
+  <div class="before-after-pane">
+    <div class="before-after-label">{after.title}</div>
+    <Code code={after.yaml} lang="yaml" theme="github-dark" />
+  </div>
+</div>

--- a/www-dev/src/components/learn/Callout.astro
+++ b/www-dev/src/components/learn/Callout.astro
@@ -1,0 +1,30 @@
+---
+interface Props {
+  type?: "tip" | "warning" | "info";
+  title?: string;
+}
+
+const { type = "tip", title } = Astro.props;
+
+const icons: Record<string, string> = {
+  tip: "M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z",
+  warning: "M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z",
+  info: "M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z",
+};
+
+const defaultTitles: Record<string, string> = {
+  tip: "Tip",
+  warning: "Watch out",
+  info: "Note",
+};
+---
+
+<div class={`callout callout-${type}`}>
+  <div class="callout-title">
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d={icons[type]} />
+    </svg>
+    {title ?? defaultTitles[type]}
+  </div>
+  <slot />
+</div>

--- a/www-dev/src/components/learn/CodeBuildUp.astro
+++ b/www-dev/src/components/learn/CodeBuildUp.astro
@@ -1,0 +1,29 @@
+---
+import { Code } from "astro:components";
+
+interface Step {
+  yaml: string;
+  note: string;
+}
+
+interface Props {
+  steps: Step[];
+}
+
+const { steps } = Astro.props;
+---
+
+<div class="code-buildup">
+  {steps.map((step, i) => (
+    <div class="code-buildup-step">
+      <div class="code-buildup-gutter">
+        <div class="code-buildup-number">{i + 1}</div>
+        {i < steps.length - 1 && <div class="code-buildup-line" />}
+      </div>
+      <div class="code-buildup-body">
+        <div class="code-buildup-note" set:html={step.note} />
+        <Code code={step.yaml} lang="yaml" theme="github-dark" />
+      </div>
+    </div>
+  ))}
+</div>

--- a/www-dev/src/components/learn/CourseLayout.astro
+++ b/www-dev/src/components/learn/CourseLayout.astro
@@ -1,0 +1,205 @@
+---
+import Base from "@shared/layouts/Base.astro";
+import DocsHeader from "@shared/components/DocsHeader.astro";
+import Sidebar from "@shared/components/Sidebar.astro";
+import SidebarNav from "@shared/components/SidebarNav.astro";
+import SearchDialog from "@shared/components/SearchDialog.astro";
+import "@/styles/global.css";
+import "@/styles/learn.css";
+
+interface Props {
+  title: string;
+  subtitle: string;
+  moduleName: string;
+  moduleNumber: number;
+  lessonNumber: number;
+  learningGoals: string[];
+  nextLesson?: { title: string; description: string; href: string };
+}
+
+const { title, subtitle, moduleName, moduleNumber, lessonNumber, learningGoals, nextLesson } = Astro.props;
+const currentPath = Astro.url.pathname;
+---
+
+<Base title={`${title} — Learn Launchfile`} description={subtitle} site="dev">
+  <DocsHeader slot="nav">
+    <SidebarNav slot="drawer-nav" currentPath={currentPath} />
+  </DocsHeader>
+  <div class="course-layout">
+    <Sidebar currentPath={currentPath} />
+    <div class="course-content">
+      <div class="course-content-inner">
+        <div class="course-main">
+          <!-- Breadcrumbs -->
+          <nav class="course-breadcrumbs" aria-label="Breadcrumb">
+            <a href="/learn/">Learn</a>
+            <span class="separator">/</span>
+            <a href="/learn/">{moduleName}</a>
+            <span class="separator">/</span>
+            <span class="current">{title}</span>
+          </nav>
+
+          <!-- Lesson Header -->
+          <header class="lesson-header">
+            <div class="lesson-indicator">
+              <span class="lesson-indicator-dot"></span>
+              Module {moduleNumber} &middot; Lesson {lessonNumber}
+            </div>
+            <h1 class="lesson-title">{title}</h1>
+            <p class="lesson-subtitle">{subtitle}</p>
+          </header>
+
+          <!-- What You'll Learn -->
+          <div class="learn-goals">
+            <div class="learn-goals-title">What you'll learn</div>
+            <ul>
+              {learningGoals.map((goal) => <li>{goal}</li>)}
+            </ul>
+          </div>
+
+          <!-- Lesson Content -->
+          <article class="prose prose-lg max-w-none prose-headings:text-ink prose-headings:scroll-mt-20 prose-p:text-charcoal prose-a:text-primary prose-a:no-underline hover:prose-a:underline prose-code:text-primary-dark prose-code:bg-primary-bg prose-code:rounded prose-code:px-1.5 prose-code:py-0.5 prose-code:text-sm prose-code:before:content-none prose-code:after:content-none prose-pre:bg-[var(--lf-ink)] prose-pre:text-[var(--lf-paper)] prose-th:text-ink prose-td:text-charcoal prose-strong:text-ink" id="lesson-content">
+            <slot />
+          </article>
+
+          <!-- Up Next -->
+          {nextLesson && (
+            <div class="up-next">
+              <a href={nextLesson.href}>
+                <div class="up-next-label">
+                  Up next
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                    <path d="M6 3l5 5-5 5" />
+                  </svg>
+                </div>
+                <div class="up-next-title">{nextLesson.title}</div>
+                <div class="up-next-desc">{nextLesson.description}</div>
+              </a>
+            </div>
+          )}
+
+          <!-- Footer -->
+          <footer class="docs-small-print">
+            <p>&copy; {new Date().getFullYear()} Launchfile. MIT License.</p>
+            <div class="docs-small-print-links">
+              <a href="https://github.com/launchfile/launchfile">GitHub</a>
+              <a href="https://launchfile.org">Spec</a>
+              <a href="https://launchfile.io">Catalog</a>
+            </div>
+          </footer>
+        </div>
+
+        <!-- Right rail: On This Page TOC -->
+        <div class="course-toc-rail">
+          <nav class="lesson-toc" aria-label="On this page">
+            <div class="lesson-toc-title">On this page</div>
+            <ul class="lesson-toc-list" id="lesson-toc-list">
+              <!-- Populated by client-side script -->
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </div>
+  </div>
+  <SearchDialog />
+
+  <!-- Anchor icon template (same as DocsLayout) -->
+  <template id="anchor-icon-template">
+    <a class="heading-anchor" aria-label="Link to section">
+      <svg width="16" height="16" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" aria-hidden="true">
+        <path d="m6.5 11.5-.964-.964a3.535 3.535 0 1 1 5-5l.964.964m2 2 .964.964a3.536 3.536 0 0 1-5 5L8.5 13.5m0-5 3 3" />
+      </svg>
+    </a>
+  </template>
+
+  <script>
+    document.addEventListener('astro:page-load', () => {
+      // --- Code copy buttons ---
+      document.querySelectorAll("article pre").forEach((pre) => {
+        if (pre.parentElement?.classList.contains("code-block-wrapper")) return;
+        const wrapper = document.createElement("div");
+        wrapper.className = "code-block-wrapper";
+        pre.parentNode?.insertBefore(wrapper, pre);
+        wrapper.appendChild(pre);
+
+        const btn = document.createElement("button");
+        btn.className = "copy-button";
+        btn.textContent = "Copy";
+        btn.setAttribute("aria-label", "Copy code");
+        btn.addEventListener("click", async () => {
+          const code = pre.querySelector("code")?.textContent ?? pre.textContent ?? "";
+          await navigator.clipboard.writeText(code);
+          btn.textContent = "Copied!";
+          btn.classList.add("copied");
+          setTimeout(() => { btn.textContent = "Copy"; btn.classList.remove("copied"); }, 2000);
+        });
+        wrapper.appendChild(btn);
+      });
+
+      // --- Heading anchor links ---
+      const anchorTemplate = document.getElementById("anchor-icon-template") as HTMLTemplateElement;
+      document.querySelectorAll("article h2[id], article h3[id]").forEach((heading) => {
+        const id = heading.getAttribute("id");
+        if (!id || !anchorTemplate) return;
+        const anchor = anchorTemplate.content.firstElementChild!.cloneNode(true) as HTMLAnchorElement;
+        anchor.href = `#${id}`;
+        anchor.setAttribute("aria-label", `Link to ${heading.textContent}`);
+        heading.appendChild(anchor);
+      });
+
+      // --- On This Page TOC ---
+      const tocList = document.getElementById("lesson-toc-list");
+      const content = document.getElementById("lesson-content");
+      if (!tocList || !content) return;
+
+      const headings = Array.from(content.querySelectorAll("h2[id], h3[id]"));
+      if (headings.length === 0) return;
+
+      headings.forEach((heading) => {
+        const li = document.createElement("li");
+        li.className = "lesson-toc-item";
+        const a = document.createElement("a");
+        a.className = `lesson-toc-link${heading.tagName === "H3" ? " depth-3" : ""}`;
+        a.href = `#${heading.id}`;
+        a.textContent = heading.textContent?.replace(/\s*#$/, "") ?? "";
+        li.appendChild(a);
+        tocList.appendChild(li);
+      });
+
+      // Scroll-linked active state via IntersectionObserver
+      const tocItems = tocList.querySelectorAll(".lesson-toc-item");
+      const contentElements = new Map<Element, number>();
+      let currentHeadingIdx: number = -1;
+
+      Array.from(content.children).forEach((el) => {
+        if (el.id && (el.tagName === "H2" || el.tagName === "H3")) {
+          currentHeadingIdx = headings.indexOf(el);
+        }
+        if (currentHeadingIdx >= 0) {
+          contentElements.set(el, currentHeadingIdx);
+        }
+      });
+
+      const visibleElements = new Set<Element>();
+
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) visibleElements.add(entry.target);
+            else visibleElements.delete(entry.target);
+          });
+
+          const firstVisible = Array.from(contentElements.entries())
+            .find(([el]) => visibleElements.has(el));
+
+          tocItems.forEach((item, i) => {
+            item.classList.toggle("active", i === firstVisible?.[1]);
+          });
+        },
+        { rootMargin: "-56px 0px 0px 0px" }
+      );
+
+      contentElements.forEach((_, el) => observer.observe(el));
+    });
+  </script>
+</Base>

--- a/www-dev/src/components/learn/GlossaryTip.astro
+++ b/www-dev/src/components/learn/GlossaryTip.astro
@@ -7,19 +7,25 @@ interface Props {
 const { term, definition } = Astro.props;
 ---
 
-<span class="glossary-term" data-glossary-term={term} data-glossary-def={definition}>
+<span class="glossary-term" data-glossary-term={term} data-glossary-def={definition} tabindex="0" role="button" aria-haspopup="true">
   <slot />
 </span>
 
 <script>
   document.addEventListener('astro:page-load', () => {
     let activeTooltip: HTMLElement | null = null;
+    let activeAnchor: Element | null = null;
 
     function hideTooltip() {
       if (activeTooltip) {
         activeTooltip.classList.remove("visible");
-        setTimeout(() => activeTooltip?.remove(), 150);
+        const tip = activeTooltip;
+        setTimeout(() => tip.remove(), 150);
         activeTooltip = null;
+      }
+      if (activeAnchor) {
+        activeAnchor.removeAttribute("aria-describedby");
+        activeAnchor = null;
       }
     }
 
@@ -31,6 +37,9 @@ const { term, definition } = Astro.props;
 
       const tip = document.createElement("div");
       tip.className = "glossary-tooltip";
+      const tipId = `glossary-tip-${Math.random().toString(36).slice(2, 8)}`;
+      tip.id = tipId;
+      tip.setAttribute("role", "tooltip");
 
       const termEl = document.createElement("div");
       termEl.className = "glossary-tooltip-term";
@@ -65,14 +74,29 @@ const { term, definition } = Astro.props;
 
       requestAnimationFrame(() => tip.classList.add("visible"));
       activeTooltip = tip;
+      activeAnchor = el;
+      el.setAttribute("aria-describedby", tipId);
     }
 
     document.querySelectorAll(".glossary-term").forEach((el) => {
       el.addEventListener("mouseenter", () => showTooltip(el));
       el.addEventListener("mouseleave", hideTooltip);
+      el.addEventListener("focus", () => showTooltip(el));
+      el.addEventListener("blur", hideTooltip);
+      el.addEventListener("keydown", (event) => {
+        const e = event as KeyboardEvent;
+        if (e.key === "Escape" && activeTooltip) {
+          hideTooltip();
+          (el as HTMLElement).blur();
+        } else if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          if (activeAnchor === el) hideTooltip();
+          else showTooltip(el);
+        }
+      });
       el.addEventListener("touchstart", (e) => {
         e.preventDefault();
-        if (activeTooltip) hideTooltip();
+        if (activeAnchor === el) hideTooltip();
         else showTooltip(el);
       }, { passive: false });
     });

--- a/www-dev/src/components/learn/GlossaryTip.astro
+++ b/www-dev/src/components/learn/GlossaryTip.astro
@@ -1,0 +1,86 @@
+---
+interface Props {
+  term: string;
+  definition: string;
+}
+
+const { term, definition } = Astro.props;
+---
+
+<span class="glossary-term" data-glossary-term={term} data-glossary-def={definition}>
+  <slot />
+</span>
+
+<script>
+  document.addEventListener('astro:page-load', () => {
+    let activeTooltip: HTMLElement | null = null;
+
+    function hideTooltip() {
+      if (activeTooltip) {
+        activeTooltip.classList.remove("visible");
+        setTimeout(() => activeTooltip?.remove(), 150);
+        activeTooltip = null;
+      }
+    }
+
+    function showTooltip(el: Element) {
+      hideTooltip();
+
+      const term = el.getAttribute("data-glossary-term") ?? "";
+      const def = el.getAttribute("data-glossary-def") ?? "";
+
+      const tip = document.createElement("div");
+      tip.className = "glossary-tooltip";
+
+      const termEl = document.createElement("div");
+      termEl.className = "glossary-tooltip-term";
+      termEl.textContent = term;
+      tip.appendChild(termEl);
+
+      const defEl = document.createElement("span");
+      defEl.textContent = def;
+      tip.appendChild(defEl);
+
+      document.body.appendChild(tip);
+
+      const rect = el.getBoundingClientRect();
+      const tipRect = tip.getBoundingClientRect();
+
+      let top: number;
+      if (rect.top - tipRect.height - 10 > 0) {
+        top = rect.top - tipRect.height - 10;
+        tip.classList.add("above");
+      } else {
+        top = rect.bottom + 10;
+        tip.classList.add("below");
+      }
+
+      const left = Math.max(8, Math.min(
+        rect.left + rect.width / 2 - tipRect.width / 2,
+        window.innerWidth - tipRect.width - 8
+      ));
+
+      tip.style.top = `${top}px`;
+      tip.style.left = `${left}px`;
+
+      requestAnimationFrame(() => tip.classList.add("visible"));
+      activeTooltip = tip;
+    }
+
+    document.querySelectorAll(".glossary-term").forEach((el) => {
+      el.addEventListener("mouseenter", () => showTooltip(el));
+      el.addEventListener("mouseleave", hideTooltip);
+      el.addEventListener("touchstart", (e) => {
+        e.preventDefault();
+        if (activeTooltip) hideTooltip();
+        else showTooltip(el);
+      }, { passive: false });
+    });
+
+    document.addEventListener("click", (e) => {
+      if (activeTooltip && !(e.target as Element)?.closest(".glossary-term")) {
+        hideTooltip();
+      }
+    });
+  });
+</script>

--- a/www-dev/src/components/learn/Quiz.astro
+++ b/www-dev/src/components/learn/Quiz.astro
@@ -12,14 +12,15 @@ interface Props {
 
 const { question, options } = Astro.props;
 const quizId = `quiz-${Math.random().toString(36).slice(2, 8)}`;
+const questionId = `${quizId}-q`;
 ---
 
 <div class="quiz" id={quizId} data-options={JSON.stringify(options)}>
-  <div class="quiz-question">{question}</div>
-  <div class="quiz-options">
+  <div class="quiz-question" id={questionId}>{question}</div>
+  <div class="quiz-options" role="radiogroup" aria-labelledby={questionId}>
     {options.map((opt, i) => (
-      <button class="quiz-option" data-index={i} type="button">
-        <span class="quiz-radio" />
+      <button class="quiz-option" data-index={i} type="button" role="radio" aria-checked="false">
+        <span class="quiz-radio" aria-hidden="true" />
         {opt.text}
       </button>
     ))}
@@ -28,7 +29,7 @@ const quizId = `quiz-${Math.random().toString(36).slice(2, 8)}`;
     <button class="quiz-btn quiz-btn-check" disabled type="button">Check answer</button>
     <button class="quiz-btn quiz-btn-retry" style="display: none;" type="button">Try again</button>
   </div>
-  <div class="quiz-feedback" style="display: none;"></div>
+  <div class="quiz-feedback" style="display: none;" role="status" aria-live="polite"></div>
 </div>
 
 <script>
@@ -45,8 +46,12 @@ const quizId = `quiz-${Math.random().toString(36).slice(2, 8)}`;
         btn.addEventListener("click", () => {
           if (btn.disabled) return;
           selected = i;
-          buttons.forEach((b) => b.classList.remove("selected"));
+          buttons.forEach((b) => {
+            b.classList.remove("selected");
+            b.setAttribute("aria-checked", "false");
+          });
           btn.classList.add("selected");
+          btn.setAttribute("aria-checked", "true");
           checkBtn.disabled = false;
         });
       });
@@ -71,11 +76,13 @@ const quizId = `quiz-${Math.random().toString(36).slice(2, 8)}`;
         buttons.forEach((btn) => {
           btn.disabled = false;
           btn.classList.remove("selected", "correct", "incorrect");
+          btn.setAttribute("aria-checked", "false");
         });
         checkBtn.style.display = "";
         checkBtn.disabled = true;
         retryBtn.style.display = "none";
         feedback.style.display = "none";
+        feedback.textContent = "";
       });
     });
   });

--- a/www-dev/src/components/learn/Quiz.astro
+++ b/www-dev/src/components/learn/Quiz.astro
@@ -1,0 +1,82 @@
+---
+interface Option {
+  text: string;
+  correct: boolean;
+  explanation: string;
+}
+
+interface Props {
+  question: string;
+  options: Option[];
+}
+
+const { question, options } = Astro.props;
+const quizId = `quiz-${Math.random().toString(36).slice(2, 8)}`;
+---
+
+<div class="quiz" id={quizId} data-options={JSON.stringify(options)}>
+  <div class="quiz-question">{question}</div>
+  <div class="quiz-options">
+    {options.map((opt, i) => (
+      <button class="quiz-option" data-index={i} type="button">
+        <span class="quiz-radio" />
+        {opt.text}
+      </button>
+    ))}
+  </div>
+  <div class="quiz-actions">
+    <button class="quiz-btn quiz-btn-check" disabled type="button">Check answer</button>
+    <button class="quiz-btn quiz-btn-retry" style="display: none;" type="button">Try again</button>
+  </div>
+  <div class="quiz-feedback" style="display: none;"></div>
+</div>
+
+<script>
+  document.addEventListener('astro:page-load', () => {
+    document.querySelectorAll(".quiz").forEach((quiz) => {
+      const options = JSON.parse(quiz.getAttribute("data-options") ?? "[]") as { text: string; correct: boolean; explanation: string }[];
+      const buttons = quiz.querySelectorAll<HTMLButtonElement>(".quiz-option");
+      const checkBtn = quiz.querySelector<HTMLButtonElement>(".quiz-btn-check")!;
+      const retryBtn = quiz.querySelector<HTMLButtonElement>(".quiz-btn-retry")!;
+      const feedback = quiz.querySelector<HTMLElement>(".quiz-feedback")!;
+      let selected = -1;
+
+      buttons.forEach((btn, i) => {
+        btn.addEventListener("click", () => {
+          if (btn.disabled) return;
+          selected = i;
+          buttons.forEach((b) => b.classList.remove("selected"));
+          btn.classList.add("selected");
+          checkBtn.disabled = false;
+        });
+      });
+
+      checkBtn.addEventListener("click", () => {
+        if (selected < 0) return;
+        const opt = options[selected];
+        buttons.forEach((btn, i) => {
+          btn.disabled = true;
+          if (i === selected) btn.classList.add(opt.correct ? "correct" : "incorrect");
+          if (options[i].correct) btn.classList.add("correct");
+        });
+        checkBtn.style.display = "none";
+        retryBtn.style.display = "";
+        feedback.style.display = "";
+        feedback.className = `quiz-feedback ${opt.correct ? "quiz-feedback-correct" : "quiz-feedback-incorrect"}`;
+        feedback.textContent = opt.explanation;
+      });
+
+      retryBtn.addEventListener("click", () => {
+        selected = -1;
+        buttons.forEach((btn) => {
+          btn.disabled = false;
+          btn.classList.remove("selected", "correct", "incorrect");
+        });
+        checkBtn.style.display = "";
+        checkBtn.disabled = true;
+        retryBtn.style.display = "none";
+        feedback.style.display = "none";
+      });
+    });
+  });
+</script>

--- a/www-dev/src/components/learn/RealWorldExample.astro
+++ b/www-dev/src/components/learn/RealWorldExample.astro
@@ -1,0 +1,52 @@
+---
+import { Code } from "astro:components";
+
+interface Annotation {
+  line: string;
+  text: string;
+}
+
+interface Props {
+  appName: string;
+  yaml: string;
+  annotations?: Annotation[];
+  catalogUrl?: string;
+}
+
+const { appName, yaml, annotations = [], catalogUrl } = Astro.props;
+const githubUrl = `https://github.com/launchfile/launchfile/blob/main/catalog/apps/${appName}/Launchfile`;
+---
+
+<div class="real-world">
+  <div class="real-world-header">
+    <span class="real-world-filename">{appName}/Launchfile</span>
+    <a href={githubUrl} class="real-world-link" target="_blank" rel="noopener">
+      View on GitHub
+      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M3.5 3.5h5v5M8.5 3.5L3.5 8.5" /></svg>
+    </a>
+  </div>
+  <Code code={yaml} lang="yaml" theme="github-dark" />
+
+  {annotations.length > 0 && (
+    <div class="real-world-annotations">
+      <dl>
+        {annotations.map((a) => (
+          <>
+            <dt><code>{a.line}</code></dt>
+            <dd>{a.text}</dd>
+          </>
+        ))}
+      </dl>
+    </div>
+  )}
+
+  {catalogUrl && (
+    <div style="margin-top: 0.75rem; padding: 0.75rem 1rem; border-radius: 0.5rem; border: 1px solid var(--lf-purple-100); background: var(--lf-purple-50);">
+      <p style="margin: 0; font-size: 0.8125rem; color: var(--lf-charcoal);">
+        <strong>Try it:</strong>{" "}
+        <code>npx launchfile up {appName}</code> to launch this app locally.
+        <a href={catalogUrl} style="color: var(--lf-primary);">View in catalog</a>
+      </p>
+    </div>
+  )}
+</div>

--- a/www-dev/src/lib/navigation.ts
+++ b/www-dev/src/lib/navigation.ts
@@ -11,6 +11,19 @@ export interface NavGroup {
 
 export const navigation: NavGroup[] = [
   {
+    title: "Learn",
+    items: [
+      { title: "Course Overview", href: "/learn/" },
+      { title: "1. Your First Launchfile", href: "/learn/first-launchfile/" },
+      { title: "2. Adding a Database", href: "/learn/adding-a-database/" },
+      { title: "3. Env Vars & Secrets", href: "/learn/env-and-secrets/" },
+      { title: "4. Ports, Storage & Health", href: "/learn/ports-storage-health/" },
+      { title: "5. Lifecycle Commands", href: "/learn/lifecycle-commands/" },
+      { title: "6. Multi-Component Apps", href: "/learn/multi-component/" },
+      { title: "7. Specialized Patterns", href: "/learn/specialized-patterns/" },
+    ],
+  },
+  {
     title: "Getting Started",
     items: [
       { title: "Installation", href: "/installation/" },

--- a/www-dev/src/pages/examples/index.astro
+++ b/www-dev/src/pages/examples/index.astro
@@ -16,6 +16,12 @@ const examples = [
   <h1>Examples</h1>
   <p>Common patterns for Launchfiles — from minimal to multi-component. Each example is a complete, valid Launchfile you can use as a starting point.</p>
 
+  <div style="padding: 0.875rem 1.25rem; border-radius: 0.5rem; border: 1px solid var(--lf-purple-100); background: var(--lf-purple-50); margin: 1.5rem 0;">
+    <p style="margin: 0; font-size: 0.9375rem; color: var(--lf-charcoal);">
+      <strong>Want to learn by building?</strong> The <a href="/learn/" style="color: var(--lf-primary); font-weight: 600;">Learn Launchfile</a> course walks you through each concept step by step.
+    </p>
+  </div>
+
   <div class="dev-quicklinks" style="margin-top: 2rem;">
     {examples.map((example) => (
       <a href={`/examples/${example.slug}/`} class="dev-quicklink">

--- a/www-dev/src/pages/index.astro
+++ b/www-dev/src/pages/index.astro
@@ -6,6 +6,12 @@ import "@/styles/global.css";
 
 const quickLinks = [
   {
+    title: "Learn Launchfile",
+    desc: "Step-by-step course — from a 3-line file to multi-component apps with databases and secrets.",
+    href: "/learn/",
+    icon: "learn",
+  },
+  {
     title: "Specification",
     desc: "The complete format reference — fields, types, expressions, and shorthand patterns.",
     href: "https://launchfile.org/spec/",
@@ -50,12 +56,12 @@ const quickLinks = [
             Platform-agnostic. Human-writable. Machine-parseable.
           </p>
           <div class="dev-hero-actions">
-            <a href="/quick-start/" class="dev-hero-btn-primary">
-              Get Started
+            <a href="/learn/" class="dev-hero-btn-primary">
+              Learn the format
               <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 3l5 5-5 5" /></svg>
             </a>
-            <a href="https://github.com/launchfile/launchfile" class="dev-hero-btn-secondary" target="_blank" rel="noopener">
-              View on GitHub
+            <a href="/quick-start/" class="dev-hero-btn-secondary">
+              Quick Start
             </a>
           </div>
         </div>
@@ -88,6 +94,9 @@ const quickLinks = [
         {quickLinks.map((link) => (
           <a href={link.href} class="dev-quicklink" target={link.href.startsWith("http") ? "_blank" : undefined} rel={link.href.startsWith("http") ? "noopener" : undefined}>
             <div class="dev-quicklink-icon" data-icon={link.icon}>
+              {link.icon === "learn" && (
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><path d="M12 14l9-5-9-5-9 5 9 5z"/><path d="M12 14l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14z"/></svg>
+              )}
               {link.icon === "book" && (
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
               )}

--- a/www-dev/src/pages/learn/adding-a-database.astro
+++ b/www-dev/src/pages/learn/adding-a-database.astro
@@ -1,6 +1,5 @@
 ---
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import minifluxYamlRaw from "../../../../catalog/apps/miniflux/Launchfile?raw";
 
 import CourseLayout from "@/components/learn/CourseLayout.astro";
 import CodeBuildUp from "@/components/learn/CodeBuildUp.astro";
@@ -10,7 +9,7 @@ import GlossaryTip from "@/components/learn/GlossaryTip.astro";
 import Quiz from "@/components/learn/Quiz.astro";
 import RealWorldExample from "@/components/learn/RealWorldExample.astro";
 
-const minifluxYaml = readFileSync(resolve(process.cwd(), "../catalog/apps/miniflux/Launchfile"), "utf-8").replace(/^#.*\n/gm, "").trim();
+const minifluxYaml = minifluxYamlRaw.replace(/^#.*\n/gm, "").trim();
 ---
 
 <CourseLayout

--- a/www-dev/src/pages/learn/adding-a-database.astro
+++ b/www-dev/src/pages/learn/adding-a-database.astro
@@ -1,0 +1,147 @@
+---
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import CourseLayout from "@/components/learn/CourseLayout.astro";
+import CodeBuildUp from "@/components/learn/CodeBuildUp.astro";
+import Callout from "@/components/learn/Callout.astro";
+import BeforeAfter from "@/components/learn/BeforeAfter.astro";
+import GlossaryTip from "@/components/learn/GlossaryTip.astro";
+import Quiz from "@/components/learn/Quiz.astro";
+import RealWorldExample from "@/components/learn/RealWorldExample.astro";
+
+const minifluxYaml = readFileSync(resolve(process.cwd(), "../catalog/apps/miniflux/Launchfile"), "utf-8").replace(/^#.*\n/gm, "").trim();
+---
+
+<CourseLayout
+  title="Adding a Database"
+  subtitle="Declare a Postgres dependency and wire it into your app."
+  moduleName="Basics"
+  moduleNumber={1}
+  lessonNumber={2}
+  learningGoals={[
+    "How requires declares resource dependencies",
+    "Shorthand vs expanded syntax for requires",
+    "How providers auto-provision and wire databases",
+    "Adding a health check endpoint",
+  ]}
+  nextLesson={{ title: "Env Vars & Secrets", description: "Configure your app with defaults, required values, and generated secrets.", href: "/learn/env-and-secrets/" }}
+>
+
+<h2 id="the-requires-field">The requires field</h2>
+
+<p>
+  Most real apps need a database. Traditionally, you'd provision one manually, copy the connection string into an env var, and hope nobody forgets a step. With a Launchfile, you <em>declare</em> what you need and the provider creates it for you.
+</p>
+
+<p>
+  The <GlossaryTip term="requires" definition="A field that declares external resources your app depends on — databases, caches, queues, etc.">requires</GlossaryTip> field tells the provider: "My app needs this resource. Provision it and give me connection details." The provider handles the actual database creation, user setup, and credential injection.
+</p>
+
+<h2 id="build-it-up">Build it up</h2>
+
+<CodeBuildUp steps={[
+  {
+    yaml: `version: launch/v1
+name: my-app
+runtime: node
+commands:
+  start: "node server.js"
+requires: [postgres]`,
+    note: "Start from where we left off in Lesson 1. Add <code>requires: [postgres]</code> — the shorthand syntax for declaring a database dependency.",
+  },
+  {
+    yaml: `requires: [postgres]
+
+# is equivalent to:
+
+requires:
+  - type: postgres`,
+    note: "The shorthand is convenient, but expands to the full form behind the scenes. Both are valid.",
+  },
+  {
+    yaml: `version: launch/v1
+name: my-app
+runtime: node
+commands:
+  start: "node server.js"
+requires:
+  - type: postgres
+    set_env:
+      DATABASE_URL: $url`,
+    note: "Use <code>set_env</code> to wire the database connection into your app. The provider fills in <code>$url</code> with the actual connection string at deploy time.",
+  },
+  {
+    yaml: `version: launch/v1
+name: my-app
+runtime: node
+commands:
+  start: "node server.js"
+requires:
+  - type: postgres
+    set_env:
+      DATABASE_URL: $url
+health: /health`,
+    note: "Add a health check endpoint so the provider knows your app is running correctly. It will hit <code>GET /health</code> periodically.",
+  },
+]} />
+
+<BeforeAfter
+  before={{ title: "Shorthand", yaml: "requires: [postgres]" }}
+  after={{ title: "Expanded", yaml: "requires:\n  - type: postgres" }}
+/>
+
+<h2 id="expressions">How expressions work</h2>
+
+<Callout type="info" title="Resource expressions">
+  <p>Inside <code>set_env</code>, you can reference properties of the provisioned resource using <code>$</code> expressions:</p>
+  <ul>
+    <li><code>$url</code> — Full connection URL (e.g. <code>postgres://user:pass@host:5432/dbname</code>)</li>
+    <li><code>$host</code> — Database hostname</li>
+    <li><code>$port</code> — Port number</li>
+    <li><code>$user</code> — Username</li>
+    <li><code>$password</code> — Password</li>
+    <li><code>$name</code> — Database name</li>
+  </ul>
+  <p>These are <GlossaryTip term="expression" definition="A $-prefixed placeholder that the provider resolves to a real value at deploy time.">expressions</GlossaryTip> that the provider resolves at deploy time. Use <code>$url</code> when your framework expects a single connection string, or individual fields when it expects them separately.</p>
+</Callout>
+
+<h2 id="in-the-wild">In the wild</h2>
+
+<p>Miniflux is a minimalist feed reader that needs Postgres. Notice how it uses <code>set_env</code> to wire the database, declares env vars with defaults, and even generates a secret for the admin password.</p>
+
+<RealWorldExample
+  appName="miniflux"
+  yaml={minifluxYaml}
+  annotations={[
+    { line: "requires:", text: "Declares a Postgres dependency — the provider creates a managed database instance." },
+    { line: "set_env:", text: "Injects the connection URL into the DATABASE_URL environment variable." },
+    { line: "generator: secret", text: "Auto-generates a secure admin password at deploy time — no manual setup needed." },
+    { line: "health: /healthcheck", text: "The provider pings this endpoint to verify the app is alive." },
+  ]}
+  catalogUrl="https://launchfile.io/apps/miniflux/"
+/>
+
+<h2 id="check-your-understanding">Check your understanding</h2>
+
+<Quiz
+  question="What does requires: [postgres] tell the provider?"
+  options={[
+    { text: "Install Postgres on the server", correct: false, explanation: "Not quite — the provider provisions a managed database instance, not a local installation. The 'how' is up to the provider." },
+    { text: "The app requires Postgres — provision it and inject connection details", correct: true, explanation: "Exactly. The provider creates the database and makes connection details available via set_env expressions." },
+    { text: "Download the Postgres Docker image", correct: false, explanation: "That's an implementation detail. The provider decides how to provision the database — it might use Docker, a managed cloud service, or something else entirely." },
+    { text: "Nothing — it's just documentation", correct: false, explanation: "requires is not a comment. It's a declaration that the provider acts on — creating real infrastructure for your app." },
+  ]}
+/>
+
+<div class="takeaways">
+  <div class="takeaways-title">Key takeaways</div>
+  <ul>
+    <li><code>requires</code> declares resource dependencies — the provider provisions them automatically.</li>
+    <li>Use <code>set_env</code> with <code>$url</code>, <code>$host</code>, <code>$port</code>, etc. to wire connection details into your app.</li>
+    <li>Shorthand (<code>[postgres]</code>) and expanded syntax (<code>- type: postgres</code>) are equivalent.</li>
+    <li>Add <code>health</code> so the provider can verify your app is running correctly after deployment.</li>
+  </ul>
+</div>
+
+</CourseLayout>

--- a/www-dev/src/pages/learn/adding-a-database.astro
+++ b/www-dev/src/pages/learn/adding-a-database.astro
@@ -114,7 +114,7 @@ health: /health`,
   appName="miniflux"
   yaml={minifluxYaml}
   annotations={[
-    { line: "requires:", text: "Declares a Postgres dependency — the provider creates a managed database instance." },
+    { line: "requires:", text: "Declares a Postgres dependency — the provider provisions Postgres however its platform chooses." },
     { line: "set_env:", text: "Injects the connection URL into the DATABASE_URL environment variable." },
     { line: "generator: secret", text: "Auto-generates a secure admin password at deploy time — no manual setup needed." },
     { line: "health: /healthcheck", text: "The provider pings this endpoint to verify the app is alive." },
@@ -127,8 +127,8 @@ health: /health`,
 <Quiz
   question="What does requires: [postgres] tell the provider?"
   options={[
-    { text: "Install Postgres on the server", correct: false, explanation: "Not quite — the provider provisions a managed database instance, not a local installation. The 'how' is up to the provider." },
-    { text: "The app requires Postgres — provision it and inject connection details", correct: true, explanation: "Exactly. The provider creates the database and makes connection details available via set_env expressions." },
+    { text: "Install Postgres on the server", correct: false, explanation: "That's one way a provider might satisfy the requirement. The Launchfile just declares intent — the provider decides how, which could be a managed cloud database, a Docker container, or a shared cluster." },
+    { text: "The app requires Postgres — provision it and inject connection details", correct: true, explanation: "Exactly. The provider decides how to satisfy the requirement and makes the connection details available via set_env expressions." },
     { text: "Download the Postgres Docker image", correct: false, explanation: "That's an implementation detail. The provider decides how to provision the database — it might use Docker, a managed cloud service, or something else entirely." },
     { text: "Nothing — it's just documentation", correct: false, explanation: "requires is not a comment. It's a declaration that the provider acts on — creating real infrastructure for your app." },
   ]}

--- a/www-dev/src/pages/learn/env-and-secrets.astro
+++ b/www-dev/src/pages/learn/env-and-secrets.astro
@@ -1,6 +1,5 @@
 ---
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import fireflyYamlRaw from "../../../../catalog/apps/firefly-iii/Launchfile?raw";
 
 import CourseLayout from "@/components/learn/CourseLayout.astro";
 import CodeBuildUp from "@/components/learn/CodeBuildUp.astro";
@@ -10,7 +9,7 @@ import GlossaryTip from "@/components/learn/GlossaryTip.astro";
 import Quiz from "@/components/learn/Quiz.astro";
 import RealWorldExample from "@/components/learn/RealWorldExample.astro";
 
-const fireflyYaml = readFileSync(resolve(process.cwd(), "../catalog/apps/firefly-iii/Launchfile"), "utf-8").replace(/^#.*\n/gm, "").trim();
+const fireflyYaml = fireflyYamlRaw.replace(/^#.*\n/gm, "").trim();
 ---
 
 <CourseLayout

--- a/www-dev/src/pages/learn/env-and-secrets.astro
+++ b/www-dev/src/pages/learn/env-and-secrets.astro
@@ -1,0 +1,141 @@
+---
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import CourseLayout from "@/components/learn/CourseLayout.astro";
+import CodeBuildUp from "@/components/learn/CodeBuildUp.astro";
+import Callout from "@/components/learn/Callout.astro";
+import BeforeAfter from "@/components/learn/BeforeAfter.astro";
+import GlossaryTip from "@/components/learn/GlossaryTip.astro";
+import Quiz from "@/components/learn/Quiz.astro";
+import RealWorldExample from "@/components/learn/RealWorldExample.astro";
+
+const fireflyYaml = readFileSync(resolve(process.cwd(), "../catalog/apps/firefly-iii/Launchfile"), "utf-8").replace(/^#.*\n/gm, "").trim();
+---
+
+<CourseLayout
+  title="Env Vars & Secrets"
+  subtitle="Configure your app with defaults, required values, and generated secrets."
+  moduleName="Basics"
+  moduleNumber={1}
+  lessonNumber={3}
+  learningGoals={[
+    "Declaring environment variables with defaults and descriptions",
+    "Using generators for automatic secret creation",
+    "The secrets block and $secrets.* expressions",
+    "Pipe transforms like |base64",
+  ]}
+  nextLesson={{ title: "Ports, Storage & Health", description: "Expose endpoints, persist data, and tell providers how to check your app.", href: "/learn/ports-storage-health/" }}
+>
+
+<h2 id="the-env-block">The env block</h2>
+
+<p>
+  Every app needs configuration — a port to listen on, an API key for a third-party service, a secret for signing sessions. In a Launchfile, the <code>env</code> block declares all of this in one place.
+</p>
+
+<p>
+  Each variable can have a <code>default</code> value, be marked as <code>required</code>, include a human-readable <code>description</code>, use a <GlossaryTip term="generator" definition="A built-in function that creates a value automatically at deploy time — e.g. 'secret' generates a cryptographic random string.">generator</GlossaryTip> for automatic creation, or be flagged as <GlossaryTip term="sensitive" definition="Marks a variable as containing secret data. Providers will mask it in logs and UI.">sensitive</GlossaryTip> so providers mask it in logs.
+</p>
+
+<h2 id="build-it-up">Build it up</h2>
+
+<CodeBuildUp steps={[
+  {
+    yaml: `env:
+  PORT:
+    default: "3000"`,
+    note: "Start simple. A default value means the app works out of the box — the deployer can override it if needed.",
+  },
+  {
+    yaml: `env:
+  PORT:
+    default: "3000"
+  API_KEY:
+    required: true
+    description: "Third-party API key"`,
+    note: "Mark a variable as <code>required</code> when the app can't start without it. The <code>description</code> tells the deployer what to provide.",
+  },
+  {
+    yaml: `env:
+  PORT:
+    default: "3000"
+  API_KEY:
+    required: true
+    description: "Third-party API key"
+  SESSION_SECRET:
+    generator: secret
+    sensitive: true`,
+    note: "The <code>generator: secret</code> field tells the provider to create a cryptographic random string at deploy time. Marking it <code>sensitive</code> keeps it out of logs.",
+  },
+  {
+    yaml: "secrets:\n  app-key:\n    generator: secret\n\nenv:\n  PORT:\n    default: \"3000\"\n  APP_KEY: \"base64:${secrets.app-key|base64}\"",
+    note: "For more complex cases, use a top-level <code>secrets</code> block. Reference secrets with <code>$&#123;secrets.app-key&#125;</code> and apply pipe transforms like <code>|base64</code>.",
+  },
+]} />
+
+<h2 id="secrets-vs-env">Secrets vs env</h2>
+
+<Callout type="tip" title="When to use which">
+  <p>There are two ways to generate secrets in a Launchfile:</p>
+  <ul>
+    <li><strong>Inline in env:</strong> Add <code>generator: secret</code> directly to an env var. Simple and self-contained.</li>
+    <li><strong>Secrets block:</strong> Define named secrets at the top level, then reference them with <code>{"${secrets.name}"}</code> in env. Useful when one secret feeds multiple env vars, or when you need transforms.</li>
+  </ul>
+  <p>For most apps, the inline approach is all you need. Reach for the <code>secrets</code> block when you need to reuse or transform a generated value.</p>
+</Callout>
+
+<BeforeAfter
+  before={{
+    title: "Inline generator",
+    yaml: `env:
+  SESSION_SECRET:
+    generator: secret
+    sensitive: true`,
+  }}
+  after={{
+    title: "Secrets block + expression",
+    yaml: "secrets:\n  session-key:\n    generator: secret\n\nenv:\n  SESSION_SECRET: \"${secrets.session-key}\"",
+  }}
+/>
+
+<h2 id="in-the-wild">In the wild</h2>
+
+<p>Firefly III is a personal finance manager with one of the more interesting Launchfiles in the catalog. It uses a <code>secrets</code> block with a <code>|base64</code> pipe transform, references <code>$app.url</code> for its public URL, and wires Postgres connection details individually.</p>
+
+<RealWorldExample
+  appName="firefly-iii"
+  yaml={fireflyYaml}
+  annotations={[
+    { line: "secrets:", text: "Defines a named secret that gets generated once and reused." },
+    { line: "APP_KEY:", text: "References the generated secret with a |base64 pipe transform — the app expects a base64-encoded key." },
+    { line: "APP_URL:", text: "Uses $app.url — a built-in expression the provider fills with the app's public URL." },
+    { line: "set_env:", text: "Wires Postgres credentials individually instead of using a single $url — because Firefly expects separate DB_HOST, DB_PORT, etc." },
+    { line: "storage:", text: "Persists the upload directory so user data survives redeployments." },
+  ]}
+  catalogUrl="https://launchfile.io/apps/firefly-iii/"
+/>
+
+<h2 id="check-your-understanding">Check your understanding</h2>
+
+<Quiz
+  question="What does generator: secret do?"
+  options={[
+    { text: "Requires the user to provide a secret", correct: false, explanation: "That's what required: true does. A generator creates the value automatically — no human input needed." },
+    { text: "Generates a cryptographic secret automatically at deploy time", correct: true, explanation: "Correct! The provider creates a secure random string when the app is first deployed. No manual setup required." },
+    { text: "Encrypts the env var", correct: false, explanation: "Generators create values, they don't encrypt them. The sensitive: true flag controls whether the value is masked in logs." },
+    { text: "Creates a .env file", correct: false, explanation: "Launchfile doesn't create .env files. The provider injects environment variables directly into the running container or process." },
+  ]}
+/>
+
+<div class="takeaways">
+  <div class="takeaways-title">Key takeaways</div>
+  <ul>
+    <li>The <code>env</code> block declares all environment variables with optional <code>default</code>, <code>required</code>, <code>description</code>, <code>generator</code>, and <code>sensitive</code> fields.</li>
+    <li><code>generator: secret</code> auto-creates a cryptographic random string at deploy time.</li>
+    <li>The <code>secrets</code> block defines reusable, named secrets referenced via <code>{"${secrets.name}"}</code> expressions.</li>
+    <li>Pipe transforms like <code>|base64</code> let you encode or transform values inline.</li>
+  </ul>
+</div>
+
+</CourseLayout>

--- a/www-dev/src/pages/learn/first-launchfile.astro
+++ b/www-dev/src/pages/learn/first-launchfile.astro
@@ -63,7 +63,7 @@ const cyberchefYaml = readFileSync(resolve(process.cwd(), "../catalog/apps/cyber
 <Callout type="tip" title="The basics">
   <p>The file is called <code>Launchfile</code> (no extension) and lives in your project root — right next to <code>package.json</code> or <code>requirements.txt</code>.</p>
   <p>When you deploy, the provider reads this file and provisions everything: the runtime, the start command, any databases or services you declared. You don't write shell scripts or Dockerfiles — the Launchfile is the contract.</p>
-  <p>The <code>version: launch/v1</code> line is optional. When absent, providers default to <code>launch/v1</code>. It's good practice to include it, but your Launchfile works without it.</p>
+  <p>The <code>version: launch/v1</code> line is optional. Your Launchfile works without it, but including it pins the schema version you wrote against — good practice as the spec evolves.</p>
 </Callout>
 
 <h2 id="in-the-wild">In the wild</h2>

--- a/www-dev/src/pages/learn/first-launchfile.astro
+++ b/www-dev/src/pages/learn/first-launchfile.astro
@@ -1,0 +1,106 @@
+---
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import CourseLayout from "@/components/learn/CourseLayout.astro";
+import CodeBuildUp from "@/components/learn/CodeBuildUp.astro";
+import Callout from "@/components/learn/Callout.astro";
+import GlossaryTip from "@/components/learn/GlossaryTip.astro";
+import Quiz from "@/components/learn/Quiz.astro";
+import RealWorldExample from "@/components/learn/RealWorldExample.astro";
+
+const minimalYaml = readFileSync(resolve(process.cwd(), "../spec/examples/minimal.yaml"), "utf-8").replace(/^#.*\n/gm, "").trim();
+const cyberchefYaml = readFileSync(resolve(process.cwd(), "../catalog/apps/cyberchef/Launchfile"), "utf-8").replace(/^#.*\n/gm, "").trim();
+---
+
+<CourseLayout
+  title="Your First Launchfile"
+  subtitle="The simplest valid Launchfile — name, runtime, and a start command."
+  moduleName="Basics"
+  moduleNumber={1}
+  lessonNumber={1}
+  learningGoals={[
+    "What a Launchfile is and where it lives",
+    "The three core fields: name, runtime, commands.start",
+    "How providers use your Launchfile to deploy your app",
+  ]}
+  nextLesson={{ title: "Adding a Database", description: "Declare a Postgres dependency and wire it into your app.", href: "/learn/adding-a-database/" }}
+>
+
+<h2 id="what-is-a-launchfile">What is a Launchfile?</h2>
+
+<p>
+  A <GlossaryTip term="Launchfile" definition="A YAML file called Launchfile (no extension) that describes everything an app needs to run.">Launchfile</GlossaryTip> is a single file that describes how to deploy your application. It lives in your project root and is called <code>Launchfile</code> — no extension, just like a <code>Dockerfile</code> or <code>Makefile</code>.
+</p>
+
+<p>
+  Instead of writing platform-specific configs for every hosting <GlossaryTip term="provider" definition="A platform or tool that reads your Launchfile and provisions infrastructure accordingly.">provider</GlossaryTip>, you describe <em>what your app needs</em> and let the provider figure out <em>how</em> to set it up. One file, any platform.
+</p>
+
+<p>
+  You declare your app's <GlossaryTip term="runtime" definition="The language or environment your app runs in — node, python, ruby, go, etc.">runtime</GlossaryTip>, how to start it, what databases it depends on, what environment variables it expects — and that's it. The provider handles the rest.
+</p>
+
+<h2 id="build-it-up">Build it up</h2>
+
+<CodeBuildUp steps={[
+  {
+    yaml: "name: my-app",
+    note: "Every Launchfile starts with a name. It follows <code>kebab-case</code> convention.",
+  },
+  {
+    yaml: "name: my-app\nruntime: node",
+    note: "The <code>runtime</code> tells providers what language your app uses — <code>node</code>, <code>python</code>, <code>ruby</code>, <code>go</code>, etc.",
+  },
+  {
+    yaml: minimalYaml,
+    note: "Add a start command and you're done. This is a complete, valid Launchfile.",
+  },
+]} />
+
+<h2 id="how-it-works">How it works</h2>
+
+<Callout type="tip" title="The basics">
+  <p>The file is called <code>Launchfile</code> (no extension) and lives in your project root — right next to <code>package.json</code> or <code>requirements.txt</code>.</p>
+  <p>When you deploy, the provider reads this file and provisions everything: the runtime, the start command, any databases or services you declared. You don't write shell scripts or Dockerfiles — the Launchfile is the contract.</p>
+  <p>The <code>version: launch/v1</code> line is optional. When absent, providers default to <code>launch/v1</code>. It's good practice to include it, but your Launchfile works without it.</p>
+</Callout>
+
+<h2 id="in-the-wild">In the wild</h2>
+
+<p>Here's a real Launchfile from the catalog. CyberChef is a simple web app — no database, no secrets, just an image and a port.</p>
+
+<RealWorldExample
+  appName="cyberchef"
+  yaml={cyberchefYaml}
+  annotations={[
+    { line: "image:", text: "Instead of building from source, CyberChef uses a prebuilt Docker image." },
+    { line: "provides:", text: "Declares an HTTP endpoint on port 8000, exposed to the internet." },
+    { line: "restart: always", text: "Tells the provider to restart the app if it crashes." },
+  ]}
+  catalogUrl="https://launchfile.io/apps/cyberchef/"
+/>
+
+<h2 id="check-your-understanding">Check your understanding</h2>
+
+<Quiz
+  question="What is the minimum you need in a Launchfile for a source-based app?"
+  options={[
+    { text: "Just a name", correct: false, explanation: "A name alone doesn't tell the provider how to run your app. You also need a runtime and a start command." },
+    { text: "name, runtime, and a start command", correct: true, explanation: "Correct! These three fields are all a provider needs to build and run your application." },
+    { text: "A Dockerfile", correct: false, explanation: "Launchfile replaces the need for a Dockerfile. You declare what you need, and the provider handles containerization." },
+    { text: "name and an image", correct: false, explanation: "That works for prebuilt images, but source-based apps need a runtime and start command instead." },
+  ]}
+/>
+
+<div class="takeaways">
+  <div class="takeaways-title">Key takeaways</div>
+  <ul>
+    <li>A Launchfile is a YAML file called <code>Launchfile</code> in your project root.</li>
+    <li>The three core fields for source-based apps are <code>name</code>, <code>runtime</code>, and <code>commands.start</code>.</li>
+    <li>Providers read your Launchfile and handle all the infrastructure — you describe the <em>what</em>, they handle the <em>how</em>.</li>
+    <li>Prebuilt apps can use <code>image</code> instead of <code>runtime</code> + <code>commands</code>.</li>
+  </ul>
+</div>
+
+</CourseLayout>

--- a/www-dev/src/pages/learn/first-launchfile.astro
+++ b/www-dev/src/pages/learn/first-launchfile.astro
@@ -85,7 +85,7 @@ image: ghcr.io/org/my-app:latest`,
 />
 
 <p>
-  Everything else — env vars, ports, databases, health checks — works the same either way. The only difference is how your code gets into the container. Lesson 7 covers the prebuilt path in more depth.
+  Everything else — env vars, ports, databases, health checks — works the same either way. The only difference is how your code gets into the container. Lesson 7 shows how <code>image</code>, <code>build</code>, and <code>runtime</code> can combine for more advanced cases.
 </p>
 
 <h2 id="how-it-works">How it works</h2>

--- a/www-dev/src/pages/learn/first-launchfile.astro
+++ b/www-dev/src/pages/learn/first-launchfile.astro
@@ -1,6 +1,6 @@
 ---
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import minimalYamlRaw from "../../../../spec/examples/minimal.yaml?raw";
+import cyberchefYamlRaw from "../../../../catalog/apps/cyberchef/Launchfile?raw";
 
 import CourseLayout from "@/components/learn/CourseLayout.astro";
 import CodeBuildUp from "@/components/learn/CodeBuildUp.astro";
@@ -9,8 +9,9 @@ import GlossaryTip from "@/components/learn/GlossaryTip.astro";
 import Quiz from "@/components/learn/Quiz.astro";
 import RealWorldExample from "@/components/learn/RealWorldExample.astro";
 
-const minimalYaml = readFileSync(resolve(process.cwd(), "../spec/examples/minimal.yaml"), "utf-8").replace(/^#.*\n/gm, "").trim();
-const cyberchefYaml = readFileSync(resolve(process.cwd(), "../catalog/apps/cyberchef/Launchfile"), "utf-8").replace(/^#.*\n/gm, "").trim();
+const stripComments = (s: string) => s.replace(/^#.*\n/gm, "").trim();
+const minimalYaml = stripComments(minimalYamlRaw);
+const cyberchefYaml = stripComments(cyberchefYamlRaw);
 ---
 
 <CourseLayout

--- a/www-dev/src/pages/learn/first-launchfile.astro
+++ b/www-dev/src/pages/learn/first-launchfile.astro
@@ -5,6 +5,7 @@ import cyberchefYamlRaw from "../../../../catalog/apps/cyberchef/Launchfile?raw"
 import CourseLayout from "@/components/learn/CourseLayout.astro";
 import CodeBuildUp from "@/components/learn/CodeBuildUp.astro";
 import Callout from "@/components/learn/Callout.astro";
+import BeforeAfter from "@/components/learn/BeforeAfter.astro";
 import GlossaryTip from "@/components/learn/GlossaryTip.astro";
 import Quiz from "@/components/learn/Quiz.astro";
 import RealWorldExample from "@/components/learn/RealWorldExample.astro";
@@ -16,13 +17,14 @@ const cyberchefYaml = stripComments(cyberchefYamlRaw);
 
 <CourseLayout
   title="Your First Launchfile"
-  subtitle="The simplest valid Launchfile — name, runtime, and a start command."
+  subtitle="The simplest valid Launchfile — a name and a way to run your code."
   moduleName="Basics"
   moduleNumber={1}
   lessonNumber={1}
   learningGoals={[
     "What a Launchfile is and where it lives",
-    "The three core fields: name, runtime, commands.start",
+    "The minimum: a name plus a way to run your code",
+    "Two paths: build from source (runtime) or pull a prebuilt image",
     "How providers use your Launchfile to deploy your app",
   ]}
   nextLesson={{ title: "Adding a Database", description: "Declare a Postgres dependency and wire it into your app.", href: "/learn/adding-a-database/" }}
@@ -44,6 +46,8 @@ const cyberchefYaml = stripComments(cyberchefYamlRaw);
 
 <h2 id="build-it-up">Build it up</h2>
 
+<p>Let's build the smallest source-based Launchfile, one line at a time.</p>
+
 <CodeBuildUp steps={[
   {
     yaml: "name: my-app",
@@ -59,6 +63,31 @@ const cyberchefYaml = stripComments(cyberchefYamlRaw);
   },
 ]} />
 
+<h2 id="prebuilt-alternative">Or pull a prebuilt image</h2>
+
+<p>
+  There's a second path. When you don't have source code to build — you're deploying a third-party app, or something you've already published to a registry — swap the <code>runtime</code> and <code>commands</code> pair for a single <code>image</code> field.
+</p>
+
+<BeforeAfter
+  before={{
+    title: "Source-based",
+    yaml: `name: my-app
+runtime: node
+commands:
+  start: "node server.js"`,
+  }}
+  after={{
+    title: "Prebuilt image",
+    yaml: `name: my-app
+image: ghcr.io/org/my-app:latest`,
+  }}
+/>
+
+<p>
+  Everything else — env vars, ports, databases, health checks — works the same either way. The only difference is how your code gets into the container. Lesson 7 covers the prebuilt path in more depth.
+</p>
+
 <h2 id="how-it-works">How it works</h2>
 
 <Callout type="tip" title="The basics">
@@ -69,7 +98,7 @@ const cyberchefYaml = stripComments(cyberchefYamlRaw);
 
 <h2 id="in-the-wild">In the wild</h2>
 
-<p>Here's a real Launchfile from the catalog. CyberChef is a simple web app — no database, no secrets, just an image and a port.</p>
+<p>Most catalog apps take the prebuilt path — they're third-party projects distributed as Docker images, not your own source code. CyberChef is a simple example: just an image, a port, and a restart policy.</p>
 
 <RealWorldExample
   appName="cyberchef"
@@ -85,12 +114,12 @@ const cyberchefYaml = stripComments(cyberchefYamlRaw);
 <h2 id="check-your-understanding">Check your understanding</h2>
 
 <Quiz
-  question="What is the minimum you need in a Launchfile for a source-based app?"
+  question="What must every Launchfile have at a minimum?"
   options={[
-    { text: "Just a name", correct: false, explanation: "A name alone doesn't tell the provider how to run your app. You also need a runtime and a start command." },
-    { text: "name, runtime, and a start command", correct: true, explanation: "Correct! These three fields are all a provider needs to build and run your application." },
-    { text: "A Dockerfile", correct: false, explanation: "Launchfile replaces the need for a Dockerfile. You declare what you need, and the provider handles containerization." },
-    { text: "name and an image", correct: false, explanation: "That works for prebuilt images, but source-based apps need a runtime and start command instead." },
+    { text: "A name, plus a way to run the code — either a runtime with a start command, or a prebuilt image", correct: true, explanation: "Correct! Every Launchfile needs a name and some way to actually run the code. Pick one of two paths: runtime + commands.start to build from source, or image to pull a prebuilt container." },
+    { text: "name, runtime, and a start command", correct: false, explanation: "That's one valid minimum — the source-based path — but not the only one. A Launchfile with just name + image is equally valid for prebuilt apps." },
+    { text: "A name and a Dockerfile", correct: false, explanation: "Launchfile doesn't require a Dockerfile. The top-level build block can configure one when you want Dockerfile-based builds, but it's optional." },
+    { text: "name, port, and a start command", correct: false, explanation: "Ports are only needed when your app exposes a network endpoint. Background workers and cron jobs don't declare any." },
   ]}
 />
 
@@ -98,9 +127,9 @@ const cyberchefYaml = stripComments(cyberchefYamlRaw);
   <div class="takeaways-title">Key takeaways</div>
   <ul>
     <li>A Launchfile is a YAML file called <code>Launchfile</code> in your project root.</li>
-    <li>The three core fields for source-based apps are <code>name</code>, <code>runtime</code>, and <code>commands.start</code>.</li>
-    <li>Providers read your Launchfile and handle all the infrastructure — you describe the <em>what</em>, they handle the <em>how</em>.</li>
-    <li>Prebuilt apps can use <code>image</code> instead of <code>runtime</code> + <code>commands</code>.</li>
+    <li>The minimum is a <code>name</code> plus a way to run your code.</li>
+    <li>Source-based apps use <code>runtime</code> + <code>commands.start</code>. Prebuilt apps use <code>image</code>.</li>
+    <li>Providers read your Launchfile and handle the infrastructure — you describe the <em>what</em>, they handle the <em>how</em>.</li>
   </ul>
 </div>
 

--- a/www-dev/src/pages/learn/index.astro
+++ b/www-dev/src/pages/learn/index.astro
@@ -1,0 +1,111 @@
+---
+import Base from "@shared/layouts/Base.astro";
+import DocsHeader from "@shared/components/DocsHeader.astro";
+import Sidebar from "@shared/components/Sidebar.astro";
+import SidebarNav from "@shared/components/SidebarNav.astro";
+import SearchDialog from "@shared/components/SearchDialog.astro";
+import "@/styles/global.css";
+import "@/styles/learn.css";
+
+const currentPath = "/learn/";
+
+const modules = [
+  {
+    number: 1,
+    title: "Basics",
+    description: "Start from zero. By the end you'll write Launchfiles with databases, environment variables, and secrets.",
+    lessons: [
+      { num: 1, title: "Your First Launchfile", desc: "Three fields and a start command — the simplest valid Launchfile.", href: "/learn/first-launchfile/" },
+      { num: 2, title: "Adding a Database", desc: "Declare a Postgres dependency and wire it into your app.", href: "/learn/adding-a-database/" },
+      { num: 3, title: "Env Vars & Secrets", desc: "Configure your app with defaults, required values, and generated secrets.", href: "/learn/env-and-secrets/" },
+    ],
+  },
+  {
+    number: 2,
+    title: "Production-Ready",
+    description: "Everything you need for a production deployment: ports, storage, health checks, and lifecycle commands.",
+    lessons: [
+      { num: 4, title: "Ports, Storage & Health", desc: "Expose endpoints, persist data, and tell providers how to check your app.", href: "/learn/ports-storage-health/" },
+      { num: 5, title: "Lifecycle Commands", desc: "Build, release, start, seed — the full app lifecycle.", href: "/learn/lifecycle-commands/" },
+    ],
+  },
+  {
+    number: 3,
+    title: "Advanced",
+    description: "Multi-component apps, cron jobs, prebuilt images, and host access patterns.",
+    lessons: [
+      { num: 6, title: "Multi-Component Apps", desc: "Wire a frontend and backend together with dependency ordering.", href: "/learn/multi-component/" },
+      { num: 7, title: "Specialized Patterns", desc: "Cron jobs, prebuilt images, host access, and optional dependencies.", href: "/learn/specialized-patterns/" },
+    ],
+  },
+];
+---
+
+<Base title="Learn Launchfile — Step-by-Step Course" description="Learn to write Launchfiles from scratch. 7 lessons from minimal to multi-component." site="dev">
+  <DocsHeader slot="nav">
+    <SidebarNav slot="drawer-nav" currentPath={currentPath} />
+  </DocsHeader>
+  <div class="docs-layout">
+    <Sidebar currentPath={currentPath} />
+    <div class="docs-content" style="padding-top: 0;">
+      <!-- Hero -->
+      <div class="course-hero">
+        <div class="course-hero-grid"></div>
+        <div class="course-hero-inner">
+          <h1 class="course-hero-title">Learn Launchfile</h1>
+          <p class="course-hero-desc">
+            A step-by-step course that takes you from a 3-line Launchfile to deploying multi-component apps with databases, secrets, and health checks.
+          </p>
+          <div class="course-hero-stats">
+            <span>3 modules</span>
+            <span class="dot">&middot;</span>
+            <span>7 lessons</span>
+            <span class="dot">&middot;</span>
+            <span>~30 min read</span>
+          </div>
+          <a href="/learn/first-launchfile/" class="course-hero-cta">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.985V5.653z" />
+            </svg>
+            Start the course
+          </a>
+        </div>
+      </div>
+
+      <!-- Modules -->
+      <div class="course-modules">
+        {modules.map((mod) => (
+          <div class="course-module">
+            <div class="course-module-label">Part {mod.number}</div>
+            <h2 class="course-module-title">{mod.title}</h2>
+            <p class="course-module-desc">{mod.description}</p>
+            <div class="course-lesson-list">
+              {mod.lessons.map((lesson) => (
+                <a href={lesson.href} class="course-lesson-card">
+                  <span class="course-lesson-num">{lesson.num}</span>
+                  <div class="course-lesson-info">
+                    <div class="course-lesson-title">{lesson.title}</div>
+                    <div class="course-lesson-desc">{lesson.desc}</div>
+                  </div>
+                  <svg class="course-lesson-chevron" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                    <path d="M6 3l5 5-5 5" />
+                  </svg>
+                </a>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <footer class="docs-small-print">
+        <p>&copy; {new Date().getFullYear()} Launchfile. MIT License.</p>
+        <div class="docs-small-print-links">
+          <a href="https://github.com/launchfile/launchfile">GitHub</a>
+          <a href="https://launchfile.org">Spec</a>
+          <a href="https://launchfile.io">Catalog</a>
+        </div>
+      </footer>
+    </div>
+  </div>
+  <SearchDialog />
+</Base>

--- a/www-dev/src/pages/learn/lifecycle-commands.astro
+++ b/www-dev/src/pages/learn/lifecycle-commands.astro
@@ -1,0 +1,150 @@
+---
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import CourseLayout from "@/components/learn/CourseLayout.astro";
+import CodeBuildUp from "@/components/learn/CodeBuildUp.astro";
+import Callout from "@/components/learn/Callout.astro";
+import BeforeAfter from "@/components/learn/BeforeAfter.astro";
+import GlossaryTip from "@/components/learn/GlossaryTip.astro";
+import Quiz from "@/components/learn/Quiz.astro";
+import RealWorldExample from "@/components/learn/RealWorldExample.astro";
+
+const captureYaml = readFileSync(resolve(process.cwd(), "../spec/examples/post-start-capture.yaml"), "utf-8").replace(/^#.*\n/gm, "").trim();
+---
+
+<CourseLayout
+  title="Lifecycle Commands"
+  subtitle="Build, release, start, seed — the full app lifecycle."
+  moduleName="Production-Ready"
+  moduleNumber={2}
+  lessonNumber={5}
+  learningGoals={[
+    "The six command types: build, release, start, seed, test, bootstrap",
+    "When each command runs in the deployment lifecycle",
+    "Command capture for post-start output",
+    "The build block for Dockerfile-based builds",
+  ]}
+  nextLesson={{ title: "Multi-Component Apps", description: "Wire a frontend and backend together with dependency ordering.", href: "/learn/multi-component/" }}
+>
+
+<h2 id="the-lifecycle">The deployment lifecycle</h2>
+
+<p>
+  Every deployment follows the same arc: compile the code, prepare the environment, then run the app. Launchfile gives you a hook for each stage via the <code>commands</code> block.
+</p>
+
+<p>Here's the order, and when each command fires:</p>
+
+<ol>
+  <li><strong><code>build</code></strong> — Compile source, install dependencies, generate assets. Runs at build time.</li>
+  <li><strong><code><GlossaryTip term="release" definition="A command that runs once per deployment before start — typically database migrations or asset uploads. If it fails, the deploy is rolled back.">release</GlossaryTip></code></strong> — Runs once per deployment, before start. Migrations, asset uploads, cache warming. If it fails, the deploy stops.</li>
+  <li><strong><code>start</code></strong> — The long-running process. This is your app.</li>
+  <li><strong><code>seed</code></strong> — Populate the database with sample or default data. Typically run on demand, not on every deploy.</li>
+  <li><strong><code>test</code></strong> — Run the test suite. Used by CI and by providers that validate before promoting a deploy.</li>
+  <li><strong><code><GlossaryTip term="bootstrap" definition="A command that runs once ever — like creating the initial admin user or generating a one-time invite link. Re-runnable but only needed on first setup.">bootstrap</GlossaryTip></code></strong> — First-time setup. Create the admin user, generate invite links, initialize config. Runs on user request, not automatically.</li>
+</ol>
+
+<Callout type="tip" title="release vs. bootstrap">
+  <p>
+    Think of <code>release</code> as "every deploy" (migrations) and <code>bootstrap</code> as "first deploy ever" (admin setup). Both run against a live app, but release gates the deploy while bootstrap is fire-and-forget.
+  </p>
+</Callout>
+
+<h2 id="build-it-up">Build it up</h2>
+
+<CodeBuildUp steps={[
+  {
+    yaml: `commands:
+  start: "node server.js"`,
+    note: "The minimum: a <code>start</code> command. The provider runs this to launch your app.",
+  },
+  {
+    yaml: `commands:
+  build: "npm install && npm run build"
+  release: "npx prisma migrate deploy"
+  start: "node dist/server.js"`,
+    note: "Add <strong>build</strong> to compile and <strong>release</strong> to run migrations before every deploy.",
+  },
+  {
+    yaml: `commands:
+  build: "npm install && npm run build"
+  release: "npx prisma migrate deploy"
+  start: "node dist/server.js"
+  seed: "node scripts/seed.js"
+  test: "npm test"`,
+    note: "Add <strong>seed</strong> for sample data and <strong>test</strong> for the test suite.",
+  },
+  {
+    yaml: `commands:
+  start:
+    run: "my-app serve"
+    capture:
+      ADMIN_TOKEN: "Admin token: (.+)"`,
+    note: "The <strong>capture</strong> pattern extracts values from stdout via regex. Useful for apps that print a generated token or URL on first start.",
+  },
+]} />
+
+<h2 id="the-build-block">The <code>build</code> block</h2>
+
+<p>
+  There's a subtle but important distinction: <code>commands.build</code> runs shell commands (like <code>npm run build</code>), while a top-level <code>build:</code> block configures a Dockerfile-based container build. They serve different purposes.
+</p>
+
+<BeforeAfter
+  before={{ title: "commands.build (shell)", yaml: `commands:
+  build: "npm install && npm run build"
+  start: "node dist/server.js"` }}
+  after={{ title: "build: (Dockerfile)", yaml: `build:
+  dockerfile: ./Dockerfile
+
+commands:
+  start: "node server.js"` }}
+/>
+
+<Callout type="warning" title="Don't confuse the two">
+  <p>
+    <code>commands.build</code> runs <em>inside</em> an already-built container (or on the host). The top-level <code>build:</code> block tells the provider <em>how to build the container image itself</em> from a Dockerfile. If you're using a prebuilt image (like <code>image: node:20</code>), you only need <code>commands.build</code>. If you have a Dockerfile, use the top-level <code>build:</code> block.
+  </p>
+</Callout>
+
+<h2 id="in-the-wild">In the wild</h2>
+
+<p>
+  This spec example shows a real-world pattern: a post-start bootstrap command that creates an admin user and captures the one-time invite link from stdout.
+</p>
+
+<RealWorldExample
+  appName="my-app"
+  yaml={captureYaml}
+  annotations={[
+    { line: "build:", text: "Top-level build block — this app uses a Dockerfile, not a prebuilt image." },
+    { line: "commands:", text: "The commands block defines start and bootstrap. No release or build command needed since the Dockerfile handles compilation." },
+    { line: "bootstrap:", text: "Runs on user request after the app is up. Creates an admin invite and captures the URL from stdout." },
+    { line: "capture:", text: "Extracts the invite link via regex. The provider stores it and shows it to the user." },
+  ]}
+/>
+
+<h2 id="check-your-understanding">Check your understanding</h2>
+
+<Quiz
+  question="When does the release command run?"
+  options={[
+    { text: "Once when the app is first deployed", correct: false, explanation: "That's bootstrap. Release runs on every deployment, not just the first." },
+    { text: "Every time the app starts", correct: false, explanation: "That's start. Release runs once per deployment, before start — not on every restart." },
+    { text: "Once per deployment, before start", correct: true, explanation: "Correct! Release runs after the build and before start — the right place for database migrations, asset compilation, or cache warming. If it fails, the deploy is rolled back." },
+    { text: "Only in CI", correct: false, explanation: "Release runs in every deployment, whether triggered by CI or manually. You might be thinking of the test command, which is often CI-only." },
+  ]}
+/>
+
+<div class="takeaways">
+  <div class="takeaways-title">Key takeaways</div>
+  <ul>
+    <li>The <strong>deployment lifecycle</strong> is: build, release, start. Seed, test, and bootstrap are on-demand.</li>
+    <li><strong><code>release</code></strong> runs once per deploy (migrations). <strong><code>bootstrap</code></strong> runs once ever (initial setup).</li>
+    <li>Commands can use the <strong>capture</strong> pattern to extract values from stdout via regex.</li>
+    <li>Top-level <strong><code>build:</code></strong> configures Docker image builds. <strong><code>commands.build</code></strong> runs shell commands inside a container.</li>
+  </ul>
+</div>
+
+</CourseLayout>

--- a/www-dev/src/pages/learn/lifecycle-commands.astro
+++ b/www-dev/src/pages/learn/lifecycle-commands.astro
@@ -1,6 +1,5 @@
 ---
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import captureYamlRaw from "../../../../spec/examples/post-start-capture.yaml?raw";
 
 import CourseLayout from "@/components/learn/CourseLayout.astro";
 import CodeBuildUp from "@/components/learn/CodeBuildUp.astro";
@@ -10,7 +9,7 @@ import GlossaryTip from "@/components/learn/GlossaryTip.astro";
 import Quiz from "@/components/learn/Quiz.astro";
 import RealWorldExample from "@/components/learn/RealWorldExample.astro";
 
-const captureYaml = readFileSync(resolve(process.cwd(), "../spec/examples/post-start-capture.yaml"), "utf-8").replace(/^#.*\n/gm, "").trim();
+const captureYaml = captureYamlRaw.replace(/^#.*\n/gm, "").trim();
 ---
 
 <CourseLayout

--- a/www-dev/src/pages/learn/multi-component.astro
+++ b/www-dev/src/pages/learn/multi-component.astro
@@ -1,0 +1,187 @@
+---
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import CourseLayout from "@/components/learn/CourseLayout.astro";
+import CodeBuildUp from "@/components/learn/CodeBuildUp.astro";
+import Callout from "@/components/learn/Callout.astro";
+import GlossaryTip from "@/components/learn/GlossaryTip.astro";
+import Quiz from "@/components/learn/Quiz.astro";
+import RealWorldExample from "@/components/learn/RealWorldExample.astro";
+
+const multiComponentYaml = readFileSync(resolve(process.cwd(), "../spec/examples/multi-component.yaml"), "utf-8").replace(/^#.*\n/gm, "").trim();
+---
+
+<CourseLayout
+  title="Multi-Component Apps"
+  subtitle="Wire a frontend and backend together with dependency ordering."
+  moduleName="Advanced"
+  moduleNumber={3}
+  lessonNumber={6}
+  learningGoals={[
+    "Using the components map for multi-service apps",
+    "Inter-component dependency ordering with depends_on",
+    "Cross-component expressions like $components.backend.url",
+    "The exposed flag — only frontends need it",
+  ]}
+  nextLesson={{ title: "Specialized Patterns", description: "Cron jobs, prebuilt images, host access, and optional dependencies.", href: "/learn/specialized-patterns/" }}
+>
+
+<h2 id="when-to-go-multi">When to go multi-component</h2>
+
+<p>
+  Everything we've built so far has been a single-component app — one runtime, one start command, one process. That covers most applications. But when your project has a separate frontend and backend (or background workers, or a websocket server), you need the <GlossaryTip term="components" definition="A map of named services within a single Launchfile. Each component has its own runtime, commands, ports, and dependencies.">components</GlossaryTip> map.
+</p>
+
+<p>
+  Instead of a flat Launchfile, you nest each service under a key in <code>components:</code>. Each component gets its own runtime, commands, ports, and health checks. The provider launches them together and wires them up.
+</p>
+
+<p>
+  Components can depend on each other using <GlossaryTip term="depends_on" definition="Declares that one component must be healthy before another starts. Ensures correct startup ordering.">depends_on</GlossaryTip> — the provider ensures the backend is healthy before starting the frontend.
+</p>
+
+<h2 id="build-it-up">Build it up</h2>
+
+<p>Let's build HedgeDoc — a collaborative markdown editor with a Node backend and a separate frontend — step by step.</p>
+
+<CodeBuildUp steps={[
+  {
+    yaml: `name: hedgedoc
+
+components:
+  backend:
+    runtime: node
+    commands:
+      start: "node dist/main.js"`,
+    note: "Start with a single backend component. Everything from flat Launchfiles works inside <code>components:</code> — it's the same fields, just nested.",
+  },
+  {
+    yaml: `name: hedgedoc
+
+components:
+  backend:
+    runtime: node
+    provides:
+      - name: api
+        protocol: http
+        port: 3000
+    requires:
+      - type: postgres
+        set_env:
+          HD_DATABASE_URL: $url
+    commands:
+      start: "node dist/main.js"`,
+    note: "Add <code>provides</code> to expose the API on port 3000, and <code>requires</code> to declare the Postgres dependency. Same fields you already know.",
+  },
+  {
+    yaml: `name: hedgedoc
+
+components:
+  backend:
+    runtime: node
+    provides:
+      - name: api
+        protocol: http
+        port: 3000
+    requires:
+      - type: postgres
+        set_env:
+          HD_DATABASE_URL: $url
+    commands:
+      start: "node dist/main.js"
+      release: "node dist/migrations.js"
+    health:
+      path: /api/private/config
+      start_period: 30s`,
+    note: "Add a health check so the provider knows when the backend is ready. The <code>release</code> command runs migrations before each deploy.",
+  },
+  {
+    yaml: `name: hedgedoc
+
+components:
+  backend:
+    runtime: node
+    provides:
+      - name: api
+        protocol: http
+        port: 3000
+    requires:
+      - type: postgres
+        set_env:
+          HD_DATABASE_URL: $url
+    commands:
+      start: "node dist/main.js"
+      release: "node dist/migrations.js"
+    health:
+      path: /api/private/config
+      start_period: 30s
+
+  frontend:
+    runtime: node
+    depends_on:
+      - component: backend
+        condition: healthy
+    provides:
+      - protocol: http
+        port: 3001
+        exposed: true
+    env:
+      HD_BASE_URL:
+        default: $components.backend.url`,
+    note: "Add the frontend. It <code>depends_on</code> the backend (waits until healthy), exposes port 3001 to the internet, and uses <code>$components.backend.url</code> to discover the backend's address.",
+  },
+  {
+    yaml: multiComponentYaml,
+    note: "The complete HedgeDoc Launchfile with build steps, environment variables, and full wiring between components.",
+  },
+]} />
+
+<h2 id="cross-component-wiring">Cross-component wiring</h2>
+
+<Callout type="info" title="How components talk to each other">
+  <p>The <GlossaryTip term="expression" definition="A $-prefixed reference that the provider resolves at deploy time — like $url for database URLs or $components.backend.url for cross-component references.">expression</GlossaryTip> <code>$components.backend.url</code> resolves to the backend's internal URL at deploy time. No hardcoded ports, no guessing — the provider handles the wiring.</p>
+  <p>Notice that only the frontend has <code>exposed: true</code>. That's because the frontend is the public-facing entry point — users hit the frontend, which talks to the backend internally. The backend stays on the private network, inaccessible from the outside.</p>
+</Callout>
+
+<p>
+  This pattern scales to any number of components. A backend, a frontend, a websocket server, a background worker — each gets a key in <code>components:</code>, declares its own ports and dependencies, and uses expressions to discover the others.
+</p>
+
+<h2 id="in-the-wild">In the wild</h2>
+
+<p>Here's the full HedgeDoc Launchfile from the spec examples. This is the same file we built step by step — now with all the production details.</p>
+
+<RealWorldExample
+  appName="hedgedoc"
+  yaml={multiComponentYaml}
+  annotations={[
+    { line: "depends_on:", text: "The frontend waits for the backend to pass its health check before starting." },
+    { line: "$components.backend.url", text: "The provider resolves this to the backend's internal URL — no hardcoded addresses." },
+    { line: "exposed: true", text: "Only the frontend is public-facing. The backend stays on the internal network." },
+  ]}
+/>
+
+<h2 id="check-your-understanding">Check your understanding</h2>
+
+<Quiz
+  question="Why does only the frontend have `exposed: true`?"
+  options={[
+    { text: "Backends can't expose ports", correct: false, explanation: "Backends can have exposed: true — but they shouldn't unless they need to be public. It's a design choice, not a syntax rule." },
+    { text: "The frontend is the public entry point — the backend is internal", correct: true, explanation: "Correct! Users access the frontend, which talks to the backend over the internal network. Keeping the backend unexposed is both simpler and more secure." },
+    { text: "It's a syntax requirement", correct: false, explanation: "There's no syntax rule about which component gets exposed. Any component can set exposed: true — it's an architectural decision." },
+    { text: "The backend uses a different protocol", correct: false, explanation: "Both the frontend and backend use HTTP. The exposed flag is about public visibility, not protocol." },
+  ]}
+/>
+
+<div class="takeaways">
+  <div class="takeaways-title">Key takeaways</div>
+  <ul>
+    <li>Use <code>components:</code> when your app has multiple services (frontend, backend, workers).</li>
+    <li><code>depends_on</code> controls startup order — a component waits until its dependency is healthy.</li>
+    <li><code>$components.&lt;name&gt;.url</code> lets components discover each other without hardcoded addresses.</li>
+    <li>Only public-facing components need <code>exposed: true</code> — keep backends internal.</li>
+  </ul>
+</div>
+
+</CourseLayout>

--- a/www-dev/src/pages/learn/multi-component.astro
+++ b/www-dev/src/pages/learn/multi-component.astro
@@ -1,6 +1,5 @@
 ---
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import multiComponentYamlRaw from "../../../../spec/examples/multi-component.yaml?raw";
 
 import CourseLayout from "@/components/learn/CourseLayout.astro";
 import CodeBuildUp from "@/components/learn/CodeBuildUp.astro";
@@ -9,7 +8,7 @@ import GlossaryTip from "@/components/learn/GlossaryTip.astro";
 import Quiz from "@/components/learn/Quiz.astro";
 import RealWorldExample from "@/components/learn/RealWorldExample.astro";
 
-const multiComponentYaml = readFileSync(resolve(process.cwd(), "../spec/examples/multi-component.yaml"), "utf-8").replace(/^#.*\n/gm, "").trim();
+const multiComponentYaml = multiComponentYamlRaw.replace(/^#.*\n/gm, "").trim();
 ---
 
 <CourseLayout

--- a/www-dev/src/pages/learn/ports-storage-health.astro
+++ b/www-dev/src/pages/learn/ports-storage-health.astro
@@ -1,6 +1,5 @@
 ---
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import ghostYamlRaw from "../../../../catalog/apps/ghost/Launchfile?raw";
 
 import CourseLayout from "@/components/learn/CourseLayout.astro";
 import CodeBuildUp from "@/components/learn/CodeBuildUp.astro";
@@ -10,7 +9,7 @@ import GlossaryTip from "@/components/learn/GlossaryTip.astro";
 import Quiz from "@/components/learn/Quiz.astro";
 import RealWorldExample from "@/components/learn/RealWorldExample.astro";
 
-const ghostYaml = readFileSync(resolve(process.cwd(), "../catalog/apps/ghost/Launchfile"), "utf-8").replace(/^#.*\n/gm, "").trim();
+const ghostYaml = ghostYamlRaw.replace(/^#.*\n/gm, "").trim();
 ---
 
 <CourseLayout

--- a/www-dev/src/pages/learn/ports-storage-health.astro
+++ b/www-dev/src/pages/learn/ports-storage-health.astro
@@ -1,0 +1,170 @@
+---
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import CourseLayout from "@/components/learn/CourseLayout.astro";
+import CodeBuildUp from "@/components/learn/CodeBuildUp.astro";
+import Callout from "@/components/learn/Callout.astro";
+import BeforeAfter from "@/components/learn/BeforeAfter.astro";
+import GlossaryTip from "@/components/learn/GlossaryTip.astro";
+import Quiz from "@/components/learn/Quiz.astro";
+import RealWorldExample from "@/components/learn/RealWorldExample.astro";
+
+const ghostYaml = readFileSync(resolve(process.cwd(), "../catalog/apps/ghost/Launchfile"), "utf-8").replace(/^#.*\n/gm, "").trim();
+---
+
+<CourseLayout
+  title="Ports, Storage & Health"
+  subtitle="Expose endpoints, persist data, and tell providers how to check your app."
+  moduleName="Production-Ready"
+  moduleNumber={2}
+  lessonNumber={4}
+  learningGoals={[
+    "How provides declares ports and protocols your app exposes",
+    "Using storage for persistent volumes",
+    "Health checks — shorthand and expanded forms",
+    "The exposed flag for public-facing ports",
+  ]}
+  nextLesson={{ title: "Lifecycle Commands", description: "Build, release, start, seed — the full app lifecycle.", href: "/learn/lifecycle-commands/" }}
+>
+
+<h2 id="provides">The <code>provides</code> field</h2>
+
+<p>
+  Your app listens on a port. But the world outside your container doesn't know which one, what protocol it speaks, or whether it should be reachable from the internet. The <GlossaryTip term="provides" definition="A list of network endpoints your app exposes. Each entry declares a protocol, port, and visibility."><code>provides</code></GlossaryTip> field makes all of that explicit.
+</p>
+
+<p>
+  Each entry in <code>provides</code> declares a single endpoint. The key properties are:
+</p>
+
+<ul>
+  <li><strong><code>protocol</code></strong> — What the endpoint speaks: <code>http</code>, <code>https</code>, <code>tcp</code>, or <code>grpc</code>.</li>
+  <li><strong><code>port</code></strong> — The port number your app listens on inside the container.</li>
+  <li><strong><code>bind</code></strong> — Optional. The address to bind to (defaults to <code>0.0.0.0</code>).</li>
+  <li><strong><code>exposed</code></strong> — When <code>true</code>, the provider should make this port <GlossaryTip term="exposed" definition="An exposed port is publicly accessible from the internet, not just from other services in the same deployment.">publicly accessible</GlossaryTip> from the internet. When <code>false</code> (the default), it's only reachable by other components in the same deployment.</li>
+</ul>
+
+<h2 id="build-it-up">Build it up</h2>
+
+<CodeBuildUp steps={[
+  {
+    yaml: `provides:
+  - protocol: http
+    port: 3000
+    exposed: true`,
+    note: "Start with a single HTTP endpoint on port 3000, publicly accessible.",
+  },
+  {
+    yaml: `provides:
+  - protocol: http
+    port: 3000
+    exposed: true
+
+storage:
+  data:
+    path: /var/lib/app/data
+    persistent: true`,
+    note: "Add <strong>persistent storage</strong>. The <code>data</code> volume mounts at the given path and survives container restarts.",
+  },
+  {
+    yaml: `provides:
+  - protocol: http
+    port: 3000
+    exposed: true
+
+storage:
+  data:
+    path: /var/lib/app/data
+    persistent: true
+
+health: /health`,
+    note: "Add a <strong>health check</strong> using shorthand. The provider will GET this path and expect a 2xx response.",
+  },
+  {
+    yaml: `provides:
+  - protocol: http
+    port: 3000
+    exposed: true
+
+storage:
+  data:
+    path: /var/lib/app/data
+    persistent: true
+
+health:
+  path: /api/health
+  interval: 30s
+  timeout: 5s
+  retries: 3
+  start_period: 60s`,
+    note: "Switch to the <strong>expanded health check</strong> form for full control over timing, retries, and startup grace period.",
+  },
+]} />
+
+<h2 id="health-checks">Health check deep dive</h2>
+
+<p>
+  The shorthand form covers most cases: give it a path and the provider does the rest. When you need more control, expand it into an object.
+</p>
+
+<BeforeAfter
+  before={{ title: "Shorthand", yaml: "health: /health" }}
+  after={{ title: "Expanded", yaml: `health:
+  path: /api/health
+  interval: 30s
+  timeout: 5s
+  retries: 3
+  start_period: 60s` }}
+/>
+
+<Callout type="info" title="Slow starters">
+  <p>
+    The <code>start_period</code> field gives your app time to boot before the provider starts counting failures. A Java app loading Spring context or a Rails app compiling assets might need 60&ndash;120 seconds. During the start period, failed health checks don't count toward the retry limit.
+  </p>
+</Callout>
+
+<p>
+  If your app has no HTTP endpoint (say, a background worker), you can omit <code>health</code> entirely. The provider will fall back to checking whether the process is running.
+</p>
+
+<h2 id="in-the-wild">In the wild</h2>
+
+<p>
+  Ghost is a professional publishing platform. Its Launchfile declares an HTTP endpoint, persistent storage for uploaded content, and a health check hitting the admin API.
+</p>
+
+<RealWorldExample
+  appName="ghost"
+  yaml={ghostYaml}
+  annotations={[
+    { line: "provides:", text: "Declares an HTTP endpoint on port 2368, publicly exposed so readers can reach the blog." },
+    { line: "storage:", text: "The content volume at /var/lib/ghost/content holds themes, images, and uploads. Persistent means it survives redeploys." },
+    { line: "health:", text: "Hits the Ghost admin site endpoint. A 2xx means the app is ready to serve traffic." },
+  ]}
+  catalogUrl="https://launchfile.io/apps/ghost"
+/>
+
+<h2 id="check-your-understanding">Check your understanding</h2>
+
+<Quiz
+  question="What does exposed: true mean on a provides entry?"
+  options={[
+    { text: "The port is publicly accessible from the internet", correct: true, explanation: "Correct! An exposed port is reachable from outside the deployment — the provider configures routing, load balancing, and TLS accordingly." },
+    { text: "The port is logged for debugging", correct: false, explanation: "Not quite. Exposed controls network visibility, not logging." },
+    { text: "The container port is mapped to the host", correct: false, explanation: "That's an implementation detail of how a specific provider works. Exposed is a higher-level declaration about intent — should the internet be able to reach this port?" },
+    { text: "The health check is enabled", correct: false, explanation: "Health checks are configured separately via the health field. Exposed is about network access." },
+  ]}
+/>
+
+<div class="takeaways">
+  <div class="takeaways-title">Key takeaways</div>
+  <ul>
+    <li><strong><code>provides</code></strong> declares every network endpoint your app exposes, with protocol, port, and visibility.</li>
+    <li><strong><code>storage</code></strong> declares named volumes. Set <code>persistent: true</code> for data that must survive restarts.</li>
+    <li><strong><code>health</code></strong> tells the provider how to check your app. Use the string shorthand for simple cases, the object form for tuning.</li>
+    <li><strong><code>exposed: true</code></strong> means "the internet should reach this." Default is <code>false</code> (internal only).</li>
+  </ul>
+</div>
+
+</CourseLayout>

--- a/www-dev/src/pages/learn/specialized-patterns.astro
+++ b/www-dev/src/pages/learn/specialized-patterns.astro
@@ -1,0 +1,206 @@
+---
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import CourseLayout from "@/components/learn/CourseLayout.astro";
+import CodeBuildUp from "@/components/learn/CodeBuildUp.astro";
+import Callout from "@/components/learn/Callout.astro";
+import BeforeAfter from "@/components/learn/BeforeAfter.astro";
+import GlossaryTip from "@/components/learn/GlossaryTip.astro";
+import Quiz from "@/components/learn/Quiz.astro";
+import RealWorldExample from "@/components/learn/RealWorldExample.astro";
+
+const cronJobYaml = readFileSync(resolve(process.cwd(), "../spec/examples/cron-job.yaml"), "utf-8").replace(/^#.*\n/gm, "").trim();
+const prebuiltImageYaml = readFileSync(resolve(process.cwd(), "../spec/examples/prebuilt-image.yaml"), "utf-8").replace(/^#.*\n/gm, "").trim();
+const hostOrchestratorYaml = readFileSync(resolve(process.cwd(), "../spec/examples/host-orchestrator.yaml"), "utf-8").replace(/^#.*\n/gm, "").trim();
+const uptimeKumaYaml = readFileSync(resolve(process.cwd(), "../catalog/apps/uptime-kuma/Launchfile"), "utf-8").replace(/^#.*\n/gm, "").trim();
+---
+
+<CourseLayout
+  title="Specialized Patterns"
+  subtitle="Cron jobs, prebuilt images, host access, and optional dependencies."
+  moduleName="Advanced"
+  moduleNumber={3}
+  lessonNumber={7}
+  learningGoals={[
+    "Scheduled tasks with schedule and restart: no",
+    "Deploying prebuilt Docker images with the image field",
+    "Host access for CI runners and orchestrators",
+    "Optional dependencies with supports",
+  ]}
+>
+
+<h2 id="cron-jobs">Cron jobs</h2>
+
+<p>
+  Not every process is a long-running server. Sometimes you need a task that runs on a <GlossaryTip term="schedule" definition="A cron expression (like &quot;0 0 * * *&quot;) that tells the provider when to run a task. Used with restart: no for one-shot jobs.">schedule</GlossaryTip> — a nightly database sync, a weekly report, a cleanup job. Launchfile handles this with two fields: <code>schedule</code> and <code>restart: no</code>.
+</p>
+
+<CodeBuildUp steps={[
+  {
+    yaml: `name: daily-sync
+runtime: node
+schedule: "0 0 * * *"
+restart: "no"
+commands:
+  start: "node scripts/sync.js"`,
+    note: "A minimal cron job. The <code>schedule</code> is a standard cron expression (midnight daily). <code>restart: no</code> tells the provider this is a one-shot task, not a daemon.",
+  },
+  {
+    yaml: cronJobYaml,
+    note: "The full example adds a Postgres dependency. The provider spins up the task on schedule, injects the database URL, runs the script, and shuts it down.",
+  },
+]} />
+
+<Callout type="tip" title="No provides needed">
+  <p>Cron jobs don't have <code>provides:</code> — they're not servers, they don't listen on ports, and nothing connects to them. They just run, do their work, and exit.</p>
+</Callout>
+
+<h2 id="prebuilt-images">Prebuilt images</h2>
+
+<p>
+  When you don't want to build from source, use the <GlossaryTip term="image" definition="A Docker image reference (like ghcr.io/org/app:tag) that the provider pulls and runs directly, instead of building from source.">image</GlossaryTip> field instead of <code>runtime</code>. This is common for third-party apps, production containers, or anything already published to a registry.
+</p>
+
+<CodeBuildUp steps={[
+  {
+    yaml: `name: my-app
+image: ghcr.io/org/my-app:latest
+provides:
+  - protocol: http
+    port: 8080
+    exposed: true`,
+    note: "The simplest prebuilt deployment. No <code>runtime</code>, no <code>commands.build</code> — the provider just pulls the image and starts it.",
+  },
+  {
+    yaml: prebuiltImageYaml,
+    note: "A full prebuilt example with health checks, database requirements, and platform pinning. Same fields as source-based apps, minus the build step.",
+  },
+]} />
+
+<BeforeAfter
+  before={{
+    title: "Source-based (build from code)",
+    yaml: `name: my-app
+runtime: node
+commands:
+  build: "npm run build"
+  start: "node dist/server.js"`,
+  }}
+  after={{
+    title: "Prebuilt (pull and run)",
+    yaml: `name: my-app
+image: ghcr.io/org/my-app:latest`,
+  }}
+/>
+
+<p>
+  Everything else — <code>provides</code>, <code>requires</code>, <code>env</code>, <code>health</code> — works the same whether you build from source or pull an image. The only difference is how the app gets onto the server.
+</p>
+
+<h2 id="host-access">Host access</h2>
+
+<p>
+  Some apps need direct access to the host machine — CI runners that manage Docker containers, deployment tools that need the Docker socket, monitoring agents that read host metrics. The <code>host</code> field declares these requirements explicitly.
+</p>
+
+<p>
+  There are three host access types: <code>host.docker</code> for Docker daemon access, <code>host.network</code> for sharing the host network stack, and <code>host.filesystem</code> for reading or writing host paths.
+</p>
+
+<Callout type="warning" title="Security-sensitive">
+  <p>Host access breaks the container isolation boundary. Providers may restrict or refuse apps that request it. Always document <em>why</em> your app needs host access in the Launchfile's <code>description</code>.</p>
+</Callout>
+
+<p>Here's a deployment tool that needs all three:</p>
+
+<RealWorldExample
+  appName="launchpad"
+  yaml={hostOrchestratorYaml}
+  annotations={[
+    { line: "host:", text: "Declares exactly what host-level access this app requires." },
+    { line: "docker: required", text: "Needs the real Docker daemon — Docker-in-Docker won't work." },
+    { line: "network: host", text: "Shares the host network to manage container ports directly." },
+    { line: "filesystem: read-write", text: "Persistent state stored on the host filesystem." },
+  ]}
+/>
+
+<h2 id="optional-dependencies">Optional dependencies</h2>
+
+<p>
+  You've been using <code>requires:</code> for dependencies your app can't run without. But some dependencies are optional — a Redis cache that improves performance but isn't mandatory, or an S3 bucket for file uploads that falls back to local storage.
+</p>
+
+<p>
+  Use <code>supports:</code> for these. The provider provisions them if available, but the app still starts without them.
+</p>
+
+<BeforeAfter
+  before={{
+    title: "Required (app won't start without it)",
+    yaml: `requires:
+  - type: postgres
+    set_env:
+      DATABASE_URL: $url`,
+  }}
+  after={{
+    title: "Optional (app works without it)",
+    yaml: `supports:
+  - type: redis
+    set_env:
+      REDIS_URL: $url`,
+  }}
+/>
+
+<p>
+  Your app should check whether the environment variable is set and gracefully degrade when it isn't. The Launchfile just declares the intent — your code handles the fallback.
+</p>
+
+<h2 id="in-the-wild">In the wild</h2>
+
+<p>Uptime Kuma is a self-hosted monitoring tool. It's one of the simplest prebuilt-image patterns in the catalog — just an image, a port, persistent storage, and a health check.</p>
+
+<RealWorldExample
+  appName="uptime-kuma"
+  yaml={uptimeKumaYaml}
+  annotations={[
+    { line: "image:", text: "Pulls the official image from Docker Hub — no source build needed." },
+    { line: "storage:", text: "Persistent storage for monitoring data. Survives container restarts." },
+    { line: "restart: always", text: "Monitoring tools should always be running — restart on crash." },
+  ]}
+  catalogUrl="https://launchfile.io/apps/uptime-kuma/"
+/>
+
+<h2 id="check-your-understanding">Check your understanding</h2>
+
+<Quiz
+  question="What's the difference between `requires` and `supports`?"
+  options={[
+    { text: "requires is for databases, supports is for caching", correct: false, explanation: "The difference is about necessity, not type. You can require a Redis cache or support a Postgres read replica — it depends on whether the app needs it to start." },
+    { text: "requires means the app won't start without it, supports means it's optional", correct: true, explanation: "Correct! Required dependencies must be provisioned or the app fails. Supported dependencies are nice-to-have — the app starts either way." },
+    { text: "They're interchangeable", correct: false, explanation: "They have different semantics. A provider must provision required dependencies. Supported ones are optional and may not be provisioned." },
+    { text: "supports is for development only", correct: false, explanation: "supports works in all environments. It means the dependency is optional, not that it's dev-only." },
+  ]}
+/>
+
+<div class="takeaways">
+  <div class="takeaways-title">Key takeaways</div>
+  <ul>
+    <li>Cron jobs use <code>schedule</code> + <code>restart: no</code> — no <code>provides</code> needed.</li>
+    <li>Prebuilt images use <code>image:</code> instead of <code>runtime:</code> — everything else works the same.</li>
+    <li>Host access (<code>host.docker</code>, <code>host.network</code>, <code>host.filesystem</code>) is security-sensitive — declare it explicitly.</li>
+    <li><code>supports:</code> is like <code>requires:</code> but optional — the app gracefully degrades without it.</li>
+  </ul>
+</div>
+
+<div style="margin-top: 2rem; padding: 1.5rem; border-radius: 0.75rem; background: var(--lf-purple-50); border: 1px solid var(--lf-purple-100); text-align: center;">
+  <p style="font-size: 1.0625rem; font-weight: 600; color: var(--lf-ink); margin: 0 0 0.5rem;">Course complete!</p>
+  <p style="font-size: 0.9375rem; color: var(--lf-slate); margin: 0 0 1rem;">You're ready to write Launchfiles for any application.</p>
+  <div style="display: flex; gap: 0.75rem; justify-content: center; flex-wrap: wrap;">
+    <a href="https://launchfile.org/spec/" style="display: inline-flex; align-items: center; gap: 0.25rem; padding: 0.5rem 1rem; border-radius: 9999px; font-size: 0.875rem; font-weight: 600; color: white; background: var(--lf-primary); text-decoration: none;">Read the full spec</a>
+    <a href="/examples/" style="display: inline-flex; align-items: center; gap: 0.25rem; padding: 0.5rem 1rem; border-radius: 9999px; font-size: 0.875rem; font-weight: 600; color: var(--lf-primary); border: 1px solid var(--lf-purple-200); text-decoration: none;">Browse examples</a>
+    <a href="https://launchfile.io/apps/" style="display: inline-flex; align-items: center; gap: 0.25rem; padding: 0.5rem 1rem; border-radius: 9999px; font-size: 0.875rem; font-weight: 600; color: var(--lf-primary); border: 1px solid var(--lf-purple-200); text-decoration: none;">Explore the catalog</a>
+  </div>
+</div>
+
+</CourseLayout>

--- a/www-dev/src/pages/learn/specialized-patterns.astro
+++ b/www-dev/src/pages/learn/specialized-patterns.astro
@@ -1,6 +1,8 @@
 ---
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import cronJobYamlRaw from "../../../../spec/examples/cron-job.yaml?raw";
+import prebuiltImageYamlRaw from "../../../../spec/examples/prebuilt-image.yaml?raw";
+import hostOrchestratorYamlRaw from "../../../../spec/examples/host-orchestrator.yaml?raw";
+import uptimeKumaYamlRaw from "../../../../catalog/apps/uptime-kuma/Launchfile?raw";
 
 import CourseLayout from "@/components/learn/CourseLayout.astro";
 import CodeBuildUp from "@/components/learn/CodeBuildUp.astro";
@@ -10,10 +12,11 @@ import GlossaryTip from "@/components/learn/GlossaryTip.astro";
 import Quiz from "@/components/learn/Quiz.astro";
 import RealWorldExample from "@/components/learn/RealWorldExample.astro";
 
-const cronJobYaml = readFileSync(resolve(process.cwd(), "../spec/examples/cron-job.yaml"), "utf-8").replace(/^#.*\n/gm, "").trim();
-const prebuiltImageYaml = readFileSync(resolve(process.cwd(), "../spec/examples/prebuilt-image.yaml"), "utf-8").replace(/^#.*\n/gm, "").trim();
-const hostOrchestratorYaml = readFileSync(resolve(process.cwd(), "../spec/examples/host-orchestrator.yaml"), "utf-8").replace(/^#.*\n/gm, "").trim();
-const uptimeKumaYaml = readFileSync(resolve(process.cwd(), "../catalog/apps/uptime-kuma/Launchfile"), "utf-8").replace(/^#.*\n/gm, "").trim();
+const stripComments = (s: string) => s.replace(/^#.*\n/gm, "").trim();
+const cronJobYaml = stripComments(cronJobYamlRaw);
+const prebuiltImageYaml = stripComments(prebuiltImageYamlRaw);
+const hostOrchestratorYaml = stripComments(hostOrchestratorYamlRaw);
+const uptimeKumaYaml = stripComments(uptimeKumaYamlRaw);
 ---
 
 <CourseLayout

--- a/www-dev/src/pages/learn/specialized-patterns.astro
+++ b/www-dev/src/pages/learn/specialized-patterns.astro
@@ -27,7 +27,7 @@ const uptimeKumaYaml = stripComments(uptimeKumaYamlRaw);
   lessonNumber={7}
   learningGoals={[
     "Scheduled tasks with schedule and restart: no",
-    "Deploying prebuilt Docker images with the image field",
+    "How runtime, build, and image interact — and platform pinning",
     "Host access for CI runners and orchestrators",
     "Optional dependencies with supports",
   ]}
@@ -59,47 +59,50 @@ commands:
   <p>Cron jobs don't have <code>provides:</code> — they're not servers, they don't listen on ports, and nothing connects to them. They just run, do their work, and exit.</p>
 </Callout>
 
-<h2 id="prebuilt-images">Prebuilt images</h2>
+<h2 id="images-builds-runtimes">Images, builds, and runtimes</h2>
 
 <p>
-  When you don't want to build from source, use the <GlossaryTip term="image" definition="A Docker image reference (like ghcr.io/org/app:tag) that the provider pulls and runs directly, instead of building from source.">image</GlossaryTip> field instead of <code>runtime</code>. This is common for third-party apps, production containers, or anything already published to a registry.
+  Lesson 1 introduced two paths: <code>runtime</code> + <code>commands.start</code> for building from source, or <GlossaryTip term="image" definition="A Docker image reference (like ghcr.io/org/app:tag) that the provider pulls and runs directly, instead of building from source."><code>image</code></GlossaryTip> for pulling a prebuilt container. There's a third field, <code>build</code>, for Dockerfile-based builds — and these three can coexist.
 </p>
 
-<CodeBuildUp steps={[
-  {
-    yaml: `name: my-app
-image: ghcr.io/org/my-app:latest
-provides:
-  - protocol: http
-    port: 8080
-    exposed: true`,
-    note: "The simplest prebuilt deployment. No <code>runtime</code>, no <code>commands.build</code> — the provider just pulls the image and starts it.",
-  },
-  {
-    yaml: prebuiltImageYaml,
-    note: "A full prebuilt example with health checks, database requirements, and platform pinning. Same fields as source-based apps, minus the build step.",
-  },
-]} />
+<p>Each answers a different question:</p>
 
-<BeforeAfter
-  before={{
-    title: "Source-based (build from code)",
-    yaml: `name: my-app
-runtime: node
-commands:
-  build: "npm run build"
-  start: "node dist/server.js"`,
-  }}
-  after={{
-    title: "Prebuilt (pull and run)",
-    yaml: `name: my-app
-image: ghcr.io/org/my-app:latest`,
-  }}
+<ul>
+  <li><strong><code>runtime:</code></strong> — what language is this? Metadata only; tooling and buildpack-style providers use it.</li>
+  <li><strong><code>build:</code></strong> — how do I build from source? Dockerfile path, context, build args, and build-time secrets.</li>
+  <li><strong><code>image:</code></strong> — what's the image called? Either the image you pull, or the tag of what <code>build</code> produces.</li>
+</ul>
+
+<Callout type="tip" title="Docker Compose semantics">
+  <p>The <code>build</code> and <code>image</code> fields mirror Docker Compose:</p>
+  <ul>
+    <li><code>image</code> alone → pull the image from a registry.</li>
+    <li><code>build</code> alone → build from a Dockerfile; the provider names the artifact.</li>
+    <li><code>build</code> + <code>image</code> → build from source and tag the result as <code>image</code> (useful when you want to push to a registry).</li>
+    <li><code>runtime</code> + anything → <code>runtime</code> is metadata; it doesn't change how the container is made.</li>
+  </ul>
+</Callout>
+
+<p>
+  Lesson 5 distinguished <code>commands.build</code> (shell commands inside an already-built container) from the top-level <code>build:</code> block (Dockerfile-based image builds). They're different layers: <code>commands.build</code> runs <em>inside</em> the container, <code>build:</code> creates the container.
+</p>
+
+<h3 id="platform-pinning">Platform pinning</h3>
+
+<p>
+  Many third-party images only ship for <code>linux/amd64</code>. The <code>platform</code> field tells the provider which OCI architecture to pull — important on ARM hosts (Apple Silicon dev machines, Graviton, Raspberry Pi) so the right variant is fetched or emulation is arranged.
+</p>
+
+<RealWorldExample
+  appName="hedgedoc-backend"
+  yaml={prebuiltImageYaml}
+  annotations={[
+    { line: "image:", text: "A specific version tag, not :latest — prebuilt deploys should be reproducible." },
+    { line: "platform:", text: "Declares the target architecture. This image only ships amd64; providers on ARM hosts need to know so they can emulate or refuse." },
+    { line: "requires:", text: "Prebuilt images declare dependencies the same way as source-based apps — the provider injects env vars before starting the container." },
+    { line: "health:", text: "Health checks apply to prebuilt images too. start_period gives the container time to initialize before checks begin." },
+  ]}
 />
-
-<p>
-  Everything else — <code>provides</code>, <code>requires</code>, <code>env</code>, <code>health</code> — works the same whether you build from source or pull an image. The only difference is how the app gets onto the server.
-</p>
 
 <h2 id="host-access">Host access</h2>
 
@@ -194,7 +197,7 @@ image: ghcr.io/org/my-app:latest`,
   <div class="takeaways-title">Key takeaways</div>
   <ul>
     <li>Cron jobs use <code>schedule</code> + <code>restart: no</code> — no <code>provides</code> needed.</li>
-    <li>Prebuilt images use <code>image:</code> instead of <code>runtime:</code> — everything else works the same.</li>
+    <li><code>runtime</code>, <code>build</code>, and <code>image</code> describe three different things and can coexist: <code>runtime</code> is metadata, <code>build</code> creates the image, <code>image</code> names it. Use <code>platform:</code> to pin OCI architecture.</li>
     <li>Host access (<code>host.docker</code>, <code>host.network</code>, <code>host.filesystem</code>) is security-sensitive — declare it explicitly.</li>
     <li><code>supports:</code> is like <code>requires:</code> but optional — the app gracefully degrades without it.</li>
   </ul>

--- a/www-dev/src/pages/learn/specialized-patterns.astro
+++ b/www-dev/src/pages/learn/specialized-patterns.astro
@@ -108,6 +108,10 @@ image: ghcr.io/org/my-app:latest`,
   There are three host access types: <code>host.docker</code> for Docker daemon access, <code>host.network</code> for sharing the host network stack, and <code>host.filesystem</code> for reading or writing host paths.
 </p>
 
+<p>
+  Add <code>host.privileged: true</code> when the app needs elevated privileges — e.g. device access for monitoring agents or kernel-level tools. Providers treat this as the most sensitive host flag and may refuse it in managed environments.
+</p>
+
 <Callout type="warning" title="Security-sensitive">
   <p>Host access breaks the container isolation boundary. Providers may restrict or refuse apps that request it. Always document <em>why</em> your app needs host access in the Launchfile's <code>description</code>.</p>
 </Callout>

--- a/www-dev/src/pages/quick-start.astro
+++ b/www-dev/src/pages/quick-start.astro
@@ -6,6 +6,12 @@ import { Code } from "astro:components";
 <DocsLayout title="Quick Start — Launchfile" description="Write your first Launchfile in two minutes." currentPath="/quick-start/">
   <h1>Quick Start</h1>
 
+  <div style="padding: 0.875rem 1.25rem; border-radius: 0.5rem; border: 1px solid var(--lf-purple-100); background: var(--lf-purple-50); margin-bottom: 1.5rem;">
+    <p style="margin: 0; font-size: 0.9375rem; color: var(--lf-charcoal);">
+      <strong>Want a guided walkthrough?</strong> The <a href="/learn/" style="color: var(--lf-primary); font-weight: 600;">Learn Launchfile</a> course takes you step by step from zero to multi-component apps.
+    </p>
+  </div>
+
   <p>A Launchfile describes what your application needs to run. Create a file called <code>Launchfile</code> (no extension) in your project root:</p>
 
   <h2 id="minimal">Minimal example</h2>

--- a/www-dev/src/pages/writing-a-launchfile.astro
+++ b/www-dev/src/pages/writing-a-launchfile.astro
@@ -5,6 +5,12 @@ import DocsLayout from "@/layouts/DocsLayout.astro";
 <DocsLayout title="Writing a Launchfile — Guide" description="A practical guide to writing Launchfiles for your applications." currentPath="/writing-a-launchfile/">
   <h1>Writing a Launchfile</h1>
 
+  <div style="padding: 0.875rem 1.25rem; border-radius: 0.5rem; border: 1px solid var(--lf-purple-100); background: var(--lf-purple-50); margin-bottom: 1.5rem;">
+    <p style="margin: 0; font-size: 0.9375rem; color: var(--lf-charcoal);">
+      <strong>New to Launchfile?</strong> Start with the <a href="/learn/" style="color: var(--lf-primary); font-weight: 600;">Learn Launchfile</a> course for a step-by-step guide with interactive examples.
+    </p>
+  </div>
+
   <p>A Launchfile is a YAML file called <code>Launchfile</code> (no extension) that lives in your project root. It declares what your application needs — the platform handles the rest.</p>
 
   <h2 id="structure">File structure</h2>

--- a/www-dev/src/styles/learn.css
+++ b/www-dev/src/styles/learn.css
@@ -1,0 +1,884 @@
+/* ===== Learn Launchfile — Course Styles ===== */
+
+/* ===== Course Layout ===== */
+.course-layout {
+  display: flex;
+  min-height: calc(100vh - var(--header-height));
+}
+
+.course-content {
+  flex: 1;
+  min-width: 0;
+  padding: 2rem 1.5rem 4rem;
+}
+
+@media (min-width: 1024px) {
+  .course-content {
+    margin-left: var(--sidebar-width);
+    padding: 2rem 3rem 4rem;
+  }
+}
+
+.course-content-inner {
+  display: flex;
+  gap: 3rem;
+  max-width: 64rem;
+  margin: 0 auto;
+}
+
+.course-main {
+  flex: 1;
+  min-width: 0;
+  max-width: 50rem;
+}
+
+.course-toc-rail {
+  display: none;
+  width: 14rem;
+  flex-shrink: 0;
+}
+
+@media (min-width: 1280px) {
+  .course-toc-rail { display: block; }
+}
+
+/* ===== Breadcrumbs ===== */
+.course-breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.8125rem;
+  color: var(--lf-slate);
+  margin-bottom: 1.5rem;
+}
+
+.course-breadcrumbs a {
+  color: var(--lf-slate);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.course-breadcrumbs a:hover { color: var(--lf-primary); }
+
+.course-breadcrumbs .separator {
+  color: var(--lf-purple-200);
+  font-size: 0.75rem;
+}
+
+.course-breadcrumbs .current {
+  color: var(--lf-charcoal);
+  font-weight: 500;
+}
+
+/* ===== Lesson Header ===== */
+.lesson-header { margin-bottom: 2.5rem; }
+
+.lesson-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--lf-primary);
+  margin-bottom: 0.75rem;
+}
+
+.lesson-indicator-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--lf-primary);
+}
+
+.lesson-title {
+  font-size: clamp(1.75rem, 3vw, 2.25rem);
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  line-height: 1.2;
+  color: var(--lf-ink);
+  margin: 0 0 0.5rem;
+}
+
+.lesson-subtitle {
+  font-size: 1.0625rem;
+  line-height: 1.6;
+  color: var(--lf-slate);
+  max-width: 36rem;
+}
+
+/* ===== What You'll Learn ===== */
+.learn-goals {
+  border: 1px solid var(--lf-purple-100);
+  border-radius: 0.75rem;
+  padding: 1.25rem 1.5rem;
+  background: var(--lf-purple-50);
+  margin-bottom: 2.5rem;
+}
+
+.learn-goals-title {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--lf-primary);
+  margin: 0 0 0.75rem;
+}
+
+.learn-goals ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.learn-goals li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  color: var(--lf-charcoal);
+}
+
+.learn-goals li::before {
+  content: "";
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  margin-top: 2px;
+  border-radius: 50%;
+  background: var(--lf-primary);
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z' clip-rule='evenodd'/%3E%3C/svg%3E");
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z' clip-rule='evenodd'/%3E%3C/svg%3E");
+}
+
+/* ===== Callout ===== */
+.callout {
+  border-radius: 0.5rem;
+  padding: 1rem 1.25rem;
+  margin: 1.5rem 0;
+  border-left: 4px solid;
+  font-size: 0.9375rem;
+  line-height: 1.6;
+}
+
+.callout-title {
+  font-weight: 600;
+  font-size: 0.875rem;
+  margin-bottom: 0.375rem;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.callout p { margin: 0; }
+.callout p + p { margin-top: 0.5rem; }
+
+.callout-tip {
+  border-color: var(--lf-primary);
+  background: var(--lf-purple-50);
+}
+.callout-tip .callout-title { color: var(--lf-primary); }
+
+.callout-warning {
+  border-color: var(--lf-warning);
+  background: #FFFBEB;
+}
+.callout-warning .callout-title { color: var(--lf-warning); }
+
+.callout-info {
+  border-color: #3B82F6;
+  background: #EFF6FF;
+}
+.callout-info .callout-title { color: #3B82F6; }
+
+/* ===== Code Build-Up ===== */
+.code-buildup {
+  margin: 1.5rem 0 2rem;
+}
+
+.code-buildup-step {
+  display: flex;
+  gap: 1.25rem;
+  position: relative;
+}
+
+.code-buildup-step + .code-buildup-step {
+  margin-top: 1.5rem;
+}
+
+.code-buildup-gutter {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex-shrink: 0;
+  width: 2rem;
+}
+
+.code-buildup-number {
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  background: var(--lf-primary);
+  color: white;
+  font-size: 0.75rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  z-index: 1;
+}
+
+.code-buildup-line {
+  flex: 1;
+  width: 2px;
+  background: var(--lf-purple-100);
+  margin-top: 0.25rem;
+}
+
+.code-buildup-body {
+  flex: 1;
+  min-width: 0;
+  padding-bottom: 0.5rem;
+}
+
+.code-buildup-note {
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  color: var(--lf-charcoal);
+  margin-bottom: 0.75rem;
+}
+
+.code-buildup-body pre {
+  margin: 0;
+  border-radius: 0.5rem;
+  font-size: 0.8125rem !important;
+}
+
+/* ===== Before/After ===== */
+.before-after {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+
+@media (min-width: 640px) {
+  .before-after { grid-template-columns: 1fr 1fr; }
+}
+
+.before-after-pane {
+  border-radius: 0.5rem;
+  overflow: hidden;
+  border: 1px solid var(--lf-purple-100);
+}
+
+.before-after-label {
+  padding: 0.5rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--lf-slate);
+  background: var(--lf-paper);
+  border-bottom: 1px solid var(--lf-purple-100);
+}
+
+.before-after-pane pre {
+  margin: 0 !important;
+  border-radius: 0 !important;
+  font-size: 0.8125rem !important;
+}
+
+/* ===== Glossary Tooltip ===== */
+.glossary-term {
+  text-decoration: underline;
+  text-decoration-style: dashed;
+  text-decoration-color: var(--lf-purple-200);
+  text-underline-offset: 3px;
+  cursor: help;
+  color: inherit;
+}
+
+.glossary-tooltip {
+  position: fixed;
+  z-index: 9999;
+  max-width: min(320px, 85vw);
+  padding: 0.625rem 0.875rem;
+  border-radius: 0.5rem;
+  background: var(--lf-ink);
+  color: var(--lf-paper);
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(4px);
+  transition: opacity 0.15s, transform 0.15s;
+}
+
+.glossary-tooltip.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.glossary-tooltip::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+}
+
+.glossary-tooltip.above::after {
+  top: 100%;
+  border-top-color: var(--lf-ink);
+}
+
+.glossary-tooltip.below::after {
+  bottom: 100%;
+  border-bottom-color: var(--lf-ink);
+}
+
+.glossary-tooltip-term {
+  font-weight: 600;
+  color: var(--lf-purple-200);
+  margin-bottom: 0.25rem;
+}
+
+/* ===== Quiz ===== */
+.quiz {
+  border: 1px solid var(--lf-purple-100);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  margin: 2rem 0;
+  background: var(--lf-white);
+}
+
+.quiz-question {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--lf-ink);
+  margin: 0 0 1rem;
+  line-height: 1.5;
+}
+
+.quiz-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.quiz-option {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.625rem 0.875rem;
+  border: 1px solid var(--lf-purple-100);
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-size: 0.9375rem;
+  transition: border-color 0.15s, background-color 0.15s;
+  background: none;
+  width: 100%;
+  text-align: left;
+  color: var(--lf-charcoal);
+}
+
+.quiz-option:hover:not(:disabled) {
+  border-color: var(--lf-purple-200);
+  background: var(--lf-purple-50);
+}
+
+.quiz-option.selected {
+  border-color: var(--lf-primary);
+  background: var(--lf-purple-50);
+}
+
+.quiz-option:disabled { cursor: default; opacity: 0.7; }
+
+.quiz-option.correct {
+  border-color: var(--lf-success);
+  background: #ECFDF5;
+  opacity: 1;
+}
+
+.quiz-option.incorrect {
+  border-color: var(--lf-error);
+  background: #FEF2F2;
+  opacity: 1;
+}
+
+.quiz-radio {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid var(--lf-purple-200);
+  flex-shrink: 0;
+  transition: border-color 0.15s, background-color 0.15s;
+}
+
+.quiz-option.selected .quiz-radio {
+  border-color: var(--lf-primary);
+  background: var(--lf-primary);
+  box-shadow: inset 0 0 0 2.5px white;
+}
+
+.quiz-option.correct .quiz-radio {
+  border-color: var(--lf-success);
+  background: var(--lf-success);
+  box-shadow: inset 0 0 0 2.5px white;
+}
+
+.quiz-option.incorrect .quiz-radio {
+  border-color: var(--lf-error);
+  background: var(--lf-error);
+  box-shadow: inset 0 0 0 2.5px white;
+}
+
+.quiz-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.quiz-btn {
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.15s, transform 0.1s;
+}
+
+.quiz-btn:active { transform: scale(0.97); }
+
+.quiz-btn-check {
+  background: var(--lf-primary);
+  color: white;
+}
+
+.quiz-btn-check:hover { background: var(--lf-primary-dark); }
+.quiz-btn-check:disabled { opacity: 0.5; cursor: default; }
+
+.quiz-btn-retry {
+  background: var(--lf-paper);
+  color: var(--lf-charcoal);
+  border: 1px solid var(--lf-purple-100);
+}
+
+.quiz-btn-retry:hover { background: var(--lf-purple-50); }
+
+.quiz-feedback {
+  margin-top: 1rem;
+  padding: 0.875rem 1rem;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.quiz-feedback-correct {
+  background: #ECFDF5;
+  color: #065F46;
+  border: 1px solid #A7F3D0;
+}
+
+.quiz-feedback-incorrect {
+  background: #FEF2F2;
+  color: #991B1B;
+  border: 1px solid #FECACA;
+}
+
+/* ===== Lesson TOC (On This Page) ===== */
+.lesson-toc {
+  position: sticky;
+  top: calc(var(--header-height) + 2rem);
+}
+
+.lesson-toc-title {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--lf-ink);
+  margin-bottom: 0.75rem;
+}
+
+.lesson-toc-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-left: 1px solid var(--lf-purple-100);
+}
+
+.lesson-toc-item {
+  margin-left: -1px;
+  border-left: 2px solid transparent;
+}
+
+.lesson-toc-item.active {
+  border-color: var(--lf-primary);
+}
+
+.lesson-toc-link {
+  display: block;
+  padding: 0.25rem 0 0.25rem 0.875rem;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--lf-slate);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.lesson-toc-link:hover { color: var(--lf-ink); }
+.lesson-toc-item.active .lesson-toc-link {
+  color: var(--lf-ink);
+  font-weight: 500;
+}
+
+.lesson-toc-link.depth-3 { padding-left: 1.75rem; }
+
+/* ===== Up Next Card ===== */
+.up-next {
+  margin-top: 3rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--lf-purple-100);
+}
+
+.up-next a {
+  display: block;
+  padding: 1rem 1.25rem;
+  border-radius: 0.75rem;
+  text-decoration: none;
+  transition: background-color 0.15s;
+}
+
+.up-next a:hover { background: var(--lf-purple-50); }
+
+.up-next-label {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.8125rem;
+  color: var(--lf-slate);
+  margin-bottom: 0.5rem;
+}
+
+.up-next-title {
+  font-size: 1.0625rem;
+  font-weight: 600;
+  color: var(--lf-ink);
+  margin-bottom: 0.25rem;
+}
+
+.up-next-desc {
+  font-size: 0.875rem;
+  color: var(--lf-slate);
+  line-height: 1.5;
+}
+
+/* ===== Key Takeaways ===== */
+.takeaways {
+  border: 1px solid var(--lf-purple-100);
+  border-radius: 0.75rem;
+  padding: 1.25rem 1.5rem;
+  margin: 2.5rem 0 0;
+  background: var(--lf-paper);
+}
+
+.takeaways-title {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--lf-charcoal);
+  margin: 0 0 0.75rem;
+}
+
+.takeaways ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.takeaways li {
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  color: var(--lf-charcoal);
+  padding-left: 1.25rem;
+  position: relative;
+}
+
+.takeaways li::before {
+  content: "\2713";
+  position: absolute;
+  left: 0;
+  color: var(--lf-success);
+  font-weight: 700;
+}
+
+/* ===== Real World Example ===== */
+.real-world {
+  margin: 2rem 0;
+}
+
+.real-world-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.875rem;
+  background: var(--lf-paper);
+  border: 1px solid var(--lf-purple-100);
+  border-bottom: none;
+  border-radius: 0.5rem 0.5rem 0 0;
+  font-size: 0.8125rem;
+}
+
+.real-world-filename {
+  font-weight: 600;
+  color: var(--lf-charcoal);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+}
+
+.real-world-link {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: var(--lf-slate);
+  text-decoration: none;
+  font-size: 0.75rem;
+  transition: color 0.15s;
+}
+
+.real-world-link:hover { color: var(--lf-primary); }
+
+.real-world pre {
+  margin: 0 !important;
+  border-radius: 0 0 0.5rem 0.5rem !important;
+}
+
+.real-world-annotations {
+  margin-top: 1rem;
+  padding: 1rem 1.25rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--lf-purple-100);
+  background: var(--lf-purple-50);
+}
+
+.real-world-annotations dt {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--lf-primary-dark);
+  margin-top: 0.75rem;
+}
+
+.real-world-annotations dt:first-child { margin-top: 0; }
+
+.real-world-annotations dd {
+  font-size: 0.875rem;
+  color: var(--lf-charcoal);
+  margin: 0.25rem 0 0 0;
+  line-height: 1.5;
+}
+
+/* ===== Course Landing Page ===== */
+.course-hero {
+  position: relative;
+  overflow: hidden;
+  background: var(--lf-ink);
+  padding: 3.5rem 1.5rem 3rem;
+  border-radius: 0 0 1rem 1rem;
+  margin-bottom: 3rem;
+}
+
+@media (min-width: 1024px) {
+  .course-hero { padding: 4.5rem 3rem 3.5rem; }
+}
+
+.course-hero-grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(127, 119, 221, 0.12) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(127, 119, 221, 0.12) 1px, transparent 1px);
+  background-size: 4rem 4rem;
+  mask-image: radial-gradient(ellipse 60% 80% at 70% 40%, black 10%, transparent 100%);
+  -webkit-mask-image: radial-gradient(ellipse 60% 80% at 70% 40%, black 10%, transparent 100%);
+}
+
+.course-hero-inner {
+  position: relative;
+  max-width: 36rem;
+}
+
+.course-hero-title {
+  font-size: clamp(1.75rem, 3.5vw, 2.5rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  line-height: 1.15;
+  color: var(--lf-white);
+  margin: 0 0 1rem;
+}
+
+.course-hero-desc {
+  font-size: 1rem;
+  line-height: 1.7;
+  color: var(--lf-purple-200);
+  margin: 0 0 1.5rem;
+}
+
+.course-hero-stats {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 1rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--lf-purple-200);
+  margin-bottom: 2rem;
+}
+
+.course-hero-stats .dot {
+  color: rgba(175, 169, 236, 0.3);
+}
+
+.course-hero-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.25rem;
+  border-radius: 9999px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: white;
+  background: var(--lf-primary-light);
+  text-decoration: none;
+  transition: background-color 0.2s, transform 0.15s, box-shadow 0.2s;
+  box-shadow: 0 0 20px rgba(83, 74, 183, 0.3);
+}
+
+.course-hero-cta:hover {
+  background: var(--lf-primary-glow);
+  transform: translateY(-1px);
+  box-shadow: 0 0 30px rgba(127, 119, 221, 0.4);
+}
+
+/* Module listing */
+.course-modules {
+  max-width: 50rem;
+  margin: 0 auto;
+}
+
+.course-module {
+  margin-bottom: 2.5rem;
+}
+
+.course-module-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--lf-primary);
+  margin-bottom: 0.25rem;
+}
+
+.course-module-title {
+  font-size: 1.375rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--lf-ink);
+  margin: 0 0 0.5rem;
+}
+
+.course-module-desc {
+  font-size: 0.9375rem;
+  color: var(--lf-slate);
+  line-height: 1.5;
+  margin: 0 0 1rem;
+}
+
+.course-lesson-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.course-lesson-card {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.875rem 1rem;
+  border: 1px solid var(--lf-purple-100);
+  border-radius: 0.5rem;
+  text-decoration: none;
+  transition: border-color 0.15s, background-color 0.15s, box-shadow 0.15s, transform 0.15s;
+}
+
+.course-lesson-card:hover {
+  border-color: var(--lf-purple-200);
+  background: var(--lf-purple-50);
+  box-shadow: 0 2px 8px rgba(60, 52, 137, 0.06);
+  transform: translateY(-1px);
+}
+
+.course-lesson-num {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background: var(--lf-paper);
+  color: var(--lf-primary);
+  font-size: 0.8125rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border: 1px solid var(--lf-purple-100);
+}
+
+.course-lesson-card:hover .course-lesson-num {
+  background: var(--lf-primary);
+  color: white;
+  border-color: var(--lf-primary);
+}
+
+.course-lesson-info { flex: 1; min-width: 0; }
+
+.course-lesson-title {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--lf-ink);
+}
+
+.course-lesson-desc {
+  font-size: 0.8125rem;
+  color: var(--lf-slate);
+  margin-top: 0.125rem;
+}
+
+.course-lesson-chevron {
+  color: var(--lf-purple-200);
+  flex-shrink: 0;
+  transition: color 0.15s, transform 0.15s;
+}
+
+.course-lesson-card:hover .course-lesson-chevron {
+  color: var(--lf-primary);
+  transform: translateX(2px);
+}
+
+/* ===== Animations ===== */
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.course-hero-inner { animation: fadeInUp 0.5s ease-out; }


### PR DESCRIPTION
## Summary

- **7-lesson interactive course** teaching Launchfile authoring from scratch — a 3-line minimal file to multi-component apps with databases, secrets, and health checks
- **Reusable Astro components**: glossary tooltips, quiz engine, code build-up steps, before/after comparisons, callout boxes
- **Wired into existing site**: homepage hero CTA, first quicklink card, sidebar navigation, and callout banners on Quick Start, Writing a Launchfile, and Examples pages

### Lessons

1. First Launchfile — minimal 3-line file
2. Adding a Database — multi-service composition
3. Env & Secrets — configuration management
4. Ports, Storage & Health — networking and persistence
5. Lifecycle Commands — start/stop/health
6. Multi-Component Apps — full-stack orchestration
7. Specialized Patterns — advanced real-world usage

## Test plan

- [x] Run `bun run dev` in `www-dev/` and navigate to `/learn/`
- [x] Walk through all 7 lessons — verify quizzes, code build-ups, glossary tooltips work
- [x] Verify homepage hero CTA links to `/learn/`
- [ ] Verify callout banners on Quick Start, Writing a Launchfile, and Examples pages
- [ ] Check mobile responsiveness of course layout and scroll-tracked TOC
- [ ] Verify "Up Next" cards link correctly between lessons

🤖 Generated with [Claude Code](https://claude.com/claude-code)