### PR TITLE
smoke-tests: gate mermaid diagram render in website CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,8 @@ jobs:
             term: validate
           - site: www-org
             term: components
+            # www-org renders mermaid diagrams; www-dev has none (empty → skipped).
+            mermaidPath: /design/
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -111,7 +113,7 @@ jobs:
       # Functional search test against the freshly-built site, BEFORE deploy.
       # Site search broke for ~6 days after the Astro 6→7 bump because nothing
       # exercised it pre-merge — only the post-deploy smoke caught it, live.
-      - name: Search works on the built site
+      - name: Search + mermaid render on the built site
         working-directory: smoke-tests
         # Matrix values go through env (not inline ${{ }} in the run body), per
         # GitHub's injection-safe guidance — keeps the habit safe if an input is
@@ -120,12 +122,19 @@ jobs:
           SEARCH_SITE: ${{ matrix.site }}
           SEARCH_TERM: ${{ matrix.term }}
           SEARCH_BASE_URL: http://127.0.0.1:8080
+          # Mermaid render gate (browser/mermaid.spec.ts). Only www-org has
+          # diagrams; for www-dev MERMAID_PATH is empty and the spec registers
+          # no tests. Catches a broken diagram render (e.g. the __VITE_PRELOAD__
+          # throw, or a fence not emitted as <pre class="mermaid">) pre-deploy.
+          MERMAID_SITE: ${{ matrix.site }}
+          MERMAID_PATH: ${{ matrix.mermaidPath }}
+          MERMAID_BASE_URL: http://127.0.0.1:8080
         run: |
           bun install --frozen-lockfile
           bunx playwright install --with-deps chromium
           node serve-build.mjs "../$SEARCH_SITE/dist/client" 8080 &
           for i in $(seq 1 30); do curl -sf "$SEARCH_BASE_URL/" >/dev/null && break; sleep 0.5; done
-          bunx playwright test browser/search.spec.ts
+          bunx playwright test browser/
 
   # Catches invalid YAML in workflow files before it gets merged and breaks
   # the CI/release pipeline. actionlint alone is not sufficient here — it

--- a/smoke-tests/browser/mermaid-tests.ts
+++ b/smoke-tests/browser/mermaid-tests.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Parameterized mermaid-render test, runnable against either a live site or a
+ * locally-served build (`dist/client`). Same two run modes as the search suite:
+ * a pre-merge CI run against the freshly-built site, and a post-deploy smoke.
+ *
+ * It exercises the *whole* diagram path, not just the build output: the page
+ * ships `<pre class="mermaid">…</pre>`, and a client script in DocsLayout.astro
+ * dynamically imports mermaid from a CDN and renders each one into an `<svg>`.
+ * Asserting the `<svg>` actually appears catches the regressions that markup
+ * checks miss — e.g. the `__VITE_PRELOAD__` throw that silently killed the
+ * dynamic import after the Astro 6→7 bump, or the content-collection mermaid
+ * fence never being emitted as `<pre class="mermaid">` in the first place.
+ *
+ * @param name        display name for the describe block
+ * @param baseURL     origin to test (no trailing slash)
+ * @param mermaidPath a route known to contain at least one mermaid diagram
+ */
+export function registerMermaidTests(
+  name: string,
+  baseURL: string,
+  mermaidPath: string,
+) {
+  const url = (path: string) => baseURL.replace(/\/$/, "") + path;
+
+  test.describe(`${name} mermaid`, () => {
+    // The diagram loads mermaid from a CDN at runtime; a transient CDN hiccup
+    // shouldn't red the whole pipeline, but a real break (no <svg> ever) still
+    // fails after the retries are exhausted.
+    test.describe.configure({ retries: 2 });
+
+    test("homepage of the diagram route loads without errors", async ({ page }) => {
+      const errors: string[] = [];
+      page.on("pageerror", (err) => errors.push(err.message));
+      await page.goto(url(mermaidPath));
+      const real = errors.filter((e) => !e.includes("favicon"));
+      expect(real, `Unexpected page errors: ${real.join("; ")}`).toHaveLength(0);
+    });
+
+    test(`renders a mermaid diagram on ${mermaidPath}`, async ({ page }) => {
+      await page.goto(url(mermaidPath));
+
+      // The build must emit the diagram source as <pre class="mermaid">.
+      const source = page.locator("pre.mermaid");
+      await expect(source.first()).toBeVisible();
+
+      // The client runner must turn it into a real, sized <svg> — proof the CDN
+      // import resolved and mermaid.run() executed against `.mermaid` nodes.
+      const svg = page.locator(".mermaid svg").first();
+      await expect(svg).toBeVisible({ timeout: 15000 });
+      const box = await svg.boundingBox();
+      expect(box?.width ?? 0).toBeGreaterThan(0);
+      expect(box?.height ?? 0).toBeGreaterThan(0);
+    });
+  });
+}

--- a/smoke-tests/browser/mermaid.spec.ts
+++ b/smoke-tests/browser/mermaid.spec.ts
@@ -1,0 +1,24 @@
+import { registerMermaidTests } from "./mermaid-tests";
+
+// Two run modes (mirrors search.spec.ts):
+//
+// 1. Post-deploy smoke (default — no env): test the live launchfile.org /design
+//    page, which renders the architecture diagram.
+// 2. Pre-merge CI (MERMAID_BASE_URL set): test ONE locally-served build. Only
+//    launchfile.org has diagrams, so the `websites` matrix sets MERMAID_PATH for
+//    www-org and leaves it empty for www-dev — when it's empty we register
+//    nothing (the diagram-less site contributes no mermaid tests).
+const localBase = process.env.MERMAID_BASE_URL;
+const localPath = process.env.MERMAID_PATH;
+
+if (localBase) {
+  if (localPath) {
+    registerMermaidTests(
+      process.env.MERMAID_SITE ?? "local build",
+      localBase,
+      localPath,
+    );
+  }
+} else {
+  registerMermaidTests("launchfile.org", "https://launchfile.org", "/design/");
+}


### PR DESCRIPTION
Adds a pre-deploy mermaid render gate to the website CI, modeled on the existing search suite. (No linked GitHub issue — this is internal task tracking; not using a `Closes #N` keyword since the bare number would point at an unrelated PR.)

The test loads a route with a diagram, asserts the build emitted `<pre class="mermaid">`, and — the point — waits for the client runner to turn it into a real, **sized `<svg>`**, exercising the full CDN-import + `mermaid.run()` path. That catches the silent breaks a markup check misses: the `__VITE_PRELOAD__` throw that killed the dynamic import after the Astro 6→7 bump, or a content-collection fence never being emitted as `<pre class="mermaid">`.

### Changes
- **`smoke-tests:`** `browser/mermaid-tests.ts` (parameterized `registerMermaidTests`) + `browser/mermaid.spec.ts`. Two run modes like `search.spec.ts`: pre-merge against the freshly-built site (`MERMAID_BASE_URL`) and post-deploy smoke against live launchfile.org `/design/`. Only launchfile.org has diagrams, so the spec registers **no tests** when `MERMAID_PATH` is empty. 2 retries absorb a transient CDN hiccup.
- **`chore:`** website CI job runs `browser/` (search + mermaid) with `MERMAID_*` env; the `www-org` matrix row adds `mermaidPath: /design/`, `www-dev` has none. Matrix values flow through `env`, not inline interpolation.

### Verification
- www-org: **8/8** (6 search + 2 mermaid) against the built site; the diagram renders to a sized `<svg>` headless. Confirmed green in CI against the live jsdelivr CDN.
- www-dev: **6/6** (mermaid spec a no-op — empty path).
- `ci.yml` validated (valid YAML; matrix/env/run wiring confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)