### PR TITLE
catalog(paperclip): fix bootstrap command — validated end-to-end on published image

### DIFF
--- a/catalog/apps/paperclip/Launchfile
+++ b/catalog/apps/paperclip/Launchfile
@@ -42,14 +42,23 @@ restart: always
 
 commands:
   # Post-start setup: provision the first admin (CEO) and capture the
-  # one-time invite link. Re-runnable; failures are reported rather than
-  # deploy-failing. A full Paperclip bootstrap also writes a config.json
-  # and restarts the server, but those steps are held for Proposal B
-  # (templated file-placement primitive) pending the incubation-mechanism
-  # decision on issue #16. For now this captures the invite step, which
-  # is the user-facing piece.
+  # one-time invite link. Re-runnable — each run issues a fresh invite,
+  # which is also the recovery path when a previous invite expires.
+  #
+  # The first run must create the CLI's config.json before it can issue
+  # invites: `onboard --yes` writes it but then starts an embedded
+  # quickstart server that never exits (hence the timeout), and it
+  # hardcodes deploymentMode=local_trusted while this deployment runs
+  # authenticated (hence the sed). When the templated file-placement
+  # primitive lands (held proposal, see issue #16), those two steps
+  # collapse into a declarative file write.
   bootstrap:
-    command: "bootstrap-ceo invite --admin"
+    command: >-
+      CFG="$PAPERCLIP_HOME/instances/default/config.json";
+      test -f "$CFG" || {
+      timeout 30 pnpm paperclipai onboard --yes >/dev/null 2>&1;
+      sed -i "s/\"deploymentMode\": \"local_trusted\"/\"deploymentMode\": \"authenticated\"/" "$CFG"; };
+      pnpm paperclipai auth bootstrap-ceo --base-url "$BETTER_AUTH_URL"
     capture:
       invite_link:
         pattern: "https?://\\S+invite\\S*"

--- a/catalog/apps/paperclip/metadata.yaml
+++ b/catalog/apps/paperclip/metadata.yaml
@@ -2,12 +2,12 @@ category: AI/Automation
 tagline: Open-source orchestration for zero-human companies
 homepage: https://paperclip.ing
 test_results:
-  last_tested: 2026-04-08
+  last_tested: 2026-06-09
   pull_time_seconds: 3
   startup_time_seconds: 11
   total_disk_mb: 2098
   health_check_passed: true
-  notes: ""
+  notes: "bootstrap command validated end-to-end on published image: fresh-install invite generation, re-run invite refresh, and invite registration page in browser"
 images:
   - name: ghcr.io/paperclipai/paperclip:latest
     size_mb: 1839


### PR DESCRIPTION
The catalog entry's `commands.bootstrap` was `bootstrap-ceo invite --admin`, which doesn't exist in the published image (exit 127). The working CLI invocation is `pnpm paperclipai auth bootstrap-ceo`, but on a fresh container it refuses to run until `onboard` has written `config.json` — and `onboard --yes` never exits (it starts an embedded quickstart server) and writes `deploymentMode: local_trusted` while this deployment shape runs authenticated.

This PR replaces the command with a chained shell sequence validated end-to-end on `ghcr.io/paperclipai/paperclip:latest`: first run writes the config (timeout-bounded) and switches it to authenticated mode, then issues the invite; subsequent runs skip straight to a fresh invite, making the command re-runnable per the spec's bootstrap semantics — and giving operators a recovery path for expired invites. The browser cannot self-serve first-run (a fresh instance explicitly instructs running the CLI), so the bootstrap command is the only path to a usable instance.

The config-creation steps are a workaround for the missing templated file-placement primitive (the held proposal from #16 names Paperclip's `config.json` as a motivating case); when that lands, the command collapses back to the single `bootstrap-ceo` invocation.

## Validation (2026-06-09, fresh containers, published image)

- Fresh install: invite generated, registration page renders in browser
- Re-run: onboard skipped, fresh invite issued
- `metadata.yaml` `test_results` updated accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)