### PR TITLE
chore: squash-merge dependency bumps automatically

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,63 @@
+name: Dependabot auto-merge
+
+# Dependency bumps are the one PR class that should squash: each is a single
+# mechanical commit, and a merge commit on top doubles the history for no
+# information. Every other PR merges (see STEWARD.md) to preserve the
+# monorepo's one-commit-one-directory history for `git subtree split`.
+#
+# Triggering on workflow_run rather than pull_request_target is deliberate:
+# `gh pr merge --auto` only defers to *required* status checks, and main has no
+# branch protection, so --auto would merge the bump the instant it opened —
+# before CI had run at all. workflow_run fires after CI has actually finished,
+# so the success conclusion below is a real gate rather than a decorative one.
+#
+# workflow_run grants a write token to a workflow definition taken from the
+# default branch, never from the PR head, and this job checks out no code, so a
+# malicious bump cannot reach the token.
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+# Least privilege: this job merges a pull request and deletes its branch. It
+# builds, tests, and checks out nothing. (CodeQL: actions/missing-workflow-permissions.)
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  squash-merge:
+    name: Squash-merge the dependency bump
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    steps:
+      - name: Resolve and merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          # Resolve the PR from the commit CI actually validated, so the merge
+          # can never land a revision newer than the one that passed. The sha
+          # reaches jq as a named argument, never spliced into the filter text.
+          pr=$(gh pr list --repo "$REPO" --state open \
+                 --json number,headRefOid,author \
+               | jq -r --arg sha "$HEAD_SHA" \
+                   '[.[] | select(.headRefOid == $sha)
+                         | select(.author.login == "app/dependabot")
+                         | .number] | first // empty')
+
+          if [ -z "$pr" ]; then
+            echo "No open dependabot PR at $HEAD_SHA — nothing to merge."
+            exit 0
+          fi
+
+          echo "Squash-merging dependabot PR #$pr ($HEAD_SHA)"
+          gh pr merge "$pr" --repo "$REPO" --squash --delete-branch


### PR DESCRIPTION
Splits the merge method by PR type: dependency bumps squash, everything
else merges.

## Why this is a workflow and not a setting

GitHub exposes only which merge methods are *allowed* (`allow_merge_commit`,
`allow_squash_merge`, `allow_rebase_merge`) plus message templates. There is
no "default merge method" field and no per-PR-type policy, so the split has
to be automated. All three methods stay enabled; the merge button is
unchanged for human PRs.

Motivated by #147, which was squash-merged from the UI and collapsed five
atomic commits across `spec/`, `governance/`, and `www-org/` into one — against
this repo's one-commit-one-directory rule. It also detached six stacked
governance branches from their base. Both were repaired by expanding main
back into a real merge commit.

## Why `workflow_run` and not `pull_request_target`

Two observed facts rule out the `--auto` path. Auto-merge is disabled on this
repo (`allow_auto_merge: false`), and `main` has no branch protection at all
(`GET /branches/main/protection` → `404 Branch not protected`). So `--auto`
would need two settings changes first, and even then would have no *required*
status checks to defer to — which is the only thing it waits on.

`workflow_run` needs neither change: it fires after CI has actually finished,
so gating on `conclusion == 'success'` is a real gate rather than a decorative
one.

`workflow_run` also runs the workflow definition from the default branch, never
from the PR head, and this job checks out no code — so a malicious bump cannot
reach the write token.

## Safety properties

| Guard | What it prevents |
|---|---|
| PR resolved by CI's `head_sha`, not branch name | A push landing mid-run slipping an unvalidated commit through |
| `author.login == "app/dependabot"` re-checked at merge time | Trusting the event payload alone |
| `head_repository.full_name == github.repository` | A fork driving the merge |
| Head sha passed to jq via `--arg` | Filter injection via the sha value |
| `permissions:` limited to `contents: write` + `pull-requests: write` | Token scope beyond merging |

## Verification

- Workflow YAML parses under a strict parser (`ruby -ryaml`); CI's `Workflow Lint` job runs the equivalent check with python `yaml`
- No `${{ }}` interpolation inside any `run:` block — every input arrives via `env:`
- No third-party actions, so nothing to SHA-pin; uses only preinstalled `gh` and `jq`
- Author login string confirmed against real merged bumps: `gh pr view 146 --json author` returns `app/dependabot`
- jq filter exercised against fixtures: matches the dependabot PR at the target sha; returns empty for a human PR at the *same* sha, for an unknown sha, and for a filter-injection attempt (no error)
