### PR TITLE
sdk+providers: inject $app.authority/scheme/tls (D-35 conformance)

### DIFF
--- a/providers/docker/src/__tests__/compose-generator.test.ts
+++ b/providers/docker/src/__tests__/compose-generator.test.ts
@@ -219,6 +219,39 @@ env:
 		expect(result.yaml).toContain("CALLBACK: http://localhost:10043/oauth/callback");
 	});
 
+	it("resolves $app.authority, $app.scheme, and $app.tls (D-35) — the HedgeDoc shape", () => {
+		const launch = readLaunch(`
+name: hedge-like
+image: nginx
+provides:
+  - port: 3000
+    protocol: http
+    exposed: true
+env:
+  CMD_DOMAIN: $app.authority
+  CMD_PROTOCOL_USESSL: $app.tls
+  SCHEME: $app.scheme
+`);
+		const result = launchToCompose(launch, { hostPorts: { default: 49200 } });
+		// Without these, an empty CMD_DOMAIN makes the app emit an invalid CSP
+		// and the page renders unstyled — the gap this fix closes.
+		expect(result.yaml).toContain("CMD_DOMAIN: localhost:49200");
+		expect(result.yaml).toContain('CMD_PROTOCOL_USESSL: "false"');
+		expect(result.yaml).toContain("SCHEME: http");
+	});
+
+	it("leaves $app.authority/scheme/tls empty for an app with no exposed component", () => {
+		const launch = readLaunch(`
+name: worker
+image: nginx
+env:
+  CMD_DOMAIN: "[\${app.authority}]"
+`);
+		const result = launchToCompose(launch);
+		// No exposed port → empty url → empty authority; resolves to "" not undefined.
+		expect(result.yaml).toContain('CMD_DOMAIN: "[]"');
+	});
+
 	it("falls back to the declared container port when no host port override is given", () => {
 		const launch = readLaunch(`
 name: ghost-like

--- a/providers/docker/src/compose-generator.ts
+++ b/providers/docker/src/compose-generator.ts
@@ -9,6 +9,7 @@
 import { resolve as resolvePath } from "node:path";
 import { stringify } from "yaml";
 import {
+	deriveAppUrlProperties,
 	resolveExpression,
 	isExpression,
 	type ResolverContext,
@@ -349,15 +350,17 @@ function createBackingServices(
 }
 
 /**
- * Compute the $app.* property set (D-33) for a Launchfile under the docker
+ * Compute the $app.* property set (D-33, D-35) for a Launchfile under the docker
  * provider. The "primary" component is the first one (in declaration order)
  * with at least one `exposed: true` provides entry; its host port becomes
- * `$app.port` and `http://localhost:<hostPort>` becomes `$app.url`.
+ * `$app.port` and `http://localhost:<hostPort>` becomes `$app.url`. The
+ * `authority`/`scheme`/`tls` trio is derived from that URL via the SDK so the
+ * split-field tokens (e.g. HedgeDoc's `CMD_DOMAIN: $app.authority`) resolve.
  *
- * Apps with no exposed component get `port: 0` and `url: ""`. For multi-
- * exposed-component apps that need a specific component's URL, use
- * `$components.<name>.url` instead — `$app.*` always points at the first
- * exposed component to give a single, predictable answer.
+ * Apps with no exposed component get `port: 0` and `url: ""` (and empty
+ * authority/scheme/tls). For multi-exposed-component apps that need a specific
+ * component's URL, use `$components.<name>.url` instead — `$app.*` always points
+ * at the first exposed component to give a single, predictable answer.
  */
 function computeAppProperties(
 	launch: NormalizedLaunch,
@@ -372,11 +375,13 @@ function computeAppProperties(
 		break;
 	}
 
+	const url = primaryPort > 0 ? `http://localhost:${primaryPort}` : "";
 	return {
 		name: launch.name,
 		host: "localhost",
 		port: primaryPort,
-		url: primaryPort > 0 ? `http://localhost:${primaryPort}` : "",
+		url,
+		...deriveAppUrlProperties(url),
 	};
 }
 

--- a/providers/macos-dev/src/env-writer.ts
+++ b/providers/macos-dev/src/env-writer.ts
@@ -8,6 +8,7 @@
 import { writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import {
+	deriveAppUrlProperties,
 	resolveExpression,
 	isExpression,
 	type NormalizedComponent,
@@ -22,10 +23,13 @@ import { generateValue } from "./secret-generator.js";
 export type { ResolverContext };
 
 /**
- * Compute the $app.* property set for a Launchfile under the macos-dev
- * provider. The app's "primary" port comes from the first component (in
- * declaration order) that has at least one `exposed: true` provides entry.
- * Apps with no exposed component get `port: 0` and `url: ""`.
+ * Compute the $app.* property set (D-33, D-35) for a Launchfile under the
+ * macos-dev provider. The app's "primary" port comes from the first component
+ * (in declaration order) that has at least one `exposed: true` provides entry.
+ * The `authority`/`scheme`/`tls` trio is derived from the resulting URL via the
+ * SDK so split-field tokens (e.g. `CMD_DOMAIN: $app.authority`) resolve.
+ * Apps with no exposed component get `port: 0` and `url: ""` (and empty
+ * authority/scheme/tls).
  *
  * For multi-exposed-component apps that need a specific component's URL,
  * use `$components.<name>.url` instead — `$app.*` always points at the
@@ -44,11 +48,13 @@ export function computeAppProperties(
 		}
 	}
 
+	const url = primaryPort > 0 ? `http://localhost:${primaryPort}` : "";
 	return {
 		name: launch.name,
 		host: "localhost",
 		port: primaryPort,
-		url: primaryPort > 0 ? `http://localhost:${primaryPort}` : "",
+		url,
+		...deriveAppUrlProperties(url),
 	};
 }
 

--- a/sdk/src/__tests__/resolver.test.ts
+++ b/sdk/src/__tests__/resolver.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { parseExpression, resolveExpression, parseDotPath, isExpression } from "../resolver.js";
+import {
+	parseExpression,
+	resolveExpression,
+	parseDotPath,
+	isExpression,
+	deriveAppUrlProperties,
+} from "../resolver.js";
 
 /*---
 req: REQ-410
@@ -494,5 +500,52 @@ describe("resolveExpression — $app.* prefix (D-33)", () => {
 		expect(resolveExpression("$app.url", ctx)).toBe("https://my-app.example.com");
 		expect(resolveExpression("$host", ctx)).toBe("db");
 		expect(resolveExpression("$secrets.token", ctx)).toBe("abc123");
+	});
+});
+
+/*--- test-spec
+title: deriveAppUrlProperties derives the authority/scheme/tls trio (D-35)
+covers:
+  - $app.authority is the WHATWG URL host (includes non-default port)
+  - default port is omitted from authority
+  - $app.scheme and $app.tls track the URL scheme
+  - empty / invalid URL degrades to empty strings
+tags: [launch-spec, resolver, app-prefix, d-35]
+---*/
+describe("deriveAppUrlProperties (D-35)", () => {
+	it("derives authority with a non-default port (WHATWG URL.host)", () => {
+		expect(deriveAppUrlProperties("http://localhost:49200")).toEqual({
+			authority: "localhost:49200",
+			scheme: "http",
+			tls: "false",
+		});
+	});
+
+	it("omits the port from authority when it is the scheme default", () => {
+		expect(deriveAppUrlProperties("https://my-app.example.com")).toEqual({
+			authority: "my-app.example.com",
+			scheme: "https",
+			tls: "true",
+		});
+	});
+
+	it("reports tls=false for an explicit http URL", () => {
+		expect(deriveAppUrlProperties("http://my-app.example.com").tls).toBe("false");
+	});
+
+	it("degrades to empty strings for an empty URL (no exposed component)", () => {
+		expect(deriveAppUrlProperties("")).toEqual({ authority: "", scheme: "", tls: "" });
+	});
+
+	it("degrades to empty strings for an unparseable URL", () => {
+		expect(deriveAppUrlProperties("not a url")).toEqual({ authority: "", scheme: "", tls: "" });
+	});
+
+	// The derived trio plugs straight into the resolver as $app.* values.
+	it("feeds the resolver so $app.authority / $app.tls resolve end-to-end", () => {
+		const ctx = { app: { url: "http://localhost:49200", ...deriveAppUrlProperties("http://localhost:49200") } };
+		expect(resolveExpression("$app.authority", ctx)).toBe("localhost:49200");
+		expect(resolveExpression("$app.tls", ctx)).toBe("false");
+		expect(resolveExpression("$app.scheme", ctx)).toBe("http");
 	});
 });

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,6 +1,7 @@
 export { cmdInspect, cmdSchema, cmdValidate } from "./commands.js";
 export { readLaunch, validateLaunch } from "./reader.js";
 export {
+	deriveAppUrlProperties,
 	isExpression,
 	parseDotPath,
 	parseExpression,

--- a/sdk/src/resolver.ts
+++ b/sdk/src/resolver.ts
@@ -21,12 +21,40 @@ export interface ResolverContext {
 	/** App-wide generated secrets (e.g., { "jwt-secret": "abc123" }) */
 	secrets?: Record<string, string>;
 	/**
-	 * Platform-injected app properties (D-33). Standard set: url, host, port,
-	 * name. Providers may expose additional properties as platform-specific
-	 * extensions. The provider populates this from its routing strategy at
-	 * deploy time.
+	 * Platform-injected app properties (D-33, D-35). Standard set: url, host,
+	 * port, name, authority, scheme, tls. Providers may expose additional
+	 * properties as platform-specific extensions. The provider populates this
+	 * from its routing strategy at deploy time — see {@link deriveAppUrlProperties}
+	 * for the authority/scheme/tls trio.
 	 */
 	app?: Record<string, string | number>;
+}
+
+/**
+ * Derive the URL-shaped members of the standard `$app.*` set (D-35) from a
+ * resolved public URL: `authority` (WHATWG URL `host` — hostname plus port,
+ * port omitted when it's the default for the scheme), `scheme` (`http`/`https`),
+ * and `tls` (the string `"true"` when https, else `"false"`).
+ *
+ * A provider computes `$app.url` for its routing strategy, then spreads this to
+ * get the split-field tokens for free, keeping a single definition consistent
+ * with the spec. An empty or unparseable URL (e.g. an app with no exposed
+ * component) yields empty strings, so the tokens degrade to "" like any other
+ * unresolved `$app.*` property.
+ */
+export function deriveAppUrlProperties(
+	url: string,
+): { authority: string; scheme: string; tls: string } {
+	try {
+		const u = new URL(url);
+		return {
+			authority: u.host,
+			scheme: u.protocol.replace(/:$/, ""),
+			tls: u.protocol === "https:" ? "true" : "false",
+		};
+	} catch {
+		return { authority: "", scheme: "", tls: "" };
+	}
 }
 
 /** Result of parsing a set_env value */


### PR DESCRIPTION
## What

Makes the two **reference providers** (docker, macos-dev) inject the
`$app.authority` / `$app.scheme` / `$app.tls` tokens standardized in #58 (D-35).
Before this, both providers computed only `name`/`host`/`port`/`url` for the
`$app.*` set, so the three new tokens resolved to empty string under a direct
`launchfile up`.

## Why — this is a real conformance bug

D-35 standardized these as part of the `$app.*` set **"every provider must
support."** A reverse-proxy-aware app like HedgeDoc wires `CMD_DOMAIN:
$app.authority`. With the providers not injecting it, `CMD_DOMAIN` is empty →
HedgeDoc emits a CSP whose `style-src`/`script-src` are bare paths (`/build/`,
`/css/`) → the browser rejects them and blocks every stylesheet → the app
renders **unstyled**. (This is the same failure that produced the broken catalog
screenshot in #60/#68 — but it bites any real `launchfile up hedgedoc`, not just
the screenshot harness.)

Verified empirically against the catalog HedgeDoc entry via the docker provider:

```
BEFORE:  CMD_DOMAIN = ""               CMD_PROTOCOL_USESSL = ""
AFTER:   CMD_DOMAIN = "localhost:49200"   CMD_PROTOCOL_USESSL = "false"
```

## How

- **`sdk:`** — new `deriveAppUrlProperties(url)` helper: one definition of the
  trio matching the spec's normative WHATWG `URL.host` (`authority` = host +
  port, port omitted when default for scheme; `scheme` = http/https; `tls` =
  `"true"`/`"false"`). Empty/unparseable URL → empty strings, so the tokens
  degrade like any other unresolved `$app.*`.
- **`providers:`** — both `computeAppProperties` functions spread the helper into
  the `$app.*` set they already build from `$app.url`. Single source of truth; no
  duplicated derivation.

## Tests

- SDK: `deriveAppUrlProperties` unit tests (non-default port kept, default port
  omitted, http→tls=false, empty/invalid → empty, end-to-end through the
  resolver). 189 SDK tests pass.
- Docker: a test asserting the generated compose injects
  `CMD_DOMAIN: localhost:<port>` / `CMD_PROTOCOL_USESSL: "false"` (the HedgeDoc
  shape), plus the no-exposed-component empty case. 79 docker + 64 macos-dev
  tests pass; all three typecheck clean.

Pairs with #59 (spec) and #60/#68 (catalog entry + screenshot) to make HedgeDoc
work end-to-end on the reference providers, not just on launchpad.
