### PR TITLE
chore: switch www-dev/www-org dependabot to the bun ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,7 +36,9 @@ updates:
         patterns: ["*"]
 
   # www-dev (launchfile.dev)
-  - package-ecosystem: npm
+  # bun ecosystem so dependabot regenerates bun.lock — npm-ecosystem PRs only
+  # bumped package.json, which fails CI's frozen-lockfile install
+  - package-ecosystem: bun
     directory: /www-dev
     schedule:
       interval: weekly
@@ -52,7 +54,7 @@ updates:
         exclude-patterns: ["astro", "@astrojs/*", "tailwindcss", "@tailwindcss/*"]
 
   # www-org (launchfile.org)
-  - package-ecosystem: npm
+  - package-ecosystem: bun
     directory: /www-org
     schedule:
       interval: weekly


### PR DESCRIPTION
The npm ecosystem bumps `package.json` without regenerating `bun.lock`, so every website dependency PR failed CI's `--frozen-lockfile` install and needed a manual lockfile commit (#30, #31, #38, #39, #41, #42 — all six fixed by hand this week). The bun ecosystem updates the lockfile in the same PR.

Scoped to the two sites per discussion; the sdk/providers/catalog entries can follow once this proves out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
