### PR TITLE
Start just the parts of an app you want, plus app-state helpers

### DIFF
--- a/providers/docker/src/__tests__/summary.test.ts
+++ b/providers/docker/src/__tests__/summary.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { summaryLines } from "../provider.js";
+
+describe("summaryLines", () => {
+	const ports = { frontend: 54000, backend: 54001 };
+
+	it("reports every component when no selector is given", () => {
+		const lines = summaryLines("acme", ports);
+		expect(lines).toHaveLength(2);
+		expect(lines).toContain("  frontend is running at http://localhost:54000");
+		expect(lines).toContain("  backend is running at http://localhost:54001");
+	});
+
+	it("reports only the components actually started under a selector", () => {
+		const lines = summaryLines("acme", ports, new Set(["backend"]));
+		expect(lines).toEqual(["  backend is running at http://localhost:54001"]);
+	});
+
+	it("uses the app name as the label for the default component", () => {
+		const lines = summaryLines("acme", { default: 54000 });
+		expect(lines).toEqual(["  acme is running at http://localhost:54000"]);
+	});
+
+	it("returns no lines when the selected set matches nothing", () => {
+		expect(summaryLines("acme", ports, new Set(["nope"]))).toEqual([]);
+	});
+});

--- a/providers/docker/src/provider.ts
+++ b/providers/docker/src/provider.ts
@@ -4,7 +4,7 @@
 
 import { writeFile } from "node:fs/promises";
 import { createInterface } from "node:readline";
-import { readLaunch, selectComponents } from "@launchfile/sdk";
+import { readLaunch, selectionClosure } from "@launchfile/sdk";
 import { checkPrereqs, composeSupportsIgnoreBuildable } from "./prereqs.js";
 import { resolveSource } from "./source-resolver.js";
 import {
@@ -29,9 +29,13 @@ export interface DockerUpOpts {
 	/** Skip confirmation prompt for remote Launchfiles */
 	yes?: boolean;
 	/**
-	 * Component selector (#77): if non-empty, only these components are started.
-	 * Their `requires` come along via compose `depends_on`; `depends_on` targets
-	 * are NOT auto-added (satisfy-not-expand). Empty = all components.
+	 * Component selector (#77): if non-empty, these components plus their
+	 * transitive downward `depends_on` closure are started (D-41). The start-set
+	 * is computed from the SDK's `selectionClosure` — the same definition the
+	 * macOS provider uses — so both produce the identical running topology (P-5),
+	 * rather than leaning on compose's implicit `depends_on` expansion. Each
+	 * closure member's `requires` come along via compose `depends_on`. Empty =
+	 * all components.
 	 */
 	components?: string[];
 }
@@ -77,8 +81,9 @@ export async function dockerUp(source: string, opts: DockerUpOpts = {}): Promise
 		const launch = readLaunch(resolved.yaml);
 		const componentNames = Object.keys(launch.components);
 
-		// Resolve component selector (#77). Empty = all components.
-		const selection = selectComponents(launch, opts.components ?? []);
+		// Resolve component selector (#77) into its D-41 start-set: selected
+		// components + their transitive downward `depends_on` closure. Empty = all.
+		const selection = selectionClosure(launch, opts.components ?? []);
 		if (selection.unknown.length > 0 || selection.resources.length > 0) {
 			console.error(`\nCannot select: ${[...selection.unknown, ...selection.resources].join(", ")}`);
 			for (const r of selection.resources) {
@@ -90,13 +95,15 @@ export async function dockerUp(source: string, opts: DockerUpOpts = {}): Promise
 			process.exit(1);
 		}
 		const selectorActive = (opts.components?.length ?? 0) > 0;
+		// Pass the explicit closure to `compose up` rather than relying on compose's
+		// implicit depends_on expansion, so the start-set matches macOS exactly.
 		const selectedServices = selectorActive
-			? selection.selected.map((name) => serviceNameFor(launch.name, name))
+			? selection.start.map((name) => serviceNameFor(launch.name, name))
 			: [];
-		// When a selector is active, the post-up summary must report only the
-		// components actually started this invocation (#77) — not every component
-		// in the Launchfile. Undefined means "report all".
-		const summaryOnly = selectorActive ? new Set(selection.selected) : undefined;
+		// When a selector is active, the post-up summary reports only the components
+		// actually started this invocation (#77) — now the full closure, not just
+		// the directly-named ones. Undefined means "report all".
+		const summaryOnly = selectorActive ? new Set(selection.start) : undefined;
 
 		// Security: prompt for confirmation before executing remote Launchfiles.
 		// Remote content can specify arbitrary images, commands, and env vars.
@@ -249,8 +256,8 @@ export async function dockerUp(source: string, opts: DockerUpOpts = {}): Promise
 		// Start services
 		await withSpan("up:start", { project }, async () => {
 			process.stdout.write(`  \u2193 Starting services...`);
-			// Selected services start with their compose `depends_on` (resources)
-			// pulled in automatically; non-selected components stay down (#77).
+			// The closure's services start with their compose `depends_on` (resources)
+			// pulled in automatically; components outside the closure stay down (#77).
 			await shell(
 				"docker",
 				["compose", "-p", project, "-f", composeFile, "up", "-d", ...selectedServices],

--- a/providers/docker/src/provider.ts
+++ b/providers/docker/src/provider.ts
@@ -4,7 +4,7 @@
 
 import { writeFile } from "node:fs/promises";
 import { createInterface } from "node:readline";
-import { readLaunch } from "@launchfile/sdk";
+import { readLaunch, selectComponents } from "@launchfile/sdk";
 import { checkPrereqs, composeSupportsIgnoreBuildable } from "./prereqs.js";
 import { resolveSource } from "./source-resolver.js";
 import {
@@ -28,6 +28,17 @@ export interface DockerUpOpts {
 	dryRun?: boolean;
 	/** Skip confirmation prompt for remote Launchfiles */
 	yes?: boolean;
+	/**
+	 * Component selector (#77): if non-empty, only these components are started.
+	 * Their `requires` come along via compose `depends_on`; `depends_on` targets
+	 * are NOT auto-added (satisfy-not-expand). Empty = all components.
+	 */
+	components?: string[];
+}
+
+/** component name → compose service name (mirrors compose-generator). */
+function serviceNameFor(appName: string, componentName: string): string {
+	return componentName === "default" ? appName : `${appName}-${componentName}`;
 }
 
 /**
@@ -65,6 +76,23 @@ export async function dockerUp(source: string, opts: DockerUpOpts = {}): Promise
 		// Parse Launchfile
 		const launch = readLaunch(resolved.yaml);
 		const componentNames = Object.keys(launch.components);
+
+		// Resolve component selector (#77). Empty = all components.
+		const selection = selectComponents(launch, opts.components ?? []);
+		if (selection.unknown.length > 0 || selection.resources.length > 0) {
+			console.error(`\nCannot select: ${[...selection.unknown, ...selection.resources].join(", ")}`);
+			for (const r of selection.resources) {
+				console.error(`  - "${r}" is a backing resource, not a component; select the component that requires it.`);
+			}
+			for (const u of selection.unknown) {
+				console.error(`  - "${u}" matches no component. Available: ${componentNames.join(", ")}`);
+			}
+			process.exit(1);
+		}
+		const selectedServices =
+			opts.components && opts.components.length > 0
+				? selection.selected.map((name) => serviceNameFor(launch.name, name))
+				: [];
 
 		// Security: prompt for confirmation before executing remote Launchfiles.
 		// Remote content can specify arbitrary images, commands, and env vars.
@@ -217,7 +245,13 @@ export async function dockerUp(source: string, opts: DockerUpOpts = {}): Promise
 		// Start services
 		await withSpan("up:start", { project }, async () => {
 			process.stdout.write(`  \u2193 Starting services...`);
-			await shell("docker", ["compose", "-p", project, "-f", composeFile, "up", "-d"], { silent: true });
+			// Selected services start with their compose `depends_on` (resources)
+			// pulled in automatically; non-selected components stay down (#77).
+			await shell(
+				"docker",
+				["compose", "-p", project, "-f", composeFile, "up", "-d", ...selectedServices],
+				{ silent: true },
+			);
 			console.log("");
 		});
 

--- a/providers/docker/src/provider.ts
+++ b/providers/docker/src/provider.ts
@@ -89,10 +89,14 @@ export async function dockerUp(source: string, opts: DockerUpOpts = {}): Promise
 			}
 			process.exit(1);
 		}
-		const selectedServices =
-			opts.components && opts.components.length > 0
-				? selection.selected.map((name) => serviceNameFor(launch.name, name))
-				: [];
+		const selectorActive = (opts.components?.length ?? 0) > 0;
+		const selectedServices = selectorActive
+			? selection.selected.map((name) => serviceNameFor(launch.name, name))
+			: [];
+		// When a selector is active, the post-up summary must report only the
+		// components actually started this invocation (#77) — not every component
+		// in the Launchfile. Undefined means "report all".
+		const summaryOnly = selectorActive ? new Set(selection.selected) : undefined;
 
 		// Security: prompt for confirmation before executing remote Launchfiles.
 		// Remote content can specify arbitrary images, commands, and env vars.
@@ -173,7 +177,7 @@ export async function dockerUp(source: string, opts: DockerUpOpts = {}): Promise
 		if (opts.dryRun) {
 			console.log("\n--- docker-compose.yml ---\n");
 			console.log(result.yaml);
-			printSummary(launch.name, result.ports);
+			printSummary(launch.name, result.ports, summaryOnly);
 			return upResult;
 		}
 
@@ -267,7 +271,7 @@ export async function dockerUp(source: string, opts: DockerUpOpts = {}): Promise
 		});
 
 		// Print summary
-		printSummary(launch.name, result.ports);
+		printSummary(launch.name, result.ports, summaryOnly);
 
 		return upResult;
 	});
@@ -446,11 +450,37 @@ async function waitForHealth(project: string, composeFile: string): Promise<bool
 	return false;
 }
 
-function printSummary(appName: string, ports: Record<string, number>): void {
-	console.log("");
+/**
+ * Build the "<component> is running at …" summary lines, one per exposed port.
+ *
+ * `only`, when provided, restricts the summary to that set of component names —
+ * used by the component selector (#77) so a partial `up` doesn't claim that
+ * components it never started are running. An undefined `only` means "report
+ * everything" (the all-components default). Pure and side-effect-free so it can
+ * be unit-tested without spinning Docker.
+ */
+export function summaryLines(
+	appName: string,
+	ports: Record<string, number>,
+	only?: ReadonlySet<string>,
+): string[] {
+	const lines: string[] = [];
 	for (const [name, port] of Object.entries(ports)) {
+		if (only && !only.has(name)) continue;
 		const label = name === "default" ? appName : name;
-		console.log(`  ${label} is running at http://localhost:${port}`);
+		lines.push(`  ${label} is running at http://localhost:${port}`);
+	}
+	return lines;
+}
+
+function printSummary(
+	appName: string,
+	ports: Record<string, number>,
+	only?: ReadonlySet<string>,
+): void {
+	console.log("");
+	for (const line of summaryLines(appName, ports, only)) {
+		console.log(line);
 	}
 }
 

--- a/providers/macos-dev/src/provider.ts
+++ b/providers/macos-dev/src/provider.ts
@@ -7,7 +7,7 @@
 
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { readLaunch, type NormalizedLaunch, type NormalizedComponent } from "@launchfile/sdk";
+import { readLaunch, selectComponents, type NormalizedLaunch, type NormalizedComponent } from "@launchfile/sdk";
 
 /**
  * Source-mode run resolution (D-38, precedence `dev` > `image` > `start`).
@@ -51,6 +51,12 @@ export interface LaunchUpOpts {
 	detach?: boolean;
 	dryRun?: boolean;
 	projectDir?: string;
+	/**
+	 * Component selector (#77): if non-empty, only these components are started
+	 * (and only their `requires` provisioned). `depends_on` is satisfy-not-expand.
+	 * Empty = all components.
+	 */
+	components?: string[];
 }
 
 export async function launchUp(opts: LaunchUpOpts = {}): Promise<void> {
@@ -75,6 +81,28 @@ export async function launchUp(opts: LaunchUpOpts = {}): Promise<void> {
 	}
 
 	const launch = readLaunch(launchfileContent);
+	const allComponentNames = Object.keys(launch.components);
+
+	// Resolve component selector (#77). Empty = all components. Narrowing
+	// launch.components here makes every downstream phase loop in launchUp honor
+	// the selection without per-loop edits. down/status/env re-read the file, so
+	// they are unaffected.
+	const selection = selectComponents(launch, opts.components ?? []);
+	if (selection.unknown.length > 0 || selection.resources.length > 0) {
+		console.error(`\nCannot select: ${[...selection.unknown, ...selection.resources].join(", ")}`);
+		for (const r of selection.resources) {
+			console.error(`  - "${r}" is a backing resource, not a component; select the component that requires it.`);
+		}
+		for (const u of selection.unknown) {
+			console.error(`  - "${u}" matches no component. Available: ${allComponentNames.join(", ")}`);
+		}
+		process.exit(1);
+	}
+	if (opts.components && opts.components.length > 0) {
+		launch.components = Object.fromEntries(
+			Object.entries(launch.components).filter(([n]) => selection.selected.includes(n)),
+		);
+	}
 	const componentNames = Object.keys(launch.components);
 
 	// 2b. Source-mode guard (D-38) — fail fast before provisioning anything.

--- a/providers/macos-dev/src/provider.ts
+++ b/providers/macos-dev/src/provider.ts
@@ -7,7 +7,7 @@
 
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { readLaunch, selectComponents, type NormalizedLaunch, type NormalizedComponent } from "@launchfile/sdk";
+import { readLaunch, selectionClosure, type NormalizedLaunch, type NormalizedComponent } from "@launchfile/sdk";
 
 /**
  * Source-mode run resolution (D-38, precedence `dev` > `image` > `start`).
@@ -52,9 +52,11 @@ export interface LaunchUpOpts {
 	dryRun?: boolean;
 	projectDir?: string;
 	/**
-	 * Component selector (#77): if non-empty, only these components are started
-	 * (and only their `requires` provisioned). `depends_on` is satisfy-not-expand.
-	 * Empty = all components.
+	 * Component selector (#77): if non-empty, these components plus their
+	 * transitive downward `depends_on` closure are started (D-41), and the
+	 * `requires` of every closure member are provisioned. The start-set is the
+	 * SDK's `selectionClosure` — the same definition the Docker provider uses —
+	 * so both yield the identical running topology (P-5). Empty = all components.
 	 */
 	components?: string[];
 }
@@ -83,11 +85,14 @@ export async function launchUp(opts: LaunchUpOpts = {}): Promise<void> {
 	const launch = readLaunch(launchfileContent);
 	const allComponentNames = Object.keys(launch.components);
 
-	// Resolve component selector (#77). Empty = all components. Narrowing
+	// Resolve component selector (#77) into its D-41 start-set: selected
+	// components + their transitive downward `depends_on` closure (and, by
+	// narrowing to that set, every closure member's `requires`). Narrowing
 	// launch.components here makes every downstream phase loop in launchUp honor
-	// the selection without per-loop edits. down/status/env re-read the file, so
-	// they are unaffected.
-	const selection = selectComponents(launch, opts.components ?? []);
+	// the closure without per-loop edits — dropping it would hand back an app
+	// missing the very dependencies a selected component needs to start (D-16).
+	// down/status/env re-read the file, so they are unaffected.
+	const selection = selectionClosure(launch, opts.components ?? []);
 	if (selection.unknown.length > 0 || selection.resources.length > 0) {
 		console.error(`\nCannot select: ${[...selection.unknown, ...selection.resources].join(", ")}`);
 		for (const r of selection.resources) {
@@ -99,8 +104,9 @@ export async function launchUp(opts: LaunchUpOpts = {}): Promise<void> {
 		process.exit(1);
 	}
 	if (opts.components && opts.components.length > 0) {
+		const startSet = new Set(selection.start);
 		launch.components = Object.fromEntries(
-			Object.entries(launch.components).filter(([n]) => selection.selected.includes(n)),
+			Object.entries(launch.components).filter(([n]) => startSet.has(n)),
 		);
 	}
 	const componentNames = Object.keys(launch.components);

--- a/sdk/src/__tests__/lint.test.ts
+++ b/sdk/src/__tests__/lint.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import { lintLaunch } from "../lint.js";
+import { readLaunch } from "../reader.js";
+
+describe("lintLaunch — conflicting same-name resources (Q1)", () => {
+	it("warns when the same name declares a divergent version", () => {
+		const launch = readLaunch(`
+name: acme
+components:
+  api:
+    image: api:latest
+    requires:
+      - { type: postgres, version: ">=15" }
+  worker:
+    image: worker:latest
+    requires:
+      - { type: postgres, version: ">=16" }
+`);
+		const warnings = lintLaunch(launch);
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain('"postgres"');
+		expect(warnings[0]).toContain("version");
+	});
+
+	it("warns when the same name declares a divergent config", () => {
+		const launch = readLaunch(`
+name: acme
+components:
+  api:
+    image: api:latest
+    requires:
+      - { type: postgres, config: { storage: "10Gi" } }
+  worker:
+    image: worker:latest
+    requires:
+      - { type: postgres, config: { storage: "20Gi" } }
+`);
+		const warnings = lintLaunch(launch);
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain("config");
+	});
+
+	it("warns when a custom name binds divergent types", () => {
+		const launch = readLaunch(`
+name: acme
+components:
+  api:
+    image: api:latest
+    requires:
+      - { name: cache, type: redis }
+  worker:
+    image: worker:latest
+    requires:
+      - { name: cache, type: memcache }
+`);
+		const warnings = lintLaunch(launch);
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain('"cache"');
+		expect(warnings[0]).toContain("type");
+	});
+
+	it("does NOT warn when the same name has an identical definition", () => {
+		const launch = readLaunch(`
+name: acme
+components:
+  api:
+    image: api:latest
+    requires:
+      - { type: postgres, version: ">=15" }
+  worker:
+    image: worker:latest
+    requires:
+      - { type: postgres, version: ">=15" }
+`);
+		expect(lintLaunch(launch)).toEqual([]);
+	});
+
+	it("treats config with reordered keys as identical (no warning)", () => {
+		const launch = readLaunch(`
+name: acme
+components:
+  api:
+    image: api:latest
+    requires:
+      - { type: postgres, config: { a: "1", b: "2" } }
+  worker:
+    image: worker:latest
+    requires:
+      - { type: postgres, config: { b: "2", a: "1" } }
+`);
+		expect(lintLaunch(launch)).toEqual([]);
+	});
+
+	it("does NOT warn when different names share a type", () => {
+		const launch = readLaunch(`
+name: acme
+components:
+  api:
+    image: api:latest
+    requires:
+      - { name: primary-db, type: postgres, version: ">=15" }
+  analytics:
+    image: analytics:latest
+    requires:
+      - { name: analytics-db, type: postgres, version: ">=16" }
+`);
+		expect(lintLaunch(launch)).toEqual([]);
+	});
+
+	it("reports multiple divergent fields together", () => {
+		const launch = readLaunch(`
+name: acme
+components:
+  api:
+    image: api:latest
+    requires:
+      - { type: postgres, version: ">=15", config: { storage: "10Gi" } }
+  worker:
+    image: worker:latest
+    requires:
+      - { type: postgres, version: ">=16", config: { storage: "20Gi" } }
+`);
+		const warnings = lintLaunch(launch);
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain("config");
+		expect(warnings[0]).toContain("version");
+	});
+
+	it("detects conflicts that mix requires and supports", () => {
+		const launch = readLaunch(`
+name: acme
+components:
+  api:
+    image: api:latest
+    requires:
+      - { type: redis, version: ">=7" }
+    supports:
+      - { type: redis, version: ">=6" }
+`);
+		const warnings = lintLaunch(launch);
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain('"redis"');
+	});
+});

--- a/sdk/src/__tests__/select.test.ts
+++ b/sdk/src/__tests__/select.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { readLaunch } from "../reader.js";
+import { selectComponents } from "../select.js";
+
+const MULTI = `
+name: acme
+components:
+  backend:
+    runtime: node
+    requires:
+      - type: postgres
+        set_env: { DATABASE_URL: $url }
+      - type: redis
+        set_env: { REDIS_URL: $url }
+    commands: { start: "node dist/main.js" }
+  frontend:
+    runtime: node
+    depends_on:
+      - component: backend
+        condition: healthy
+    commands: { start: "node server.js" }
+`;
+
+describe("selectComponents", () => {
+	const launch = readLaunch(MULTI);
+
+	it("selects a single existing component", () => {
+		const r = selectComponents(launch, ["backend"]);
+		expect(r.selected).toEqual(["backend"]);
+		expect(r.resources).toEqual([]);
+		expect(r.unknown).toEqual([]);
+	});
+
+	it("empty selector means all components", () => {
+		const r = selectComponents(launch, []);
+		expect(r.selected.sort()).toEqual(["backend", "frontend"]);
+	});
+
+	it("does NOT expand depends_on targets (satisfy-not-expand)", () => {
+		const r = selectComponents(launch, ["frontend"]);
+		expect(r.selected).toEqual(["frontend"]);
+		expect(r.selected).not.toContain("backend");
+	});
+
+	it("classifies a resource type as a resource, not a component", () => {
+		const r = selectComponents(launch, ["postgres", "redis", "backend"]);
+		expect(r.selected).toEqual(["backend"]);
+		expect(r.resources.sort()).toEqual(["postgres", "redis"]);
+		expect(r.unknown).toEqual([]);
+	});
+
+	it("reports unknown names", () => {
+		const r = selectComponents(launch, ["database"]);
+		expect(r.selected).toEqual([]);
+		expect(r.unknown).toEqual(["database"]);
+	});
+});

--- a/sdk/src/__tests__/select.test.ts
+++ b/sdk/src/__tests__/select.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { readLaunch } from "../reader.js";
-import { selectComponents } from "../select.js";
+import { selectComponents, selectionClosure } from "../select.js";
 
 const MULTI = `
 name: acme
@@ -21,6 +21,40 @@ components:
     commands: { start: "node server.js" }
 `;
 
+// a -> b -> c chain plus an unrelated component, for closure tests.
+const CHAIN = `
+name: chain
+components:
+  a:
+    runtime: node
+    depends_on: [b]
+    commands: { start: "node a.js" }
+  b:
+    runtime: node
+    depends_on: [c]
+    commands: { start: "node b.js" }
+  c:
+    runtime: node
+    commands: { start: "node c.js" }
+  unrelated:
+    runtime: node
+    commands: { start: "node u.js" }
+`;
+
+// p <-> q form a depends_on cycle; the closure must terminate.
+const CYCLE = `
+name: cyclic
+components:
+  p:
+    runtime: node
+    depends_on: [q]
+    commands: { start: "node p.js" }
+  q:
+    runtime: node
+    depends_on: [p]
+    commands: { start: "node q.js" }
+`;
+
 describe("selectComponents", () => {
 	const launch = readLaunch(MULTI);
 
@@ -36,10 +70,11 @@ describe("selectComponents", () => {
 		expect(r.selected.sort()).toEqual(["backend", "frontend"]);
 	});
 
-	it("does NOT expand depends_on targets (satisfy-not-expand)", () => {
+	it("classifies (does not expand) — selected is exactly the requested components", () => {
+		// Closure expansion is selectionClosure's job (D-41); the classifier
+		// returns the literal requested components, nothing more.
 		const r = selectComponents(launch, ["frontend"]);
 		expect(r.selected).toEqual(["frontend"]);
-		expect(r.selected).not.toContain("backend");
 	});
 
 	it("classifies a resource type as a resource, not a component", () => {
@@ -53,5 +88,45 @@ describe("selectComponents", () => {
 		const r = selectComponents(launch, ["database"]);
 		expect(r.selected).toEqual([]);
 		expect(r.unknown).toEqual(["database"]);
+	});
+});
+
+describe("selectionClosure (D-41)", () => {
+	const launch = readLaunch(MULTI);
+
+	it("starts a selected component plus its downward depends_on target", () => {
+		const r = selectionClosure(launch, ["frontend"]);
+		// frontend depends_on backend → backend joins the start-set.
+		expect(r.start).toEqual(["backend", "frontend"]);
+	});
+
+	it("does NOT pull in reverse-dependencies (downward only)", () => {
+		const r = selectionClosure(launch, ["backend"]);
+		// frontend depends_on backend, but `up backend` must not start frontend.
+		expect(r.start).toEqual(["backend"]);
+		expect(r.start).not.toContain("frontend");
+	});
+
+	it("follows a transitive a→b→c chain and excludes unrelated components", () => {
+		const r = selectionClosure(readLaunch(CHAIN), ["a"]);
+		expect(r.start).toEqual(["a", "b", "c"]);
+		expect(r.start).not.toContain("unrelated");
+	});
+
+	it("empty selection is the full closure (all components)", () => {
+		const r = selectionClosure(readLaunch(CHAIN), []);
+		expect(r.start).toEqual(["a", "b", "c", "unrelated"]);
+	});
+
+	it("terminates on a depends_on cycle instead of hanging", () => {
+		const r = selectionClosure(readLaunch(CYCLE), ["p"]);
+		expect(r.start).toEqual(["p", "q"]);
+	});
+
+	it("returns an empty start-set when the selection is invalid", () => {
+		const r = selectionClosure(launch, ["postgres", "nope"]);
+		expect(r.start).toEqual([]);
+		expect(r.resources).toEqual(["postgres"]);
+		expect(r.unknown).toEqual(["nope"]);
 	});
 });

--- a/sdk/src/__tests__/state.test.ts
+++ b/sdk/src/__tests__/state.test.ts
@@ -1,0 +1,377 @@
+import { describe, expect, it } from "vitest";
+import {
+	type DeploymentState,
+	diff,
+	type Endpoint,
+	type LaunchEvent,
+	reduce,
+	resolveRef,
+	type Vantage,
+} from "../state.js";
+
+function emptyState(): DeploymentState {
+	return {
+		id: "acme-abc123",
+		app: "acme",
+		updatedAt: "2026-01-01T00:00:00.000Z",
+		components: {},
+		resources: {},
+	};
+}
+
+const httpEndpoint: Endpoint = {
+	name: "default",
+	scheme: "http",
+	internal: "acme-backend:3000",
+	published: "localhost:54000",
+};
+
+describe("reduce", () => {
+	it("does not mutate the input state", () => {
+		const state = emptyState();
+		const snapshot = JSON.parse(JSON.stringify(state));
+		reduce(state, {
+			kind: "component.status",
+			component: "backend",
+			status: "up",
+		});
+		expect(state).toEqual(snapshot);
+	});
+
+	it("carries updatedAt over by default and accepts an explicit stamp", () => {
+		const state = emptyState();
+		const carried = reduce(state, {
+			kind: "component.status",
+			component: "backend",
+			status: "up",
+		});
+		expect(carried.updatedAt).toBe(state.updatedAt);
+
+		const stamped = reduce(
+			state,
+			{ kind: "component.status", component: "backend", status: "up" },
+			"2026-02-02T00:00:00.000Z",
+		);
+		expect(stamped.updatedAt).toBe("2026-02-02T00:00:00.000Z");
+	});
+
+	it("records a slot event as a status on the component", () => {
+		const next = reduce(emptyState(), {
+			slot: "run",
+			phase: "completed",
+			component: "backend",
+		});
+		expect(next.components.backend?.status).toBe("up");
+
+		const failed = reduce(emptyState(), {
+			slot: "prepare",
+			phase: "failed",
+			component: "backend",
+		});
+		expect(failed.components.backend?.status).toBe("prepare:failed");
+	});
+
+	it("upserts an endpoint and keeps endpoints sorted by name", () => {
+		let state = emptyState();
+		state = reduce(state, {
+			kind: "endpoint.resolved",
+			component: "backend",
+			endpoint: {
+				name: "metrics",
+				scheme: "http",
+				internal: "acme-backend:9090",
+			},
+		});
+		state = reduce(state, {
+			kind: "endpoint.resolved",
+			component: "backend",
+			endpoint: httpEndpoint,
+		});
+		expect(state.components.backend?.endpoints.map((e) => e.name)).toEqual([
+			"default",
+			"metrics",
+		]);
+
+		// Re-resolving the same name replaces, not duplicates.
+		state = reduce(state, {
+			kind: "endpoint.resolved",
+			component: "backend",
+			endpoint: { ...httpEndpoint, published: "localhost:55555" },
+		});
+		const def = state.components.backend?.endpoints.find(
+			(e) => e.name === "default",
+		);
+		expect(state.components.backend?.endpoints).toHaveLength(2);
+		expect(def?.published).toBe("localhost:55555");
+	});
+
+	it("records component.status", () => {
+		const next = reduce(emptyState(), {
+			kind: "component.status",
+			component: "backend",
+			status: "unhealthy",
+		});
+		expect(next.components.backend?.status).toBe("unhealthy");
+	});
+
+	it("records a capture", () => {
+		const next = reduce(emptyState(), {
+			kind: "capture",
+			component: "backend",
+			name: "admin-url",
+			value: "http://localhost:54000/admin",
+		});
+		expect(next.components.backend?.captures["admin-url"]).toBe(
+			"http://localhost:54000/admin",
+		);
+	});
+
+	it("records a provisioned resource with sorted endpoints", () => {
+		const next = reduce(emptyState(), {
+			kind: "resource.provisioned",
+			name: "primary-db",
+			type: "postgres",
+			endpoints: [
+				{ name: "replica", scheme: "postgres", internal: "db-r:5432" },
+				{ name: "default", scheme: "postgres", internal: "db:5432" },
+			],
+		});
+		expect(next.resources["primary-db"]?.type).toBe("postgres");
+		expect(next.resources["primary-db"]?.endpoints.map((e) => e.name)).toEqual([
+			"default",
+			"replica",
+		]);
+	});
+});
+
+describe("diff", () => {
+	function fold(
+		state: DeploymentState,
+		events: LaunchEvent[],
+	): DeploymentState {
+		return events.reduce((acc, e) => reduce(acc, e), state);
+	}
+
+	/** Compare only the fields diff/reduce cover. */
+	function covered(state: DeploymentState) {
+		const components: Record<string, unknown> = {};
+		for (const [name, c] of Object.entries(state.components)) {
+			components[name] = {
+				status: c.status,
+				endpoints: c.endpoints,
+				captures: c.captures,
+			};
+		}
+		const resources: Record<string, unknown> = {};
+		for (const [name, r] of Object.entries(state.resources)) {
+			resources[name] = { type: r.type, endpoints: r.endpoints };
+		}
+		return { components, resources };
+	}
+
+	it("returns no events for identical states", () => {
+		const a = emptyState();
+		expect(diff(a, a)).toEqual([]);
+	});
+
+	it("round-trips: fold(diff(a,b)) over a equals b for covered fields", () => {
+		const a = emptyState();
+		let b = emptyState();
+		b = reduce(b, {
+			kind: "component.status",
+			component: "backend",
+			status: "up",
+		});
+		b = reduce(b, {
+			kind: "endpoint.resolved",
+			component: "backend",
+			endpoint: httpEndpoint,
+		});
+		b = reduce(b, {
+			kind: "capture",
+			component: "backend",
+			name: "token",
+			value: "abc",
+		});
+		b = reduce(b, {
+			kind: "resource.provisioned",
+			name: "redis",
+			type: "redis",
+			endpoints: [{ name: "default", scheme: "redis", internal: "redis:6379" }],
+		});
+
+		const events = diff(a, b);
+		expect(covered(fold(a, events))).toEqual(covered(b));
+	});
+
+	it("round-trips when fields change between two non-empty states", () => {
+		let a = emptyState();
+		a = reduce(a, {
+			kind: "component.status",
+			component: "backend",
+			status: "up",
+		});
+		a = reduce(a, {
+			kind: "endpoint.resolved",
+			component: "backend",
+			endpoint: httpEndpoint,
+		});
+
+		let b = a;
+		b = reduce(b, {
+			kind: "component.status",
+			component: "backend",
+			status: "unhealthy",
+		});
+		b = reduce(b, {
+			kind: "endpoint.resolved",
+			component: "backend",
+			endpoint: { ...httpEndpoint, published: "localhost:60000" },
+		});
+
+		const events = diff(a, b);
+		expect(events.length).toBeGreaterThan(0);
+		expect(covered(fold(a, events))).toEqual(covered(b));
+	});
+
+	it("produces a deterministic, stably-ordered event list", () => {
+		const a = emptyState();
+		let b = emptyState();
+		b = reduce(b, {
+			kind: "component.status",
+			component: "zeta",
+			status: "up",
+		});
+		b = reduce(b, {
+			kind: "component.status",
+			component: "alpha",
+			status: "up",
+		});
+
+		const components = diff(a, b)
+			.filter((e) => "kind" in e && e.kind === "component.status")
+			.map((e) => (e as { component: string }).component);
+		expect(components).toEqual(["alpha", "zeta"]);
+	});
+});
+
+describe("resolveRef", () => {
+	function stateWithBackend(): DeploymentState {
+		let state = emptyState();
+		state = reduce(state, {
+			kind: "endpoint.resolved",
+			component: "backend",
+			endpoint: httpEndpoint,
+		});
+		state = reduce(state, {
+			kind: "capture",
+			component: "backend",
+			name: "admin-token",
+			value: "s3cret",
+		});
+		state = reduce(state, {
+			kind: "resource.provisioned",
+			name: "primary-db",
+			type: "postgres",
+			endpoints: [
+				{
+					name: "default",
+					scheme: "postgres",
+					internal: "primary-db:5432",
+					published: "localhost:55432",
+				},
+			],
+		});
+		return state;
+	}
+
+	const hostVantage: Vantage = {
+		provider: "docker",
+		mode: "source",
+		network: "host",
+	};
+	const networkVantage: Vantage = {
+		provider: "docker",
+		mode: "artifact",
+		network: "compose",
+	};
+
+	it("host vantage gets the published address", () => {
+		const state = stateWithBackend();
+		expect(resolveRef(state, "$components.backend.url", hostVantage)).toBe(
+			"http://localhost:54000",
+		);
+		expect(resolveRef(state, "$components.backend.host", hostVantage)).toBe(
+			"localhost",
+		);
+		expect(resolveRef(state, "$components.backend.port", hostVantage)).toBe(
+			"54000",
+		);
+	});
+
+	it("in-network vantage gets the internal address", () => {
+		const state = stateWithBackend();
+		expect(resolveRef(state, "$components.backend.url", networkVantage)).toBe(
+			"http://acme-backend:3000",
+		);
+		expect(resolveRef(state, "$components.backend.host", networkVantage)).toBe(
+			"acme-backend",
+		);
+		expect(resolveRef(state, "$components.backend.port", networkVantage)).toBe(
+			"3000",
+		);
+	});
+
+	it("source mode without an explicit network still prefers published", () => {
+		const state = stateWithBackend();
+		const v: Vantage = { provider: "docker", mode: "source" };
+		expect(resolveRef(state, "$components.backend.url", v)).toBe(
+			"http://localhost:54000",
+		);
+	});
+
+	it("falls back to internal when no published address exists", () => {
+		let state = emptyState();
+		state = reduce(state, {
+			kind: "endpoint.resolved",
+			component: "worker",
+			endpoint: {
+				name: "default",
+				scheme: "http",
+				internal: "acme-worker:8080",
+			},
+		});
+		expect(resolveRef(state, "$components.worker.url", hostVantage)).toBe(
+			"http://acme-worker:8080",
+		);
+	});
+
+	it("resolves a resource reference and honors vantage", () => {
+		const state = stateWithBackend();
+		expect(resolveRef(state, "$primary-db.host", hostVantage)).toBe(
+			"localhost",
+		);
+		expect(resolveRef(state, "$primary-db.host", networkVantage)).toBe(
+			"primary-db",
+		);
+		expect(resolveRef(state, "$primary-db.port", networkVantage)).toBe("5432");
+	});
+
+	it("resolves a capture by name", () => {
+		const state = stateWithBackend();
+		expect(
+			resolveRef(state, "$components.backend.admin-token", hostVantage),
+		).toBe("s3cret");
+	});
+
+	it("returns empty string for unknown references", () => {
+		const state = stateWithBackend();
+		expect(resolveRef(state, "$components.nope.url", hostVantage)).toBe("");
+		expect(resolveRef(state, "$components.backend.bogus", hostVantage)).toBe(
+			"",
+		);
+		expect(resolveRef(state, "$missing-db.host", hostVantage)).toBe("");
+		expect(resolveRef(state, "literal", hostVantage)).toBe("");
+		expect(resolveRef(state, "$components.backend", hostVantage)).toBe("");
+	});
+});

--- a/sdk/src/commands.ts
+++ b/sdk/src/commands.ts
@@ -7,6 +7,7 @@
 
 import { readFileSync } from "node:fs";
 import { resolve, dirname, join } from "node:path";
+import { lintLaunch } from "./lint.js";
 import { readLaunch } from "./reader.js";
 import type { NormalizedLaunch } from "./types.js";
 
@@ -90,6 +91,8 @@ export interface ValidateResult {
 	components?: string[];
 	requires?: string[];
 	errors?: string[];
+	/** Non-fatal lint advisories (do not affect `valid`). */
+	warnings?: string[];
 }
 
 /**
@@ -104,6 +107,7 @@ export function cmdValidate(path: string, opts: ValidateOpts = {}): ValidateResu
 		const launch = readLaunch(yaml);
 		const componentNames = Object.keys(launch.components);
 		const allRequires = collectRequires(launch);
+		const warnings = lintLaunch(launch);
 
 		const result: ValidateResult = {
 			valid: true,
@@ -111,6 +115,7 @@ export function cmdValidate(path: string, opts: ValidateOpts = {}): ValidateResu
 			name: launch.name,
 			components: componentNames,
 			requires: allRequires,
+			...(warnings.length > 0 && { warnings }),
 		};
 
 		if (opts.json) {
@@ -123,6 +128,9 @@ export function cmdValidate(path: string, opts: ValidateOpts = {}): ValidateResu
 			console.log(`  ${fmt.dim("components:")} ${componentNames.join(", ")}`);
 			if (allRequires.length > 0) {
 				console.log(`  ${fmt.dim("requires:")}   ${allRequires.join(", ")}`);
+			}
+			for (const w of warnings) {
+				console.error(`  ${fmt.yellow("warning:")} ${w}`);
 			}
 		}
 

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,4 +1,5 @@
 export { cmdInspect, cmdSchema, cmdValidate } from "./commands.js";
+export { lintLaunch } from "./lint.js";
 export { readLaunch, validateLaunch } from "./reader.js";
 export {
 	deriveAppUrlProperties,
@@ -8,18 +9,22 @@ export {
 	type ResolverContext,
 	resolveExpression,
 } from "./resolver.js";
-export { lintLaunch } from "./lint.js";
 export { LaunchSchema } from "./schema.js";
-export { selectComponents, type SelectionResult } from "./select.js";
+export {
+	type SelectionClosureResult,
+	type SelectionResult,
+	selectComponents,
+	selectionClosure,
+} from "./select.js";
 export {
 	type ComponentState,
 	type DeploymentState,
 	diff,
 	type Endpoint,
 	type LaunchEvent,
+	type ResourceState,
 	reduce,
 	resolveRef,
-	type ResourceState,
 	type Vantage,
 } from "./state.js";
 export type {

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -9,6 +9,7 @@ export {
 	resolveExpression,
 } from "./resolver.js";
 export { LaunchSchema } from "./schema.js";
+export { selectComponents, type SelectionResult } from "./select.js";
 export type {
 	ToolchainLanguage,
 	ToolchainSource,

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -8,8 +8,20 @@ export {
 	type ResolverContext,
 	resolveExpression,
 } from "./resolver.js";
+export { lintLaunch } from "./lint.js";
 export { LaunchSchema } from "./schema.js";
 export { selectComponents, type SelectionResult } from "./select.js";
+export {
+	type ComponentState,
+	type DeploymentState,
+	diff,
+	type Endpoint,
+	type LaunchEvent,
+	reduce,
+	resolveRef,
+	type ResourceState,
+	type Vantage,
+} from "./state.js";
 export type {
 	ToolchainLanguage,
 	ToolchainSource,

--- a/sdk/src/lint.ts
+++ b/sdk/src/lint.ts
@@ -1,0 +1,92 @@
+/**
+ * Non-fatal lint checks over a normalized Launch.
+ *
+ * These complement the hard schema validation in {@link readLaunch}: a file can
+ * be schema-valid yet still contain footguns worth surfacing. Like the
+ * providers' warning channel, a lint result is a flat `string[]` of
+ * human-readable messages — empty means clean. Lint never throws and never
+ * rejects a file; it only advises.
+ */
+
+import type { NormalizedLaunch, NormalizedRequirement } from "./types.js";
+
+/** A resource declaration seen at a particular location, for conflict reporting. */
+interface ResourceDecl {
+	/** Where it was declared (component name, or "(top-level)"). */
+	where: string;
+	req: NormalizedRequirement;
+}
+
+/** Stable string form of a `config` object for divergence comparison. */
+function configKey(config: Record<string, unknown> | undefined): string {
+	if (!config) return "";
+	// Sort keys so declaration order doesn't register as a divergence.
+	const sorted: Record<string, unknown> = {};
+	for (const key of Object.keys(config).sort()) sorted[key] = config[key];
+	return JSON.stringify(sorted);
+}
+
+/**
+ * Resolve the name a resource declaration binds to. Per D-24, `name` defaults
+ * to `type` when omitted, so two entries that omit `name` and share a `type`
+ * resolve to the same resource.
+ */
+function resourceName(req: NormalizedRequirement): string {
+	return req.name ?? req.type;
+}
+
+/**
+ * Lint a normalized Launch, returning non-fatal warning strings (empty = clean).
+ *
+ * Currently checks (Q1): when two `requires`/`supports` entries across all
+ * components (and any single-component top-level fields, which normalize into
+ * the "default" component) resolve to the SAME resource name (D-24) but declare
+ * DIVERGENT `type`, `version`, or `config`, a single warning per conflicting
+ * resource names the field(s) that diverge. Same name + identical definition is
+ * normal resource sharing and is not warned about.
+ */
+export function lintLaunch(launch: NormalizedLaunch): string[] {
+	const warnings: string[] = [];
+
+	// Collect every requires/supports declaration grouped by resolved name.
+	const byName = new Map<string, ResourceDecl[]>();
+	for (const [componentName, component] of Object.entries(launch.components)) {
+		const where = componentName === "default" ? "(top-level)" : componentName;
+		for (const req of [
+			...(component.requires ?? []),
+			...(component.supports ?? []),
+		]) {
+			const name = resourceName(req);
+			const decls = byName.get(name) ?? [];
+			decls.push({ where, req });
+			byName.set(name, decls);
+		}
+	}
+
+	for (const [name, decls] of [...byName.entries()].sort((a, b) =>
+		a[0].localeCompare(b[0]),
+	)) {
+		if (decls.length < 2) continue;
+
+		const first = decls[0]!.req;
+		const conflicting = new Set<string>();
+		for (const { req } of decls.slice(1)) {
+			if (req.type !== first.type) conflicting.add("type");
+			if ((req.version ?? "") !== (first.version ?? ""))
+				conflicting.add("version");
+			if (configKey(req.config) !== configKey(first.config))
+				conflicting.add("config");
+		}
+
+		if (conflicting.size > 0) {
+			const fields = [...conflicting].sort().join(", ");
+			const places = [...new Set(decls.map((d) => d.where))].sort().join(", ");
+			warnings.push(
+				`resource "${name}" is declared with divergent ${fields} across ${places}; ` +
+					"entries sharing a name should share their definition (see D-24)",
+			);
+		}
+	}
+
+	return warnings;
+}

--- a/sdk/src/select.ts
+++ b/sdk/src/select.ts
@@ -1,0 +1,54 @@
+import type { NormalizedLaunch } from "./types.js";
+
+/** Outcome of resolving a component selector against a launch. */
+export interface SelectionResult {
+	/** Requested component names that exist — the set the provider acts on. */
+	selected: string[];
+	/** Requested names that match only a resource (`requires`/`supports`), not a component. */
+	resources: string[];
+	/** Requested names that match neither a component nor a resource. */
+	unknown: string[];
+}
+
+/**
+ * Resolve a component selector against a normalized launch.
+ *
+ * Per the execution-mode taxonomy RFC (#77), selection is a verb-level concern:
+ *  - selecting a component brings along its `requires` (those are nested inside
+ *    the component, so a provider provisions them automatically); and
+ *  - `depends_on` is satisfy-not-expand — selection does NOT pull dependency
+ *    targets in; the provider verifies they are already running.
+ *
+ * Resources (postgres, redis, …) are NOT first-class units in the normalized
+ * model — they live inside a component's `requires`/`supports`. They are
+ * therefore not independently selectable. Requested names that match only a
+ * resource are returned separately so the caller can emit a useful error
+ * rather than silently dropping them.
+ *
+ * An empty `requested` selects everything (the all-components default).
+ */
+export function selectComponents(
+	launch: NormalizedLaunch,
+	requested: string[],
+): SelectionResult {
+	const componentNames = new Set(Object.keys(launch.components));
+	const resourceNames = new Set<string>();
+	for (const comp of Object.values(launch.components)) {
+		for (const req of comp.requires ?? []) resourceNames.add(req.name ?? req.type);
+		for (const sup of comp.supports ?? []) resourceNames.add(sup.name ?? sup.type);
+	}
+
+	if (requested.length === 0) {
+		return { selected: Object.keys(launch.components), resources: [], unknown: [] };
+	}
+
+	const selected: string[] = [];
+	const resources: string[] = [];
+	const unknown: string[] = [];
+	for (const name of requested) {
+		if (componentNames.has(name)) selected.push(name);
+		else if (resourceNames.has(name)) resources.push(name);
+		else unknown.push(name);
+	}
+	return { selected, resources, unknown };
+}

--- a/sdk/src/select.ts
+++ b/sdk/src/select.ts
@@ -11,13 +11,13 @@ export interface SelectionResult {
 }
 
 /**
- * Resolve a component selector against a normalized launch.
+ * Classify a component selector against a normalized launch.
  *
- * Per the execution-mode taxonomy RFC (#77), selection is a verb-level concern:
- *  - selecting a component brings along its `requires` (those are nested inside
- *    the component, so a provider provisions them automatically); and
- *  - `depends_on` is satisfy-not-expand — selection does NOT pull dependency
- *    targets in; the provider verifies they are already running.
+ * This is the name-resolution primitive: it sorts the requested names into the
+ * components that exist (`selected`), the names that match only a backing
+ * resource (`resources`), and the names that match nothing (`unknown`). It does
+ * NOT expand the dependency closure — that is {@link selectionClosure}'s job
+ * (D-41). `selected` is exactly the requested components, in request order.
  *
  * Resources (postgres, redis, …) are NOT first-class units in the normalized
  * model — they live inside a component's `requires`/`supports`. They are
@@ -34,12 +34,18 @@ export function selectComponents(
 	const componentNames = new Set(Object.keys(launch.components));
 	const resourceNames = new Set<string>();
 	for (const comp of Object.values(launch.components)) {
-		for (const req of comp.requires ?? []) resourceNames.add(req.name ?? req.type);
-		for (const sup of comp.supports ?? []) resourceNames.add(sup.name ?? sup.type);
+		for (const req of comp.requires ?? [])
+			resourceNames.add(req.name ?? req.type);
+		for (const sup of comp.supports ?? [])
+			resourceNames.add(sup.name ?? sup.type);
 	}
 
 	if (requested.length === 0) {
-		return { selected: Object.keys(launch.components), resources: [], unknown: [] };
+		return {
+			selected: Object.keys(launch.components),
+			resources: [],
+			unknown: [],
+		};
 	}
 
 	const selected: string[] = [];
@@ -51,4 +57,63 @@ export function selectComponents(
 		else unknown.push(name);
 	}
 	return { selected, resources, unknown };
+}
+
+/** {@link selectComponents} extended with the resolved D-41 start-set. */
+export interface SelectionClosureResult extends SelectionResult {
+	/**
+	 * Component names a provider must start: the resolved `selected` set plus its
+	 * transitive downward `depends_on` closure (D-41), sorted for determinism.
+	 * Empty when the selection cannot be satisfied (i.e. `unknown` or `resources`
+	 * is non-empty) — the caller errors on those before acting on `start`.
+	 */
+	start: string[];
+}
+
+/**
+ * Resolve the D-41 start-set for a component selector: the requested components
+ * (or all components when `requested` is empty) **plus their transitive downward
+ * `depends_on` closure**. Each closure member's `requires` backing services come
+ * along for free — they are nested inside the component, so narrowing a launch /
+ * starting a service to the closure pulls them in at the provider boundary; this
+ * helper deals only in component names.
+ *
+ * Downward only: reverse-dependencies (components that depend *on* a selected
+ * one) and unrelated components are excluded. `depends_on` is honored as a hard
+ * prerequisite (D-16) — a selected component cannot start without it.
+ *
+ * This is the single source of truth every provider computes its start-set from,
+ * so the same Launchfile yields the same running topology everywhere (P-5).
+ *
+ * Pure (no input mutation) and cycle-safe: a `visited` set bounds the traversal,
+ * so a `depends_on` cycle terminates instead of looping forever. Name resolution
+ * is delegated to {@link selectComponents}, so unknown / resource-only names are
+ * rejected identically; when the selection is invalid, `start` is empty.
+ */
+export function selectionClosure(
+	launch: NormalizedLaunch,
+	requested: string[],
+): SelectionClosureResult {
+	const base = selectComponents(launch, requested);
+	if (base.unknown.length > 0 || base.resources.length > 0) {
+		return { ...base, start: [] };
+	}
+
+	const known = new Set(Object.keys(launch.components));
+	const visited = new Set<string>();
+	const stack = [...base.selected];
+	while (stack.length > 0) {
+		const name = stack.pop();
+		if (name === undefined || visited.has(name)) continue;
+		visited.add(name);
+		for (const dep of launch.components[name]?.depends_on ?? []) {
+			// Guard against a dangling depends_on target and re-visiting a node: the
+			// visited set is what makes a depends_on cycle terminate.
+			if (known.has(dep.component) && !visited.has(dep.component)) {
+				stack.push(dep.component);
+			}
+		}
+	}
+
+	return { ...base, start: [...visited].sort() };
 }

--- a/sdk/src/state.ts
+++ b/sdk/src/state.ts
@@ -1,0 +1,416 @@
+/**
+ * Pure-core deployment state, event, and reference-resolution model.
+ *
+ * A provider runs a deployment as a stream of {@link LaunchEvent}s. This module
+ * gives the SDK a deterministic, side-effect-free way to fold those events into
+ * a {@link DeploymentState} ({@link reduce}), to recover the events that
+ * separate two states ({@link diff}), and to resolve `$`-references against a
+ * state from a particular consumer's {@link Vantage} ({@link resolveRef}).
+ *
+ * Everything here is pure: no fs, no logging, no clocks, no mutation of inputs.
+ * The SDK never performs I/O — it throws or returns. Callers own timestamps,
+ * persistence, and emission. See the note on {@link reduce} about `updatedAt`.
+ */
+
+/**
+ * Where a reference is being resolved *from*. Determines whether a consumer
+ * reaches an endpoint via its published (host-side) or internal (in-network)
+ * address.
+ *
+ * - `provider` — the provider resolving the reference (e.g. "docker").
+ * - `mode` — `source` runs on the host (gets published addresses); `artifact`
+ *   runs inside the provider's network (gets internal addresses).
+ * - `network` — explicit network hint. `host` forces published; `compose`
+ *   forces internal. Open string for provider-specific networks.
+ */
+export type Vantage = {
+	provider: string;
+	mode: "source" | "artifact";
+	network?: "host" | "compose" | (string & {});
+};
+
+/** A resolved network endpoint exposed by a component or resource. */
+export interface Endpoint {
+	/** Endpoint name (e.g. "http", "metrics"); the default endpoint is "default". */
+	name: string;
+	/** URL scheme / protocol (e.g. "http", "postgres", "tcp"). */
+	scheme: string;
+	/** In-network address (`host:port`), reachable by same-network consumers. */
+	internal: string;
+	/** Host-side address (`host:port`), reachable from outside the network. */
+	published?: string;
+}
+
+/**
+ * An event in a deployment's lifecycle. Two disjoint families:
+ *
+ * - **slot events** — lifecycle progress for a component's `prepare`/`release`/
+ *   `run` slot (started → completed/failed).
+ * - **kind events** — discrete facts (endpoint resolved, status change, a
+ *   captured value, a provisioned resource).
+ */
+export type LaunchEvent =
+	| {
+			slot: "prepare" | "release" | "run";
+			phase: "started" | "completed" | "failed";
+			component: string;
+	  }
+	| { kind: "endpoint.resolved"; component: string; endpoint: Endpoint }
+	| {
+			kind: "component.status";
+			component: string;
+			status: "up" | "down" | "unhealthy";
+	  }
+	| {
+			kind: "capture";
+			component: string;
+			name: string;
+			value: string;
+			sensitive?: boolean;
+	  }
+	| {
+			kind: "resource.provisioned";
+			name: string;
+			type: string;
+			endpoints: Endpoint[];
+	  };
+
+/** Per-component slice of deployment state. */
+export interface ComponentState {
+	/** Whether this component runs from source or a built artifact. */
+	mode: "source" | "artifact";
+	/** Free-form status string (e.g. "up", "down", "running", "prepare:started"). */
+	status: string;
+	/** Resolved endpoints, in stable name order. */
+	endpoints: Endpoint[];
+	/** Environment the component runs with. */
+	env: Record<string, string>;
+	/** Captured values keyed by capture name. */
+	captures: Record<string, string>;
+	/** Process id, when the provider runs the component as a host process. */
+	pid?: number;
+}
+
+/** Per-resource slice of deployment state (postgres, redis, …). */
+export interface ResourceState {
+	/** Resource type (e.g. "postgres"). */
+	type: string;
+	/** Free-form status string. */
+	status: string;
+	/** Resolved endpoints, in stable name order. */
+	endpoints: Endpoint[];
+	/** Environment the resource exposes. */
+	env: Record<string, string>;
+}
+
+/** The full deployment state — the fold target for {@link reduce}. */
+export interface DeploymentState {
+	/** Deployment id (provider-assigned slug). */
+	id: string;
+	/** App name. */
+	app: string;
+	/**
+	 * Caller-owned last-update timestamp (ISO 8601). {@link reduce} never sets
+	 * this from a clock; see the note on {@link reduce}.
+	 */
+	updatedAt: string;
+	/** Components keyed by name. */
+	components: Record<string, ComponentState>;
+	/** Resources keyed by name. */
+	resources: Record<string, ResourceState>;
+}
+
+// --- reduce ---
+
+/** Status string a slot/phase event records on its component. */
+function slotStatus(
+	slot: "prepare" | "release" | "run",
+	phase: "started" | "completed" | "failed",
+): string {
+	// "run" maps onto the lifecycle words operators expect; prepare/release keep
+	// their slot name so a status string is self-describing in either family.
+	if (slot === "run") {
+		if (phase === "completed") return "up";
+		if (phase === "failed") return "down";
+		return "starting";
+	}
+	return `${slot}:${phase}`;
+}
+
+/** Create an empty component slice. */
+function emptyComponent(mode: "source" | "artifact"): ComponentState {
+	return { mode, status: "pending", endpoints: [], env: {}, captures: {} };
+}
+
+/** Insert/replace an endpoint by name, returning a new, name-sorted array. */
+function upsertEndpoint(endpoints: Endpoint[], next: Endpoint): Endpoint[] {
+	const others = endpoints.filter((e) => e.name !== next.name);
+	return [...others, next].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Pure fold: apply one {@link LaunchEvent} to a {@link DeploymentState},
+ * returning a NEW state. The input is never mutated (copy-on-write at every
+ * level the event touches).
+ *
+ * `updatedAt` is intentionally NOT derived from a clock here — `reduce` must be
+ * deterministic and pure. If the caller wants the result stamped, it passes a
+ * timestamp via the optional `at` argument; otherwise `updatedAt` is carried
+ * over from the input unchanged and the caller can stamp the result itself.
+ */
+export function reduce(
+	state: DeploymentState,
+	event: LaunchEvent,
+	at?: string,
+): DeploymentState {
+	const updatedAt = at ?? state.updatedAt;
+
+	if ("slot" in event) {
+		const prev =
+			state.components[event.component] ?? emptyComponent("artifact");
+		const components = {
+			...state.components,
+			[event.component]: {
+				...prev,
+				status: slotStatus(event.slot, event.phase),
+			},
+		};
+		return { ...state, updatedAt, components };
+	}
+
+	switch (event.kind) {
+		case "endpoint.resolved": {
+			const prev =
+				state.components[event.component] ?? emptyComponent("artifact");
+			const components = {
+				...state.components,
+				[event.component]: {
+					...prev,
+					endpoints: upsertEndpoint(prev.endpoints, event.endpoint),
+				},
+			};
+			return { ...state, updatedAt, components };
+		}
+		case "component.status": {
+			const prev =
+				state.components[event.component] ?? emptyComponent("artifact");
+			const components = {
+				...state.components,
+				[event.component]: { ...prev, status: event.status },
+			};
+			return { ...state, updatedAt, components };
+		}
+		case "capture": {
+			const prev =
+				state.components[event.component] ?? emptyComponent("artifact");
+			const components = {
+				...state.components,
+				[event.component]: {
+					...prev,
+					captures: { ...prev.captures, [event.name]: event.value },
+				},
+			};
+			return { ...state, updatedAt, components };
+		}
+		case "resource.provisioned": {
+			const prev = state.resources[event.name];
+			const endpoints = [...event.endpoints].sort((a, b) =>
+				a.name.localeCompare(b.name),
+			);
+			const resources = {
+				...state.resources,
+				[event.name]: {
+					type: event.type,
+					status: prev?.status ?? "up",
+					endpoints,
+					env: prev?.env ?? {},
+				},
+			};
+			return { ...state, updatedAt, resources };
+		}
+	}
+}
+
+// --- diff ---
+
+/** Stable JSON identity for an endpoint, for set-difference comparisons. */
+function endpointKey(e: Endpoint): string {
+	return JSON.stringify([e.name, e.scheme, e.internal, e.published ?? ""]);
+}
+
+/**
+ * Compute a minimal, deterministic list of events that, folded over `prev` in
+ * order, yields `next` for the fields the event types cover (component status,
+ * endpoints, captures, and resources). Ordering is stable: components and
+ * resources are visited in sorted name order, endpoints/captures within each in
+ * sorted name order.
+ *
+ * Fields with no covering event (e.g. `mode`, `pid`, `env`) are not diffed.
+ */
+export function diff(
+	prev: DeploymentState,
+	next: DeploymentState,
+): LaunchEvent[] {
+	const events: LaunchEvent[] = [];
+
+	for (const component of Object.keys(next.components).sort()) {
+		const before = prev.components[component];
+		const after = next.components[component]!;
+
+		// Endpoints: emit one endpoint.resolved per added-or-changed endpoint.
+		const beforeEndpoints = new Map(
+			(before?.endpoints ?? []).map((e) => [e.name, endpointKey(e)]),
+		);
+		for (const endpoint of [...after.endpoints].sort((a, b) =>
+			a.name.localeCompare(b.name),
+		)) {
+			if (beforeEndpoints.get(endpoint.name) !== endpointKey(endpoint)) {
+				events.push({ kind: "endpoint.resolved", component, endpoint });
+			}
+		}
+
+		// Status: emit component.status when it changed to a known status value.
+		if (before?.status !== after.status && isKnownStatus(after.status)) {
+			events.push({
+				kind: "component.status",
+				component,
+				status: after.status,
+			});
+		}
+
+		// Captures: emit capture for each added-or-changed value.
+		for (const name of Object.keys(after.captures).sort()) {
+			if (before?.captures[name] !== after.captures[name]) {
+				events.push({
+					kind: "capture",
+					component,
+					name,
+					value: after.captures[name]!,
+				});
+			}
+		}
+	}
+
+	for (const name of Object.keys(next.resources).sort()) {
+		const before = prev.resources[name];
+		const after = next.resources[name]!;
+		const beforeEndpoints = (before?.endpoints ?? [])
+			.map(endpointKey)
+			.join("|");
+		const afterEndpoints = after.endpoints.map(endpointKey).join("|");
+		if (before?.type !== after.type || beforeEndpoints !== afterEndpoints) {
+			events.push({
+				kind: "resource.provisioned",
+				name,
+				type: after.type,
+				endpoints: after.endpoints,
+			});
+		}
+	}
+
+	return events;
+}
+
+/** Whether a status string is one a `component.status` event can carry. */
+function isKnownStatus(status: string): status is "up" | "down" | "unhealthy" {
+	return status === "up" || status === "down" || status === "unhealthy";
+}
+
+// --- resolveRef ---
+
+/**
+ * URL/host/port-style property names whose value depends on the consumer's
+ * vantage (published vs internal address). Other props (e.g. captures, env) are
+ * vantage-independent.
+ */
+const ADDRESS_PROPS = new Set(["url", "host", "port", "authority", "address"]);
+
+/** Whether this vantage reaches endpoints by their published (host-side) address. */
+function prefersPublished(vantage: Vantage): boolean {
+	if (vantage.network === "host") return true;
+	if (vantage.network === "compose") return false;
+	// No explicit network hint: source-mode consumers run on the host.
+	return vantage.mode === "source";
+}
+
+/** Pick the address an endpoint exposes for a given vantage, with fallback. */
+function addressFor(endpoint: Endpoint, vantage: Vantage): string {
+	if (prefersPublished(vantage)) return endpoint.published ?? endpoint.internal;
+	return endpoint.internal;
+}
+
+/** Derive a single address-shaped property from an endpoint. */
+function endpointProp(
+	endpoint: Endpoint,
+	prop: string,
+	vantage: Vantage,
+): string {
+	const address = addressFor(endpoint, vantage);
+	switch (prop) {
+		case "host":
+			return address.split(":")[0] ?? "";
+		case "port":
+			return address.includes(":") ? (address.split(":")[1] ?? "") : "";
+		case "authority":
+		case "address":
+			return address;
+		default:
+			// "url"
+			return address ? `${endpoint.scheme}://${address}` : "";
+	}
+}
+
+/**
+ * Resolve a `$`-reference against a {@link DeploymentState} from a consumer's
+ * {@link Vantage}.
+ *
+ * Supported forms:
+ * - `$components.<name>.<prop>` — a component's endpoint/capture property.
+ * - `$<resource>.<prop>` — a resource's endpoint property.
+ *
+ * Address-shaped props (`url`, `host`, `port`, `authority`, `address`) resolve
+ * against the default endpoint and honor the vantage: a host / source-mode
+ * consumer gets the published address (falling back to internal when no
+ * published address exists); an in-network consumer gets the internal address.
+ * A `<prop>` matching a capture name resolves to that capture's value.
+ *
+ * Unknown references return "" — mirroring the `$`-expression resolver, which
+ * never throws on an unresolved reference (the caller supplies `:-default` or
+ * falls back to the empty string).
+ */
+export function resolveRef(
+	state: DeploymentState,
+	ref: string,
+	vantage: Vantage,
+): string {
+	if (!ref.startsWith("$")) return "";
+	const path = ref.slice(1).split(".");
+
+	if (path[0] === "components") {
+		const name = path[1];
+		const prop = path[2];
+		if (!name || !prop) return "";
+		const component = state.components[name];
+		if (!component) return "";
+		if (prop in component.captures) return component.captures[prop]!;
+		const endpoint = defaultEndpoint(component.endpoints);
+		if (!endpoint || !ADDRESS_PROPS.has(prop)) return "";
+		return endpointProp(endpoint, prop, vantage);
+	}
+
+	// $<resource>.<prop>
+	const name = path[0];
+	const prop = path[1];
+	if (!name || !prop) return "";
+	const resource = state.resources[name];
+	if (!resource) return "";
+	const endpoint = defaultEndpoint(resource.endpoints);
+	if (!endpoint || !ADDRESS_PROPS.has(prop)) return "";
+	return endpointProp(endpoint, prop, vantage);
+}
+
+/** The endpoint named "default" if present, else the first by sort order. */
+function defaultEndpoint(endpoints: Endpoint[]): Endpoint | undefined {
+	if (endpoints.length === 0) return undefined;
+	return endpoints.find((e) => e.name === "default") ?? endpoints[0];
+}

--- a/sdk/src/state.ts
+++ b/sdk/src/state.ts
@@ -390,9 +390,17 @@ export function resolveRef(
 		const name = path[1];
 		const prop = path[2];
 		if (!name || !prop) return "";
-		const component = state.components[name];
+		// Object.hasOwn, not `name in` / bracket access: a plain Record inherits
+		// Object.prototype, so `state.components["toString"]` would otherwise hand
+		// back the inherited method instead of resolving to "".
+		const component = Object.hasOwn(state.components, name)
+			? state.components[name]
+			: undefined;
 		if (!component) return "";
-		if (prop in component.captures) return component.captures[prop]!;
+		// hasOwn, not `prop in`: keeps `$components.api.toString` from resolving to
+		// the inherited Object.prototype.toString rather than "".
+		if (Object.hasOwn(component.captures, prop))
+			return component.captures[prop]!;
 		const endpoint = defaultEndpoint(component.endpoints);
 		if (!endpoint || !ADDRESS_PROPS.has(prop)) return "";
 		return endpointProp(endpoint, prop, vantage);
@@ -402,7 +410,9 @@ export function resolveRef(
 	const name = path[0];
 	const prop = path[1];
 	if (!name || !prop) return "";
-	const resource = state.resources[name];
+	const resource = Object.hasOwn(state.resources, name)
+		? state.resources[name]
+		: undefined;
 	if (!resource) return "";
 	const endpoint = defaultEndpoint(resource.endpoints);
 	if (!endpoint || !ADDRESS_PROPS.has(prop)) return "";

--- a/spec/DESIGN.md
+++ b/spec/DESIGN.md
@@ -448,6 +448,16 @@ Source-mode resolution is **per component**, with precedence **`dev` > `image` >
 
 ---
 
+### D-41: Component selection starts the downward dependency closure
+
+**Decision**: The component selector (the verb argument from [D-37](#d-37-execution-mode-vs-deployment-environment-commands-vary-by-mode-config-by-environment)) starts the named components **plus their transitive downward dependency closure** — each selected component's `depends_on` target components (transitively) and every closure member's `requires` backing services. It does **not** start reverse-dependencies (components that depend *on* a selected one) or unrelated components; the closure is downward only (`up backend` does not start `frontend`). Already-running dependencies are left untouched (idempotent). Selecting nothing acts on all components. A future `--no-deps` opt-out MAY start only the directly-named components for operators who manage dependencies themselves; absent that flag, the closure is started. Providers MUST compute the start-set from one shared definition (a `selectionClosure` helper in the SDK) so every provider produces the same running topology.
+
+**Rejected**: *Satisfy-not-expand* (start only the named components; fail if a `depends_on` target is not already running) — contradicts [D-16](#d-16-depends_on-for-startup-ordering), which makes `depends_on` a hard startup prerequisite (SPEC.md: *"`depends_on` ensures `frontend` waits for `backend` to become healthy before starting"*); a selected component whose prerequisite is down is non-functional by the file's own declaration, so the headline `up <component>` would fail by default. It also pulled the two reference providers apart — Docker's `compose up <service>` starts the closure while a hand-narrowed macOS started only the named component — a [P-5](#p-5-provider-translatable) violation (same file, two running topologies). *Total/upward closure* (also starting reverse-deps) — starts components the operator neither asked for nor needs.
+
+**Why**: Honors D-16 so a selected component can actually start. One shared `selectionClosure` definition closes the provider divergence at the source (Docker's compose default is already correct under this rule; macOS adopts the same helper). Downward-only keeps the set minimal — you get what you asked for and what it needs, never what needs it. Purely additive ([P-13](#p-13-additive-extensibility)): no schema or parser change; with no selector, behavior is unchanged. Extends D-37. See [#97](https://github.com/launchfile/launchfile/pull/97).
+
+---
+
 ## 4. Known Limitations
 
 Each limitation includes the problem, current stance, and future considerations.


### PR DESCRIPTION
## What this does

Today `launch up` always starts every part of an app. This lets you start
only the parts you name:

    launch up backend     # starts the backend and the services it needs,
                          # leaves the frontend (and anything else) stopped

- Works on both reference providers — Docker and the macOS dev provider.
- If you name something that isn't a startable part (a typo, or a database
  that belongs to a part rather than being a part itself), it says so clearly
  and stops, instead of guessing.
- The Docker "what's running" summary now lists only the parts you actually
  started — not the whole app.

It also adds three small, self-contained helper functions to the SDK for
tracking what's running:

- one updates a record of the app's state as things happen (a part started,
  became healthy, stopped, got an address),
- one compares two such records and reports what changed,
- one looks up a part's address and returns the right one for whoever's
  asking — a program on your laptop gets `localhost:3001`; a program inside
  the same Docker network gets the internal name.

These are pure functions: they don't touch files or do anything on their own,
they just compute values that tools build on. A separate check warns if two
parts ask for the same database name but with conflicting settings, so a
provider never silently picks one.

## Why

Implements the agreed design decision **D-37** (from #77): you can act on
part of an app, and asking for one part never silently starts others.

## Tested

All green on current `main`: SDK 231 tests, Docker 85, macOS 74, type-checks
clean. The selector was also run for real against Docker — starting only the
chosen part, leaving the rest down, and cleaning up afterward.

4 commits, each scoped to one folder (`sdk:` / `providers:`), per repo convention.
