### PR TITLE
catalog: self-URL defaults for 10 DB-backed apps (staging-vetted)

### DIFF
--- a/catalog/apps/activepieces/Launchfile
+++ b/catalog/apps/activepieces/Launchfile
@@ -30,5 +30,5 @@ env:
     generator: secret
     sensitive: true
   AP_FRONTEND_URL:
-    default: "http://localhost"
+    default: $app.url
 restart: always

--- a/catalog/apps/bookstack/Launchfile
+++ b/catalog/apps/bookstack/Launchfile
@@ -20,7 +20,7 @@ requires:
       DB_PASSWORD: $password
 env:
   APP_URL:
-    required: true
+    default: $app.url
     description: "Public URL of the BookStack instance"
   APP_KEY:
     generator: secret

--- a/catalog/apps/gitea/Launchfile
+++ b/catalog/apps/gitea/Launchfile
@@ -24,6 +24,9 @@ requires:
 env:
   GITEA__database__DB_TYPE:
     default: "postgres"
+  GITEA__server__ROOT_URL:
+    default: $app.url
+    description: "Public base URL Gitea builds clone and web links from"
 storage:
   data:
     path: /data

--- a/catalog/apps/grafana/Launchfile
+++ b/catalog/apps/grafana/Launchfile
@@ -15,6 +15,9 @@ env:
     generator: secret
     sensitive: true
     description: "Admin password"
+  GF_SERVER_ROOT_URL:
+    default: $app.url
+    description: "Public URL Grafana builds links and redirects from"
 health: /api/health
 storage:
   data:

--- a/catalog/apps/linkwarden/Launchfile
+++ b/catalog/apps/linkwarden/Launchfile
@@ -19,7 +19,7 @@ env:
     generator: secret
     sensitive: true
   NEXTAUTH_URL:
-    default: "http://localhost:3000"
+    default: $app.url
 storage:
   data:
     path: /data/data

--- a/catalog/apps/mealie/Launchfile
+++ b/catalog/apps/mealie/Launchfile
@@ -20,7 +20,7 @@ env:
     default: "true"
     description: "Allow new user registration"
   BASE_URL:
-    required: true
+    default: $app.url
     description: "Public URL for the Mealie instance"
   DEFAULT_EMAIL:
     default: "changeme@example.com"

--- a/catalog/apps/nocodb/Launchfile
+++ b/catalog/apps/nocodb/Launchfile
@@ -15,6 +15,9 @@ env:
     generator: secret
     sensitive: true
     description: "JWT secret for authentication"
+  NC_PUBLIC_URL:
+    default: $app.url
+    description: "Public base URL NocoDB uses for invite and email links"
 storage:
   data:
     path: /usr/app/data

--- a/catalog/apps/paperless/Launchfile
+++ b/catalog/apps/paperless/Launchfile
@@ -35,6 +35,9 @@ env:
   PAPERLESS_OCR_LANGUAGE:
     default: "eng"
     description: "OCR language (ISO 639-2/T codes, e.g., eng+deu)"
+  PAPERLESS_URL:
+    default: $app.url
+    description: "Public URL paperless-ngx is served from (CSRF trusted origin behind the proxy)"
 storage:
   data:
     path: /usr/src/paperless/data

--- a/catalog/apps/searxng/Launchfile
+++ b/catalog/apps/searxng/Launchfile
@@ -15,6 +15,9 @@ env:
     generator: secret
     sensitive: true
     description: "Secret key for session encryption"
+  SEARXNG_BASE_URL:
+    default: $app.url
+    description: "Public base URL SearXNG builds result and opensearch links from"
 storage:
   data:
     path: /etc/searxng

--- a/catalog/apps/vaultwarden/Launchfile
+++ b/catalog/apps/vaultwarden/Launchfile
@@ -22,6 +22,9 @@ env:
   SIGNUPS_ALLOWED:
     default: "true"
     description: "Whether new user signups are allowed"
+  DOMAIN:
+    default: $app.url
+    description: "Public URL vaultwarden is served from (required for WebAuthn/U2F)"
 storage:
   data:
     path: /data


### PR DESCRIPTION
Declares each app's public-URL env with a `$app.url` default (D-35) so managed
hosts fill it automatically — instead of a `localhost` placeholder or
`required: true` that forces manual input.

**Group A — fix existing localhost/required default → `$app.url`:**
- `bookstack` (APP_URL), `mealie` (BASE_URL), `linkwarden` (NEXTAUTH_URL), `activepieces` (AP_FRONTEND_URL)

**Group B — add the documented public-URL var:**
- `gitea` (GITEA__server__ROOT_URL), `grafana` (GF_SERVER_ROOT_URL),
  `vaultwarden` (DOMAIN — required for WebAuthn/U2F), `nocodb` (NC_PUBLIC_URL),
  `searxng` (SEARXNG_BASE_URL), `paperless` (PAPERLESS_URL — CSRF trusted origin)

## Verification

Each was launched on a staging provider that resolves `$app.url`, with **no
out-of-band env injection** — the Launchfile default alone supplied the URL. Every
app reached `running` and returned HTTP 200/302 on its routed public URL, then tore
down cleanly with no leaked resources.

Two gotchas a `/`-probe alone would miss, confirmed and worth calling out:
- **vaultwarden** `DOMAIN` must be the exact public origin or WebAuthn/2FA fails.
- **paperless** derives `CSRF_TRUSTED_ORIGINS` from `PAPERLESS_URL`; without it, GET
  works but login POST is rejected with a CSRF 403.

No schema or index changes — these apps already live in `apps/`; this is a fix.
