### PR TITLE
packages: ship @launchfile/macos-dev with the CLI on macOS

### DIFF
--- a/packages/launchfile/package.json
+++ b/packages/launchfile/package.json
@@ -41,6 +41,9 @@
     "@launchfile/sdk": "^0.3.0",
     "@launchfile/docker": "^0.3.0"
   },
+  "optionalDependencies": {
+    "@launchfile/macos-dev": "^0.3.0"
+  },
   "devDependencies": {
     "@biomejs/biome": "^2.4.10",
     "@types/bun": "^1.3.11",

--- a/providers/macos-dev/package.json
+++ b/providers/macos-dev/package.json
@@ -2,6 +2,9 @@
   "name": "@launchfile/macos-dev",
   "version": "0.3.0",
   "description": "macOS dev provider for Launchfile — run apps locally via brew services and native runtimes",
+  "os": [
+    "darwin"
+  ],
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
The CLI dynamically imports `@launchfile/macos-dev` but declares it in no
dependency field, so a registry install never brings it along.

## The gap, on current `main`

| Observed | Where |
|---|---|
| Four dynamic `import("@launchfile/macos-dev")` call sites | `up.ts:94`, `down.ts:34`, `status.ts:18`, `bootstrap.ts:65` |
| Declared in `dependencies` / `optionalDependencies` / `peerDependencies` | **none of them** |
| `os` field on the provider package | **absent** |

Taking the native path prints `macOS native provider not available.`
(`up.ts:120`). It is not a dead end — `up.ts:121` tells the user to run
`npm install -g @launchfile/macos-dev` — but the provider should arrive with
the CLI on the platform it supports.

## The fix

- `optionalDependencies: { "@launchfile/macos-dev": "^0.3.0" }` on the CLI
- `os: ["darwin"]` on the provider

Together: macOS installs get the provider automatically, non-macOS installs skip
it cleanly rather than failing on a package that could only fail at import.

## Why CI is unaffected

Inside the monorepo the provider resolves through a **bun workspace symlink**
(`packages/launchfile/node_modules/@launchfile/macos-dev -> ../../../../providers/macos-dev`),
not through the registry, so `os` never gates it here. `bun install
--frozen-lockfile` reports `no changes` — the install graph is identical.

## Verification

Ran CI's `CLI` job sequence locally (macOS; the ubuntu run is this PR's job):

- `sdk` install + build — OK
- `providers/docker` install + build — OK
- `packages/launchfile` `bun install --frozen-lockfile` — `Checked 202 installs across 249 packages (no changes)`
- `bun run typecheck` — clean
- `bun run build` — OK, `dist/cli.js` present
- `bun test` — **34 pass, 0 fail**

## Provenance

Salvaged from `feat/dev-mode-commands`, abandoned in June. Its spec and provider
work landed independently as **D-38** (`install` / `dev` source-mode commands and
the `source` field) — of eight candidate items on that branch and its two
descendants, five are already on `main`. This packaging pair is what was left
worth taking. The one remaining item, a source-mode `remote-claude-concentrator`
catalog entry, is not included here: its own commit subject marks it
`UNVALIDATED`, so it needs testing rather than a cherry-pick.
Versions widened `^0.2.0` → `^0.3.0` to match the sibling dependencies.
