### PR TITLE
catalog: list hedgedoc under Tested Apps (stale index after #60 promotion)

### DIFF
--- a/catalog/CLAUDE.md
+++ b/catalog/CLAUDE.md
@@ -29,6 +29,12 @@ App names are kebab-case, matching the `name:` field inside the Launchfile.
 1. Pick a draft: `catalog/drafts/<app>/Launchfile`
 2. Test it locally (e.g. docker compose, validate against schema)
 3. Once verified: `git mv catalog/drafts/<app> catalog/apps/<app>`
+4. **Update the indexes in the same PR** — the `git mv` alone leaves stale
+   listings:
+   - Move the app's row in `README.md` from **Proposed Apps** to **Tested Apps**
+     (and repoint its link from `drafts/` to `apps/`).
+   - Add it to the matching tier in `test/src/test-all.ts` so it joins the batch
+     regression run; drop any stale "skipped — no image" note.
 
 ## Testing
 

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -23,6 +23,7 @@ These apps have been verified to launch successfully from their Launchfile:
 | [FreshRSS](apps/freshrss/) | RSS | Postgres |
 | [Ghost](apps/ghost/) | CMS | MySQL |
 | [Gitea](apps/gitea/) | Git | Postgres |
+| [HedgeDoc](apps/hedgedoc/) | Documents | Postgres |
 | [IT Tools](apps/it-tools/) | Utilities | — |
 | [LinkDing](apps/linkding/) | Bookmarks | Postgres |
 | [Mealie](apps/mealie/) | Recipes | Postgres |
@@ -63,7 +64,6 @@ Draft Launchfiles in [`drafts/`](drafts/) — not yet verified end-to-end. PRs w
 | [Glance](drafts/glance/) | Dashboard | |
 | [Gokapi](drafts/gokapi/) | Files | |
 | [Gotify](drafts/gotify/) | Notifications | |
-| [HedgeDoc](drafts/hedgedoc/) | Editor | |
 | [Home Assistant](drafts/home-assistant/) | Automation | Gaps: G-9, G-11, G-12 |
 | [Hoppscotch](drafts/hoppscotch/) | API Tools | |
 | [Immich](drafts/immich/) | Photos | Gap: GPU (G-10) |

--- a/catalog/test/src/test-all.ts
+++ b/catalog/test/src/test-all.ts
@@ -39,6 +39,7 @@ const TIERS: Record<number, { name: string; apps: string[] }> = {
       "redmine",
       "mattermost",
       "vaultwarden",
+      "hedgedoc",
     ],
   },
   2: {
@@ -77,7 +78,7 @@ const TIERS: Record<number, { name: string; apps: string[] }> = {
   // Skipped: home-assistant (multicast/device), pihole (host networking),
   // plex (claim token), diun (docker socket), calibre-web (host bind mount),
   // ollama-openwebui (GPU), jellyfin (/dev/dri), duplicati (host bind mount),
-  // syncthing (host bind mount), hedgedoc (build only, no image)
+  // syncthing (host bind mount)
 };
 
 // --- CLI args ---


### PR DESCRIPTION
## What

Fixes the stale catalog index after HedgeDoc's promotion. HedgeDoc was promoted
`drafts/ → apps/` in #60 (verified, image-based v1, `health_check_passed: true`),
but `catalog/README.md` still listed it under **Proposed Apps** with a now-broken
`drafts/hedgedoc/` link — so it still *looked* like a draft.

## Changes

- **`README.md`** — move HedgeDoc from the Proposed Apps table to the **Tested
  Apps** table (Documents / Postgres), fixing the link to `apps/hedgedoc/`.
- **`test/src/test-all.ts`** — add `hedgedoc` to **Tier 1 (Postgres only)** so it
  joins the batch regression run, and drop the stale `hedgedoc (build only, no
  image)` skip note (that described the old build-from-source draft, not the
  promoted image-based entry; the 2.x build-from-source variant stays parked at
  `drafts/hedgedoc-v2/`).
- **`CLAUDE.md`** — document the index-update step in the promotion workflow so a
  future `git mv` to `apps/` also updates the README table and test-all tier in
  the same PR, instead of leaving a stale "Proposed" listing (the exact gap this
  PR closes).

## Note

No descriptor change — the `apps/hedgedoc/Launchfile`, metadata, and screenshot
from #60/#68 are untouched. This is index/doc sync only.
