### PR TITLE
chore: upgrade Changesets to CLI v3 for changesets/action v2

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@3.1.3/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@4.0.0/schema.json",
   "changelog": ["@changesets/changelog-github", { "repo": "launchfile/launchfile" }],
   "commit": false,
   "fixed": [],
@@ -9,5 +9,6 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "privatePackages": { "version": true, "tag": false },
   "ignore": []
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ name: Release
 #   Phase B — PUBLISH (no changesets, e.g. the version PR just merged):
 #     `changeset publish` runs `npm publish` for every package whose
 #     version isn't already on the registry, pushes git tags, and (with
-#     createGithubReleases: true) cuts a GitHub Release per package.
+#     create-github-releases: true) cuts a GitHub Release per package.
 #
 # changesets/action picks the phase automatically from repo state, so
 # both phases share the same build + auth setup above. A previous
@@ -69,7 +69,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       # Build packages in dependency order so `npm publish` ships fresh dist/.
-      # changesets/action runs `publish:` from the repo root, so builds must
+      # changesets/action runs `publish-script:` from the repo root, so builds must
       # happen beforehand — there is no per-package build hook.
       - run: cd sdk && bun install --frozen-lockfile && bun run build
       - run: cd providers/docker && bun install && bun run build
@@ -77,15 +77,21 @@ jobs:
       - run: cd packages/launchfile && bun install && bun run build
 
       # Phase selector. See the header comment at the top of this file for
-      # the full explanation of why `version:` and `publish:` are both set —
-      # the action decides which one to actually run based on repo state.
+      # the full explanation of why `version-script:` and `publish-script:` are
+      # both set — the action decides which one to actually run based on repo
+      # state.
       - name: Create Release PR or Publish
-        uses: changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a # v1
+        uses: changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a # v2.1.0
         with:
-          version: npx changeset version
-          publish: npx changeset publish
-          commit: "chore: version packages"
-          title: "chore: version packages"
-          createGithubReleases: true
+          # changesets/action throws if GITHUB_TOKEN is set and differs from
+          # this input, so both must name the same secret. The env var itself
+          # is required: @changesets/changelog-github reads process.env.GITHUB_TOKEN
+          # to resolve PR/author links while `changeset version` writes CHANGELOGs.
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version-script: npx changeset version
+          publish-script: npx changeset publish
+          commit-message: "chore: version packages"
+          pr-title: "chore: version packages"
+          create-github-releases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "packages/*"
   ],
   "devDependencies": {
-    "@changesets/changelog-github": "^0.6.0",
-    "@changesets/cli": "^2.30.0"
+    "@changesets/changelog-github": "^1.0.0",
+    "@changesets/cli": "^3.0.1"
   }
 }


### PR DESCRIPTION
## Problem

The Release workflow has failed on **every completed run** since #146 bumped
`changesets/action` 1.9.0 → 2.1.0 — `f33ba37`, `be34b03`, `567ed99`, `aedf02e`,
`c26a009`, `560e723` (three others were cancelled by the concurrency group).
Last green run was `0aecdc8`, immediately before the bump.
([failing run](https://github.com/launchfile/launchfile/actions/runs/32566645126/job/97016113793))

> Error: This version of the Changesets action is designed to work with Changesets CLI v3.
> Changesets CLI v2 is not supported; use Changesets action v1 instead, which is compatible with CLI v2.

Two problems in one bump. Action v2 hard-refuses CLI v2, and it renamed every
input — so the step was also silently passing v1 names (`version`, `publish`,
`commit`, `title`, `createGithubReleases`) that v2 ignores. The resolved-input
dump in the run log confirms it: `commit-message: Version Packages`, not our
`chore: version packages`.

## Fix

Move forward to the CLI the action expects, rather than pinning the action
back to v1:

- `@changesets/cli` `^2.30.0` → `^3.0.1`; `@changesets/changelog-github` `^0.6.0` → `^1.0.0`
- Rename the inputs to their v2 names
- Pass `github-token` explicitly — v2 throws when the `GITHUB_TOKEN` env var is
  set and differs from the input. The env var must stay:
  `@changesets/get-github-info` reads `process.env.GITHUB_TOKEN`
  (`dist/index.mjs:25`) and throws without it (`:45`)
- `privatePackages: { version: true, tag: false }` — CLI v3 stops versioning
  private packages by default. This is exactly what `@changesets/config` v3.1.4
  resolves when the key is absent (`changesets-config.cjs.js:246-248`), so
  `providers/aws` keeps being versioned
- `$schema` → `@changesets/config@4.0.0`

`release.yml` keeps its filename. Header comments naming old inputs are updated
in place.

## Verification

Ran one trial changeset through both CLIs against identical trees at `d05c14c`:

- **Same version bumps across all five workspace packages**, including the
  private `providers/aws` (0.1.1 → 0.1.2) — confirming the `privatePackages`
  setting preserves current behaviour
- Only output difference is cosmetic: v3 emits a *tight* markdown bullet list
  where v2 emits a *loose* one. Renders identically
- `changeset publish-plan` (v3): "No projects to publish or tag" — correct, all
  four packages are already on npm at 0.3.0, so the failing runs were no-op publishes
- Read the action v2 source: `version-script` only runs when changesets exist
  (`src/index.ts` phase switch), so v3's new "`changeset version` exits 1 with no
  changesets" behaviour cannot bite us
- Build chain green (sdk → providers → cli); sdk tests 237/237

## Caveat

`release.yml` only triggers on `push` to `main`, so **CI on this PR does not
exercise this fix**. The first live test is the merge. Everything above is what
could be verified pre-merge.
