### PR TITLE
spec: ratify P-14 — legible evolution (D-42 deprecation metadata model)

### DIFF
--- a/governance/GOVERNANCE.md
+++ b/governance/GOVERNANCE.md
@@ -12,7 +12,7 @@ The Launchfile specification is governed by a constitutional model: human author
 
 Listed in the `AUTHORS` file at the repository root. Authors:
 
-- Write and amend the constitution (DESIGN.md principles P-1 through P-13)
+- Write and amend the constitution (DESIGN.md principles P-1 through P-14)
 - Have final authority over all specification decisions
 - Can override any AI recommendation with documented rationale
 - Add new Authors by consensus

--- a/governance/GOVERNANCE.md
+++ b/governance/GOVERNANCE.md
@@ -59,7 +59,7 @@ Open a GitHub issue with:
 - Problem statement
 - Proposed solution
 - 3+ real-app motivations from the [catalog](../catalog/)
-- Self-assessment against P-1 through P-13
+- Self-assessment against P-1 through P-14
 
 ### 2. AI Evaluation
 

--- a/spec/CONTRIBUTING.md
+++ b/spec/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## How Decisions Are Made
 
-Proposals are evaluated against the [13 design principles](DESIGN.md) by an AI Steward, with Authors (listed in [AUTHORS](../AUTHORS)) having final authority. See [GOVERNANCE.md](GOVERNANCE.md) for the full governance model.
+Proposals are evaluated against the [14 design principles](DESIGN.md) by an AI Steward, with Authors (listed in [AUTHORS](../AUTHORS)) having final authority. See [GOVERNANCE.md](GOVERNANCE.md) for the full governance model.
 
 ## How to Propose Changes
 
@@ -16,7 +16,7 @@ Open a pull request directly. No RFC needed.
 
 1. **Open an issue** describing the problem and proposed solution
 2. **Include real-world motivation** — which apps need this? Show concrete Launchfile snippets
-3. **Evaluate against design principles** — does the proposal align with P-1 through P-13? (see [DESIGN.md](DESIGN.md))
+3. **Evaluate against design principles** — does the proposal align with P-1 through P-14? (see [DESIGN.md](DESIGN.md))
 4. **Draft the spec change** — PR against SPEC.md with the new field/behavior documented
 5. **Update the JSON Schema** — if adding fields, update `schema/launchfile.schema.json`
 6. **Add or update examples** — demonstrate the new feature in `examples/`
@@ -47,5 +47,5 @@ When reviewing spec PRs, check:
 - [ ] Is the JSON Schema updated and consistent with the spec text?
 - [ ] Are examples provided that demonstrate the feature?
 - [ ] Does DESIGN.md have a new decision entry explaining the rationale?
-- [ ] Does this align with the 13 design principles?
+- [ ] Does this align with the 14 design principles?
 - [ ] Are existing valid Launchfiles still valid?

--- a/spec/DESIGN.md
+++ b/spec/DESIGN.md
@@ -82,7 +82,7 @@ The format evolves by adding new fields, never new syntax. A v1 parser ignores u
 
 #### P-14: Legible evolution
 
-New capability is additive ([P-13](#p-13-additive-extensibility)). When a field or value must be sunset, the deprecation is *machine-readable* — it carries the version it was deprecated in, the version that removes it, its replacement, and a migration hint — sufficient for tooling to report which parts of a given file are deprecated or scheduled for removal, preview what a target version breaks before an upgrade, and drive the migration. No upgrade silently breaks a file; removal happens only at a major version. Deprecation may warn; removal must migrate; never break.
+New capability is additive ([P-13](#p-13-additive-extensibility)). When a field or value must be sunset, the deprecation is *machine-readable* — it carries the version it was deprecated in, the version that removes it, its replacement, and a migration hint — sufficient for tooling to report which parts of a given file are deprecated or scheduled for removal, preview what a target version breaks before an upgrade, and drive the migration. No upgrade silently breaks a file; removal happens only at a major version of the format — a `launch/vN` bump ([D-17](#d-17-version-header-for-spec-versioning)), never a package release. Deprecation may warn; removal must migrate; never break.
 
 ---
 

--- a/spec/DESIGN.md
+++ b/spec/DESIGN.md
@@ -20,7 +20,7 @@ graph TD
 
 ## 1. Design Principles
 
-Thirteen principles organized in three categories govern every decision in the format.
+Fourteen principles organized in three categories govern every decision in the format.
 
 ### Format Philosophy
 
@@ -80,6 +80,10 @@ The format's structure naturally guides apps toward 12-factor compliance. Config
 
 The format evolves by adding new fields, never new syntax. A v1 parser ignores unknown fields gracefully. No existing field changes meaning across versions. The `version` header enables breaking changes if absolutely necessary, but the design minimizes the need.
 
+#### P-14: Legible evolution
+
+New capability is additive ([P-13](#p-13-additive-extensibility)). When a field or value must be sunset, the deprecation is *machine-readable* — it carries the version it was deprecated in, the version that removes it, its replacement, and a migration hint — sufficient for tooling to report which parts of a given file are deprecated or scheduled for removal, preview what a target version breaks before an upgrade, and drive the migration. No upgrade silently breaks a file; removal happens only at a major version. Deprecation may warn; removal must migrate; never break.
+
 ---
 
 ## 1b. Governance Heuristics
@@ -90,7 +94,7 @@ These heuristics support the [governance model](GOVERNANCE.md) by making the des
 
 When principles conflict, higher-tier principles take priority:
 
-- **Tier 1 (inviolable):** P-1 (app-focused, not infra-focused), P-13 (additive extensibility), P-6 (it's just YAML)
+- **Tier 1 (inviolable):** P-1 (app-focused, not infra-focused), P-13 (additive extensibility), P-14 (legible evolution), P-6 (it's just YAML)
 - **Tier 2 (strong):** P-11 (separate intent from execution), P-5 (provider-translatable), P-12 (12-factor by default)
 - **Tier 3 (guiding):** P-2 (incrementally adoptable), P-3 (machine-generatable), P-4 (human-writable), P-7 (simple things simple), P-8 (familiar idioms), P-9 (unambiguous by convention), P-10 (source of truth co-located)
 
@@ -455,6 +459,16 @@ Source-mode resolution is **per component**, with precedence **`dev` > `image` >
 **Rejected**: *Satisfy-not-expand* (start only the named components; fail if a `depends_on` target is not already running) — contradicts [D-16](#d-16-depends_on-for-startup-ordering), which makes `depends_on` a hard startup prerequisite (SPEC.md: *"`depends_on` ensures `frontend` waits for `backend` to become healthy before starting"*); a selected component whose prerequisite is down is non-functional by the file's own declaration, so the headline `up <component>` would fail by default. It also pulled the two reference providers apart — Docker's `compose up <service>` starts the closure while a hand-narrowed macOS started only the named component — a [P-5](#p-5-provider-translatable) violation (same file, two running topologies). *Total/upward closure* (also starting reverse-deps) — starts components the operator neither asked for nor needs.
 
 **Why**: Honors D-16 so a selected component can actually start. One shared `selectionClosure` definition closes the provider divergence at the source (Docker's compose default is already correct under this rule; macOS adopts the same helper). Downward-only keeps the set minimal — you get what you asked for and what it needs, never what needs it. Purely additive ([P-13](#p-13-additive-extensibility)): no schema or parser change; with no selector, behavior is unchanged. Extends D-37. See [#97](https://github.com/launchfile/launchfile/pull/97).
+
+---
+
+### D-42: Deprecation metadata model — the P-14 mechanism
+
+**Decision**: Every deprecation the spec declares carries machine-readable metadata with four semantic parts: the version the field or value was **deprecated in**, the version that **removes it** (always a major version, per [P-14](#p-14-legible-evolution)), its **replacement**, and a **migration hint**. The metadata MUST be sufficient for tooling to (a) report which parts of a given file are deprecated or scheduled for removal, (b) preview what a target version breaks before an upgrade, and (c) drive or automate the migration. These three capabilities are the normative tooling contract; the CLI surface that delivers them (`lint`, `doctor`, `upgrade --dry-run`, `migrate`, or anything else) is SDK/CLI UX, not spec. Exact schema field names are settled by the first implementing schema PR — the semantics, not the spellings, are the precedent.
+
+**Rejected**: *Normative CLI command names in the principle* (binds the spec to one reference implementation's UX — against [P-1](#p-1-app-focused-not-infra-focused)/[P-11](#p-11-separate-intent-from-execution); the capability contract is what matters). *Minor-with-notice removal* (an Author value call, answered strict: removal only at a major version — a minor-version escape hatch reintroduces the silent-ish break the principle exists to forbid; flexibility is expressed as the length of the deprecation window, never as which version may remove). *Ad-hoc prose deprecation* (the pre-P-14 status quo — a one-off removal justified by 0.x semver, invisible to tooling, is exactly the illegible evolution this forecloses).
+
+**Why**: [P-14](#p-14-legible-evolution) is the subtractive complement of [D-14](#d-14-additive-extensibility----new-fields-never-new-syntax)'s additive path and gives the [D-17](#d-17-version-header-for-spec-versioning)/[P-13](#p-13-additive-extensibility) `version`-header escape hatch the discipline it lacked. Structured metadata serves [P-3](#p-3-machine-generatable) (tooling tracks the lifecycle) and [P-4](#p-4-human-writable) (an author writes nothing — the metadata lives in the schema — and is warned with a migration, never surprised). Carries the #113 invariant verbatim: deprecation may warn, removal must migrate, never break. First application: the `host.docker → container_runtime` deprecation ([#120](https://github.com/launchfile/launchfile/issues/120)). See [#117](https://github.com/launchfile/launchfile/issues/117).
 
 ---
 

--- a/www-org/src/pages/design.astro
+++ b/www-org/src/pages/design.astro
@@ -7,6 +7,6 @@ if (!entry) throw new Error("DESIGN.md not found in spec collection");
 const { Content } = await render(entry);
 ---
 
-<DocsLayout title="Design Principles — Launchfile" description="The 13 design principles and key decisions behind the Launchfile specification." currentPath="/design/">
+<DocsLayout title="Design Principles — Launchfile" description="The 14 design principles and key decisions behind the Launchfile specification." currentPath="/design/">
   <Content />
 </DocsLayout>

--- a/www-org/src/pages/index.astro
+++ b/www-org/src/pages/index.astro
@@ -11,7 +11,7 @@ const guides = [
   { title: "Quick Start", href: "/spec/quick-start/", desc: "Three fields to a running app. Learn the basics in two minutes." },
   { title: "Expression Syntax", href: "/spec/expression-syntax/", desc: "Wire dynamic values between resources, components, and secrets." },
   { title: "Value Patterns", href: "/spec/value-patterns/", desc: "Scalar shorthands that expand into structured objects." },
-  { title: "Design Principles", href: "/design/", desc: "Why the spec is shaped this way — 13 principles and key decisions." },
+  { title: "Design Principles", href: "/design/", desc: "Why the spec is shaped this way — 14 principles and key decisions." },
 ];
 
 const specSections = [


### PR DESCRIPTION
Ratifies **P-14 — Legible evolution** and its mechanism **D-42 — Deprecation
metadata model**, per the Author approval on #117.

## What lands

- **P-14** in `spec/DESIGN.md` — new capability is additive (P-13); when a field
  or value must be sunset, the deprecation is machine-readable and carries
  deprecated-in / removed-in / replacement / migration-hint. No upgrade silently
  breaks a file; removal only at a major version.
- **Tier 1** — P-14 placed alongside P-13 in the inviolable tier.
- **D-42** — the deprecation metadata model: four semantic parts, and the
  normative tooling contract (report / preview / migrate).
- Principle-count and range references updated in `spec/CONTRIBUTING.md`,
  `governance/GOVERNANCE.md`, and the two `www-org` pages.

## Author decisions applied (from #117)

| Open question                          | Resolution                                                                                                          |
|----------------------------------------|---------------------------------------------------------------------------------------------------------------------|
| Q1 — exact metadata field names        | Not ratified. Semantics are the precedent; spellings settled by the first implementing schema PR                      |
| Q2 — normative CLI surface             | **Trimmed.** The three capabilities are normative; `lint`/`doctor`/`upgrade --dry-run`/`migrate` are SDK/CLI UX, not spec |
| Q3 — removal at minor with notice?     | **Strict.** Removal only at a major version. Flexibility is the length of the deprecation window, never which version may remove |

## Scope

No field is deprecated by this PR. The first application is the
`host.docker → container_runtime` deprecation (#120), filed separately.

Closes #117
