### PR TITLE
catalog: self-URL defaults + cyberchef port fix (staging-vetted)

### DIFF
--- a/catalog/apps/cyberchef/Launchfile
+++ b/catalog/apps/cyberchef/Launchfile
@@ -8,7 +8,7 @@ logo: https://raw.githubusercontent.com/gchq/CyberChef/master/src/web/static/ima
 image: ghcr.io/gchq/cyberchef:latest
 provides:
   - protocol: http
-    port: 8000
+    port: 8080
     exposed: true
 health: /
 restart: always

--- a/catalog/apps/docmost/Launchfile
+++ b/catalog/apps/docmost/Launchfile
@@ -23,6 +23,6 @@ env:
     sensitive: true
     description: "Secret key for session encryption"
   APP_URL:
-    required: true
+    default: $app.url
     description: "Public-facing URL of the Docmost instance"
 restart: always

--- a/catalog/apps/ghost/Launchfile
+++ b/catalog/apps/ghost/Launchfile
@@ -22,6 +22,7 @@ env:
   database__client:
     default: "mysql"
   url:
+    default: $app.url
     required: true
     description: "Public URL of the Ghost instance"
 storage:

--- a/catalog/apps/miniflux/Launchfile
+++ b/catalog/apps/miniflux/Launchfile
@@ -29,5 +29,8 @@ env:
     sensitive: true
     description: "Admin password"
     generator: secret
+  BASE_URL:
+    default: $app.url
+    description: "Public-facing URL; miniflux uses it for absolute links and feed URLs"
 health: /healthcheck
 restart: always


### PR DESCRIPTION
## What

Four small catalog corrections, each verified by deploying the app on the real Launchpad **staging** box (sslip.io + Traefik) and confirming it serves:

| App | Change | Why |
|-----|--------|-----|
| `cyberchef` | `provides.port` `8000` → `8080` | The `ghcr.io/gchq/cyberchef:latest` image listens on **8080**; the old value never passed health checks. |
| `docmost` | `env.APP_URL` `required: true` → `default: $app.url` | The host knows the public URL; defaulting it removes a required-input footgun and lets the app boot unattended. |
| `ghost` | `env.url` gains `default: $app.url` (still `required`) | Same self-URL default; Ghost crash-loops without `url`, so the platform supplies it. |
| `miniflux` | add `env.BASE_URL` `default: $app.url` | Miniflux uses it for absolute links and feed URLs. |

## How verified

Each app was launched through the staging control plane and reached a healthy/serving state with these descriptors. The `$app.url` token resolves to the deployment's public URL at launch time.

## Notes

- Catalog-only; no SDK/spec/provider changes.
- Ready for steward review against the published catalog principles.