### PR TITLE
www-shared: inject the header Get Started CTA by config (de-hardcode launchfile.io funnel)

### DIFF
--- a/www-dev/src/components/learn/CourseLayout.astro
+++ b/www-dev/src/components/learn/CourseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import Base from "@shared/layouts/Base.astro";
 import DocsHeader from "@shared/components/DocsHeader.astro";
+import { GET_STARTED } from "@/site";
 import Sidebar from "@shared/components/Sidebar.astro";
 import SidebarNav from "@shared/components/SidebarNav.astro";
 import SearchDialog from "@shared/components/SearchDialog.astro";
@@ -22,7 +23,7 @@ const currentPath = Astro.url.pathname;
 ---
 
 <Base title={`${title} — Learn Launchfile`} description={subtitle} site="dev">
-  <DocsHeader slot="nav">
+  <DocsHeader slot="nav" getStarted={GET_STARTED}>
     <SidebarNav slot="drawer-nav" currentPath={currentPath} />
   </DocsHeader>
   <div class="course-layout">

--- a/www-dev/src/layouts/DocsLayout.astro
+++ b/www-dev/src/layouts/DocsLayout.astro
@@ -1,6 +1,7 @@
 ---
 import Base from "@shared/layouts/Base.astro";
 import DocsHeader from "@shared/components/DocsHeader.astro";
+import { GET_STARTED } from "@/site";
 import Sidebar from "@shared/components/Sidebar.astro";
 import SidebarNav from "@shared/components/SidebarNav.astro";
 import PageFooter from "@shared/components/PageFooter.astro";
@@ -17,7 +18,7 @@ const { title, description, currentPath } = Astro.props;
 ---
 
 <Base title={title} description={description} site="dev">
-  <DocsHeader slot="nav">
+  <DocsHeader slot="nav" getStarted={GET_STARTED}>
     <SidebarNav slot="drawer-nav" currentPath={currentPath} />
   </DocsHeader>
   <div class="docs-layout">

--- a/www-dev/src/pages/index.astro
+++ b/www-dev/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Base from "@shared/layouts/Base.astro";
 import DocsHeader from "@shared/components/DocsHeader.astro";
+import { GET_STARTED } from "@/site";
 import SearchDialog from "@shared/components/SearchDialog.astro";
 import "@/styles/global.css";
 
@@ -39,7 +40,7 @@ const quickLinks = [
 ---
 
 <Base title="Launchfile — Describe your app. Deploy it anywhere." description="Developer documentation for the Launchfile deployment specification. SDK, examples, and guides." site="dev">
-  <DocsHeader slot="nav" />
+  <DocsHeader slot="nav" getStarted={GET_STARTED} />
 
   <main>
     <!-- Dark hero section -->

--- a/www-dev/src/pages/learn/index.astro
+++ b/www-dev/src/pages/learn/index.astro
@@ -1,6 +1,7 @@
 ---
 import Base from "@shared/layouts/Base.astro";
 import DocsHeader from "@shared/components/DocsHeader.astro";
+import { GET_STARTED } from "@/site";
 import Sidebar from "@shared/components/Sidebar.astro";
 import SidebarNav from "@shared/components/SidebarNav.astro";
 import SearchDialog from "@shared/components/SearchDialog.astro";
@@ -42,7 +43,7 @@ const modules = [
 ---
 
 <Base title="Learn Launchfile — Step-by-Step Course" description="Learn to write Launchfiles from scratch. 7 lessons from minimal to multi-component." site="dev">
-  <DocsHeader slot="nav">
+  <DocsHeader slot="nav" getStarted={GET_STARTED}>
     <SidebarNav slot="drawer-nav" currentPath={currentPath} />
   </DocsHeader>
   <div class="docs-layout">

--- a/www-dev/src/site.ts
+++ b/www-dev/src/site.ts
@@ -1,0 +1,4 @@
+// Site-level fragments injected into shared components (e.g. DocsHeader's CTA),
+// so the shared shell in www-shared/ stays funnel-agnostic — the launchfile.io
+// funnel URL lives here in the consuming site, not hardcoded in the shared code.
+export const GET_STARTED = { href: "https://launchfile.io/get-started" };

--- a/www-org/src/layouts/DocsLayout.astro
+++ b/www-org/src/layouts/DocsLayout.astro
@@ -1,6 +1,7 @@
 ---
 import Base from "@shared/layouts/Base.astro";
 import DocsHeader from "@shared/components/DocsHeader.astro";
+import { GET_STARTED } from "@/site";
 import Sidebar from "@shared/components/Sidebar.astro";
 import SidebarNav from "@shared/components/SidebarNav.astro";
 import PageFooter from "@shared/components/PageFooter.astro";
@@ -17,7 +18,7 @@ const { title, description, currentPath } = Astro.props;
 ---
 
 <Base title={title} description={description} site="org">
-  <DocsHeader slot="nav" site="org">
+  <DocsHeader slot="nav" getStarted={GET_STARTED} site="org">
     <SidebarNav slot="drawer-nav" currentPath={currentPath} />
   </DocsHeader>
   <div class="docs-layout">

--- a/www-org/src/pages/index.astro
+++ b/www-org/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Base from "@shared/layouts/Base.astro";
 import DocsHeader from "@shared/components/DocsHeader.astro";
+import { GET_STARTED } from "@/site";
 import SearchDialog from "@shared/components/SearchDialog.astro";
 
 import "@/styles/global.css";
@@ -22,7 +23,7 @@ const specSections = [
 ---
 
 <Base title="Launchfile — Application Deployment Specification" description="An open specification for describing application deployment requirements. Platform-agnostic, human-writable, machine-parseable." site="org">
-  <DocsHeader slot="nav" site="org" />
+  <DocsHeader slot="nav" getStarted={GET_STARTED} site="org" />
 
   <main>
     <!-- Hero section with grid pattern background -->

--- a/www-org/src/site.ts
+++ b/www-org/src/site.ts
@@ -1,0 +1,4 @@
+// Site-level fragments injected into shared components (e.g. DocsHeader's CTA),
+// so the shared shell in www-shared/ stays funnel-agnostic — the launchfile.io
+// funnel URL lives here in the consuming site, not hardcoded in the shared code.
+export const GET_STARTED = { href: "https://launchfile.io/get-started" };

--- a/www-shared/components/DocsHeader.astro
+++ b/www-shared/components/DocsHeader.astro
@@ -2,10 +2,12 @@
 interface Props {
   site?: "dev" | "org" | "io";
   /**
-   * Show the "Get Started" CTA. launchfile.io turns this off and supplies its
-   * own auth-aware actions (avatar / Sign up) via the `header-actions` slot.
+   * The "Get Started" CTA (header + drawer), injected by the consuming site so
+   * no funnel URL is hardcoded in this shared shell. Omit it for no CTA — e.g.
+   * launchfile.io's dashboard supplies its own auth-aware actions (avatar /
+   * Sign up) via the `header-actions` slot instead.
    */
-  showGetStarted?: boolean;
+  getStarted?: { href: string; label?: string };
   /**
    * Show the docs search (⌘K bar + mobile icon). The authenticated dashboard
    * shell turns this off — there's no docs index to search there.
@@ -19,7 +21,7 @@ const siteLabels: Record<string, string> = {
   io: "Catalog",
 };
 
-const { site = "dev", showGetStarted = true, showSearch = true } = Astro.props;
+const { site = "dev", getStarted, showSearch = true } = Astro.props;
 const siteLabel = siteLabels[site] ?? "Docs";
 
 const sites = [
@@ -77,8 +79,8 @@ const hasDrawerNav = Astro.slots.has("drawer-nav");
         ))}
       </nav>
 
-      {showGetStarted && (
-        <a href="https://launchfile.io/get-started" class="docs-get-started">Get Started</a>
+      {getStarted && (
+        <a href={getStarted.href} class="docs-get-started">{getStarted.label ?? "Get Started"}</a>
       )}
 
       {showSearch && (
@@ -122,8 +124,8 @@ const hasDrawerNav = Astro.slots.has("drawer-nav");
           {s.label}
         </a>
       ))}
-      {showGetStarted && (
-        <a href="https://launchfile.io/get-started" class="drawer-get-started">Get Started</a>
+      {getStarted && (
+        <a href={getStarted.href} class="drawer-get-started">{getStarted.label ?? "Get Started"}</a>
       )}
       <slot name="drawer-actions" />
     </nav>


### PR DESCRIPTION
## Summary

Removes the hardcoded launchfile.io funnel fragment from the shared `DocsHeader` and lets each consuming site inject its own "Get Started" CTA by configuration.

## Why

The shared header baked in `https://launchfile.io/get-started` and gated it with a `showGetStarted` boolean — hardcoding a consumer-site fragment into the public shared shell. Sites should inject such fragments, not have them hardcoded in `www-shared`.

## Change

- **`www-shared/components/DocsHeader.astro`**: replace `showGetStarted: boolean` (+ the hardcoded href, ×2) with `getStarted?: { href: string; label?: string }`. Provided → render the CTA (header + drawer) with that href/label; omitted → no CTA. The cross-site nav + footer keep their shared defaults (they're the public product directory) — only the funnel fragment moves out. **No consuming-site URL remains in www-shared.**
- **`www-dev` / `www-org`**: each adds `src/site.ts` exporting `GET_STARTED` (single source of truth for the site's CTA target) and passes `getStarted={GET_STARTED}` at its DocsHeader call sites.

## Compatibility

- www-dev / www-org render **identically** — the CTA still points to `https://launchfile.io/get-started`, now injected from each site's own config.
- A consuming site that omits `getStarted` simply shows no CTA (this is how the commercial launchfile.io dashboard shell will drop it and supply its own auth-aware actions via the existing `header-actions` slot).

## Verification

Both sites: typecheck 0 errors, build clean, CTA renders in header + drawer from the injected config. (Also verified a downstream consumer that omits `getStarted` renders no CTA.)
