### PR TITLE
feat: docker provider builds components from source

### DIFF
--- a/providers/docker/CLAUDE.md
+++ b/providers/docker/CLAUDE.md
@@ -8,7 +8,8 @@ A Launchfile provider that runs apps via Docker Compose. Generates a docker-comp
 
 ## Philosophy
 
-- **Image-first** — uses `image:` field, generates backing services as Docker containers
+- **Image-first, build-capable** — uses `image:` when present; components with `build:` are built via `docker compose build` (contexts resolve against the project directory; git-URL contexts pass through). Building in Docker is the sandboxed path for untrusted sources — nothing from the repo executes on the host
+- **Artifact-context commands only** — runs `commands.start`/`bootstrap`; ignores dev-mode variants (`dev`, `dev:*` — D-35)
 - **Zero-install** — works via `npx launchfile up ghost`
 - **100% cleanable** — `down --destroy` removes all containers, volumes, and networks
 - **Catalog-friendly** — accepts app slugs, URLs, or local Launchfile paths

--- a/providers/docker/src/__tests__/compose-generator.test.ts
+++ b/providers/docker/src/__tests__/compose-generator.test.ts
@@ -284,3 +284,88 @@ secrets:
 		);
 	});
 });
+
+describe("compose-generator build support", () => {
+	it("emits a build config for components with build:, resolved against projectDir", () => {
+		const launch = readLaunch(`
+name: srcapp
+build:
+  dockerfile: Dockerfile
+provides:
+  - protocol: http
+    port: 9999
+    exposed: true
+`);
+		const result = launchToCompose(launch, { projectDir: "/repos/srcapp" });
+
+		expect(result.warnings).toHaveLength(0);
+		expect(result.builds).toEqual(["srcapp"]);
+		expect(result.images).toHaveLength(0); // nothing to pull
+		expect(result.yaml).toContain("context: /repos/srcapp");
+		expect(result.yaml).toContain("dockerfile: Dockerfile");
+	});
+
+	it("uses image: as the tag for the built artifact when both are present", () => {
+		const launch = readLaunch(`
+name: srcapp
+build: "."
+image: srcapp:dev
+`);
+		const result = launchToCompose(launch, { projectDir: "/repos/srcapp" });
+
+		expect(result.builds).toEqual(["srcapp"]);
+		// The image is a tag for the build output, not something to pull
+		expect(result.images).toHaveLength(0);
+		expect(result.yaml).toContain("image: srcapp:dev");
+	});
+
+	it("passes remote git contexts through untouched", () => {
+		const launch = readLaunch(`
+name: remoteapp
+build:
+  context: https://github.com/example/app.git
+`);
+		const result = launchToCompose(launch);
+
+		expect(result.builds).toEqual(["remoteapp"]);
+		expect(result.yaml).toContain("context: https://github.com/example/app.git");
+	});
+
+	it("skips relative build contexts when the source is not local", () => {
+		const launch = readLaunch(`
+name: srcapp
+build: "."
+`);
+		const result = launchToCompose(launch); // no projectDir
+
+		expect(result.builds).toHaveLength(0);
+		expect(result.warnings.some((w) => w.includes("not local"))).toBe(true);
+	});
+
+	it("warns that build secrets are not supported", () => {
+		const launch = readLaunch(`
+name: srcapp
+build:
+  context: "."
+  secrets: [npm-token]
+`);
+		const result = launchToCompose(launch, { projectDir: "/repos/srcapp" });
+
+		expect(result.warnings.some((w) => w.includes("build secrets"))).toBe(true);
+	});
+
+	it("resolves build args and target", () => {
+		const launch = readLaunch(`
+name: srcapp
+build:
+  context: "."
+  target: runtime
+  args:
+    NODE_ENV: production
+`);
+		const result = launchToCompose(launch, { projectDir: "/repos/srcapp" });
+
+		expect(result.yaml).toContain("target: runtime");
+		expect(result.yaml).toContain("NODE_ENV: production");
+	});
+});

--- a/providers/docker/src/__tests__/prereqs.test.ts
+++ b/providers/docker/src/__tests__/prereqs.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { composeVersionAtLeast } from "../prereqs.js";
+
+describe("composeVersionAtLeast", () => {
+	it("accepts versions at or above the threshold", () => {
+		expect(composeVersionAtLeast("2.18.0", 2, 18)).toBe(true);
+		expect(composeVersionAtLeast("v2.18.1", 2, 18)).toBe(true);
+		expect(composeVersionAtLeast("2.39.1", 2, 18)).toBe(true);
+		expect(composeVersionAtLeast("3.0.0", 2, 18)).toBe(true);
+	});
+
+	it("rejects versions below the threshold", () => {
+		expect(composeVersionAtLeast("2.17.9", 2, 18)).toBe(false);
+		expect(composeVersionAtLeast("v2.2.3", 2, 18)).toBe(false);
+		expect(composeVersionAtLeast("1.29.2", 2, 18)).toBe(false);
+	});
+
+	it("returns false for unparseable output (conservative fallback)", () => {
+		expect(composeVersionAtLeast("", 2, 18)).toBe(false);
+		expect(composeVersionAtLeast("dev-build", 2, 18)).toBe(false);
+	});
+});

--- a/providers/docker/src/__tests__/source-resolver.test.ts
+++ b/providers/docker/src/__tests__/source-resolver.test.ts
@@ -106,3 +106,35 @@ describe("resolveSource", () => {
 		});
 	});
 });
+
+describe("resolveSource local directories", () => {
+	it("accepts a project directory and finds the Launchfile inside it", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "lf-dir-"));
+		try {
+			writeFileSync(join(dir, "Launchfile"), "name: dirapp\nimage: nginx\n");
+			const result = await resolveSource(dir);
+
+			expect(result.source).toBe("local");
+			expect(result.slug).toBe("dirapp");
+			expect(result.dir).toBe(dir);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("returns the containing directory for a Launchfile path", async () => {
+		const result = await resolveSource(join(CATALOG_DIR, "apps/ghost/Launchfile"));
+		expect(result.dir).toBe(join(CATALOG_DIR, "apps/ghost"));
+	});
+});
+
+describe("resolveSource directory without Launchfile", () => {
+	it("throws a helpful error naming the directory", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "lf-empty-"));
+		try {
+			await expect(resolveSource(dir)).rejects.toThrow(/No Launchfile found in/);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/providers/docker/src/compose-generator.ts
+++ b/providers/docker/src/compose-generator.ts
@@ -6,6 +6,7 @@
  * host port mappings.
  */
 
+import { resolve as resolvePath } from "node:path";
 import { stringify } from "yaml";
 import {
 	resolveExpression,
@@ -388,12 +389,17 @@ export interface ComposeOpts {
 	hostPorts?: Record<string, number>;
 	/** Docker network name */
 	networkName?: string;
+	/** Project directory for local sources — relative `build:` contexts resolve against this */
+	projectDir?: string;
 }
 
 export interface ComposeResult {
 	yaml: string;
 	warnings: string[];
+	/** Images to pull (services without a build config) */
 	images: string[];
+	/** Service names that must be built from a `build:` config before start */
+	builds: string[];
 	/** Secrets generated during composition (save to state) */
 	secrets: Record<string, string>;
 	/** Map of component name → exposed host port */
@@ -406,6 +412,7 @@ export function launchToCompose(
 ): ComposeResult {
 	const warnings: string[] = [];
 	const images: string[] = [];
+	const builds: string[] = [];
 	const services: Record<string, Record<string, unknown>> = {};
 	const volumes: Record<string, Record<string, unknown>> = {};
 	const secrets = opts.secrets ?? {};
@@ -445,11 +452,7 @@ export function launchToCompose(
 		const serviceName =
 			componentName === "default" ? launch.name : `${launch.name}-${componentName}`;
 
-		if (!component.image) {
-			if (component.build) {
-				warnings.push(`${componentName}: uses build — skipped (no image)`);
-				continue;
-			}
+		if (!component.image && !component.build) {
 			warnings.push(`${componentName}: no image or build — skipped`);
 			continue;
 		}
@@ -471,11 +474,41 @@ export function launchToCompose(
 			warnings.push(`${componentName}: has schedule — included but won't cron`);
 		}
 
-		images.push(component.image);
+		const service: Record<string, unknown> = {};
 
-		const service: Record<string, unknown> = {
-			image: component.image,
-		};
+		if (component.build) {
+			// Build from source. Relative contexts resolve against the project
+			// directory (the compose file lives in state, not the project), so
+			// `context: "."` means "the directory containing the Launchfile".
+			// Remote contexts (git URLs) pass through — docker clones and builds
+			// them itself, which keeps the build off the host for untrusted repos.
+			const context = component.build.context ?? ".";
+			const isRemoteContext = /^(https?:\/\/|git@|ssh:\/\/)/.test(context);
+			if (!isRemoteContext && !opts.projectDir) {
+				warnings.push(
+					`${componentName}: build context "${context}" is relative but the source is not local — skipped`,
+				);
+				continue;
+			}
+
+			const build: Record<string, unknown> = {
+				context: isRemoteContext ? context : resolvePath(opts.projectDir!, context),
+			};
+			if (component.build.dockerfile) build.dockerfile = component.build.dockerfile;
+			if (component.build.target) build.target = component.build.target;
+			if (component.build.args) build.args = component.build.args;
+			if (component.build.secrets?.length) {
+				warnings.push(`${componentName}: build secrets are not yet supported by the docker provider — ignored`);
+			}
+			service.build = build;
+			// `image:` alongside `build:` names the built artifact (SPEC.md:
+			// "build + image — image is the name/tag for the resulting artifact").
+			if (component.image) service.image = component.image;
+			builds.push(serviceName);
+		} else {
+			service.image = component.image;
+			images.push(component.image!);
+		}
 
 		// Ports — map to specific host ports
 		if (component.provides?.length) {
@@ -616,6 +649,7 @@ export function launchToCompose(
 		yaml: stringify(compose, { lineWidth: 120 }),
 		warnings,
 		images: [...new Set(images)],
+		builds,
 		secrets,
 		ports,
 	};

--- a/providers/docker/src/prereqs.ts
+++ b/providers/docker/src/prereqs.ts
@@ -31,3 +31,31 @@ export async function checkPrereqs(): Promise<PrereqResult> {
 
 	return { ok: missing.length === 0, missing };
 }
+
+/**
+ * Parse a `docker compose version --short` string (e.g. "2.39.1" or
+ * "v2.18.0") and report whether it is at least major.minor. Unparseable
+ * versions return false — callers fall back to the conservative path.
+ * Exported for unit testing.
+ */
+export function composeVersionAtLeast(version: string, major: number, minor: number): boolean {
+	const m = /^v?(\d+)\.(\d+)/.exec(version.trim());
+	if (!m) return false;
+	const maj = Number(m[1]);
+	const min = Number(m[2]);
+	return maj > major || (maj === major && min >= minor);
+}
+
+/**
+ * `docker compose pull --ignore-buildable` requires Compose >= 2.18 (2023).
+ * On older installs the unknown flag aborts the pull outright, so callers
+ * must choose a fallback instead of passing it blindly.
+ */
+export async function composeSupportsIgnoreBuildable(): Promise<boolean> {
+	const result = await shell("docker", ["compose", "version", "--short"], {
+		allowFailure: true,
+		silent: true,
+	});
+	if (result.exitCode !== 0) return false;
+	return composeVersionAtLeast(result.stdout, 2, 18);
+}

--- a/providers/docker/src/provider.ts
+++ b/providers/docker/src/provider.ts
@@ -5,7 +5,7 @@
 import { writeFile } from "node:fs/promises";
 import { createInterface } from "node:readline";
 import { readLaunch } from "@launchfile/sdk";
-import { checkPrereqs } from "./prereqs.js";
+import { checkPrereqs, composeSupportsIgnoreBuildable } from "./prereqs.js";
 import { resolveSource } from "./source-resolver.js";
 import {
 	loadState,
@@ -19,7 +19,7 @@ import {
 } from "./state.js";
 import { allocatePorts } from "./port-allocator.js";
 import { launchToCompose } from "./compose-generator.js";
-import { shell } from "./shell.js";
+import { shell, shellStream } from "./shell.js";
 import { getLogger, withSpan } from "./logger.js";
 import { readdir } from "node:fs/promises";
 
@@ -61,10 +61,14 @@ export async function dockerUp(source: string, opts: DockerUpOpts = {}): Promise
 			const images = componentNames
 				.map((name) => launch.components[name]?.image)
 				.filter(Boolean) as string[];
+			const buildComponents = componentNames.filter(
+				(name) => launch.components[name]?.build,
+			);
 
 			console.log(`  App: ${launch.name} (${resolved.slug})`);
 			if (resources.length) console.log(`  Resources: ${resources.join(", ")}`);
 			if (images.length) console.log(`  Images: ${images.join(", ")}`);
+			if (buildComponents.length) console.log(`  Builds from source: ${buildComponents.join(", ")}`);
 			console.log("");
 
 			const confirmed = await confirm("  Proceed? [Y/n] ");
@@ -88,6 +92,7 @@ export async function dockerUp(source: string, opts: DockerUpOpts = {}): Promise
 		const result = launchToCompose(launch, {
 			secrets: state.secrets,
 			hostPorts,
+			projectDir: resolved.dir,
 		});
 
 		// Log warnings
@@ -120,19 +125,43 @@ export async function dockerUp(source: string, opts: DockerUpOpts = {}): Promise
 		const project = composeProject(resolved.slug);
 		const composeFile = composePath(resolved.slug);
 
-		// Pull images — one step per image for progress visibility
-		await withSpan("up:pull", { images: result.images }, async () => {
-			for (const img of result.images) {
+		// Pull images for services that don't build from source
+		if (result.images.length > 0) {
+			await withSpan("up:pull", { images: result.images }, async () => {
 				const t0 = Date.now();
-				process.stdout.write(`  \u2193 Pulling ${img} image...`);
-				await shell("docker", ["compose", "-p", project, "-f", composeFile, "pull", "--quiet"], {
+				process.stdout.write(`  \u2193 Pulling ${result.images.join(", ")}...`);
+				const pullArgs = ["compose", "-p", project, "-f", composeFile, "pull", "--quiet"];
+				// Don't try to pull images that compose will build locally.
+				// --ignore-buildable needs Compose >= 2.18; older installs get
+				// --ignore-pull-failures so locally-built tags don't abort the pull.
+				if (result.builds.length > 0) {
+					pullArgs.push((await composeSupportsIgnoreBuildable()) ? "--ignore-buildable" : "--ignore-pull-failures");
+				}
+				await shell("docker", pullArgs, {
 					timeout: 300_000,
 					silent: true,
 				});
 				const sec = Math.round((Date.now() - t0) / 1000);
 				console.log(` done (${sec}s)`);
-			}
-		});
+			});
+		}
+
+		// Build images for services with a build: config. Source builds run
+		// inside docker build — nothing from the repo executes on the host.
+		if (result.builds.length > 0) {
+			await withSpan("up:build", { services: result.builds }, async () => {
+				const t0 = Date.now();
+				console.log(`  \u2193 Building from source: ${result.builds.join(", ")} (this can take a few minutes)`);
+				// One invocation builds all services concurrently under BuildKit
+				// with a shared layer cache; output streams so the user sees
+				// progress instead of silence (and no maxBuffer ceiling).
+				await shellStream("docker", ["compose", "-p", project, "-f", composeFile, "build", ...result.builds], {
+					timeout: 1_800_000,
+				});
+				const sec = Math.round((Date.now() - t0) / 1000);
+				console.log(`  \u2713 Built ${result.builds.join(", ")} (${sec}s)`);
+			});
+		}
 
 		// Configure resources (if any)
 		const resources = componentNames.flatMap((name) => {

--- a/providers/docker/src/shell.ts
+++ b/providers/docker/src/shell.ts
@@ -2,7 +2,7 @@
  * Shell execution helper with timeout and structured results.
  */
 
-import { execFile as cpExecFile, type ExecFileOptions } from "node:child_process";
+import { execFile as cpExecFile, spawn, type ExecFileOptions } from "node:child_process";
 import { getLogger } from "./logger.js";
 
 export interface ShellResult {
@@ -70,4 +70,55 @@ export async function shell(
 export async function shellOk(cmd: string, args: string[], opts?: ShellOpts): Promise<boolean> {
 	const result = await shell(cmd, args, { ...opts, allowFailure: true, silent: true });
 	return result.exitCode === 0;
+}
+
+/**
+ * Run a command with stdout/stderr streamed straight to the terminal.
+ * For long-running commands (image builds) where buffered execFile output
+ * would show nothing for minutes and can exceed maxBuffer.
+ */
+export async function shellStream(
+	cmd: string,
+	args: string[],
+	opts: ShellOpts & { allowFailure?: boolean } = {},
+): Promise<number> {
+	const display = [cmd, ...args].join(" ");
+	if (!opts.silent) {
+		console.log(`  $ ${display}`);
+	}
+
+	const log = getLogger();
+	log.debug({ cmd, args, cwd: opts.cwd }, "shell stream exec");
+	const t0 = performance.now();
+
+	return new Promise((resolvePromise, reject) => {
+		const child = spawn(cmd, args, {
+			cwd: opts.cwd,
+			env: opts.env ? { ...process.env, ...opts.env } : undefined,
+			stdio: ["ignore", "inherit", "inherit"],
+		});
+
+		const timer = opts.timeout
+			? setTimeout(() => child.kill("SIGTERM"), opts.timeout)
+			: undefined;
+
+		child.on("error", (err) => {
+			if (timer) clearTimeout(timer);
+			reject(err);
+		});
+
+		child.on("close", (code) => {
+			if (timer) clearTimeout(timer);
+			const exitCode = code ?? 1;
+			log.debug(
+				{ cmd, args, exitCode, durationMs: Math.round(performance.now() - t0) },
+				"shell stream complete",
+			);
+			if (exitCode !== 0 && !opts.allowFailure) {
+				reject(new Error(`Command failed: ${display} (exit ${exitCode})`));
+			} else {
+				resolvePromise(exitCode);
+			}
+		});
+	});
 }

--- a/providers/docker/src/source-resolver.ts
+++ b/providers/docker/src/source-resolver.ts
@@ -9,13 +9,15 @@
 
 import { readFile } from "node:fs/promises";
 import { basename, dirname, join, resolve } from "node:path";
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 export interface ResolvedSource {
 	yaml: string;
 	slug: string;
 	source: "local" | "catalog" | "url";
+	/** Project directory for local sources — `build:` contexts resolve against this */
+	dir?: string;
 }
 
 // Security: cap remote Launchfile size to prevent memory exhaustion.
@@ -50,10 +52,20 @@ export async function resolveSource(input: string): Promise<ResolvedSource> {
 }
 
 async function readLocal(path: string): Promise<ResolvedSource> {
-	const resolved = resolve(path);
+	let resolved = resolve(path);
+	// Accept a project directory — look for the Launchfile inside it.
+	if (existsSync(resolved) && statSync(resolved).isDirectory()) {
+		const inDir = join(resolved, "Launchfile");
+		if (!existsSync(inDir)) {
+			throw new Error(
+				`No Launchfile found in ${resolved}. Create a file named "Launchfile" (no extension) or pass its path directly.`,
+			);
+		}
+		resolved = inDir;
+	}
 	const yaml = await readFile(resolved, "utf8");
 	const slug = inferSlug(resolved, yaml);
-	return { yaml, slug, source: "local" };
+	return { yaml, slug, source: "local", dir: dirname(resolved) };
 }
 
 /**


### PR DESCRIPTION
The docker provider was pull-only: components with `build:` and no `image:` were warned about and skipped. This makes `build:` real — and makes containerized builds the sandboxed path for untrusted sources (nothing from the repo executes on the host; git-URL contexts never even clone locally).

- `launchToCompose` emits compose `build:` configs — context resolved against the project directory, `dockerfile`/`target`/`args` passed through, `image:` kept as the artifact tag (per SPEC's build+image semantics); new `builds` result field
- `dockerUp` runs one streamed `docker compose build` for all buildable services (concurrent under BuildKit, shared layer cache); pull covers only pullable images
- `resolveSource` accepts project directories (`launchfile up ~/code/myapp`) and returns the dir for build-context resolution

Hardening from the pre-PR review, closes #46:
- `--ignore-buildable` version-gated (Compose ≥ 2.18); older installs fall back to `--ignore-pull-failures` instead of dying on an unknown flag
- build output streams via spawn (no more silent multi-minute builds or 10MB maxBuffer ceiling)
- directory without a Launchfile → named error instead of raw ENOENT

**Verification**: 142 provider tests green (incl. new build-emission, directory-resolution, version-gate tests); exercised end-to-end against a real app (claudewerk broker): `up --docker` built the image from its Dockerfile, health check passed, `bootstrap` ran the invite CLI via compose exec with capture, `down` clean.

Related: #48 (slug/appName identity mismatch — pre-existing, easier to hit now; not addressed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
