### PR TITLE
chore: clear js/unused-local-variable alerts and enforce noUnusedLocals

### DIFF
--- a/catalog/test/src/screenshot.ts
+++ b/catalog/test/src/screenshot.ts
@@ -8,7 +8,7 @@
  * Finds the mapped port from docker compose, navigates to it, screenshots.
  */
 
-import { existsSync, mkdirSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { chromium } from "playwright";
 

--- a/catalog/test/tsconfig.json
+++ b/catalog/test/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
+    "noUnusedLocals": true,
     "noEmit": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/packages/launchfile/src/commands/up.ts
+++ b/packages/launchfile/src/commands/up.ts
@@ -11,7 +11,6 @@ import {
 	addDeployment,
 	updateDeployment,
 	findBySource,
-	deploymentDir,
 	generateDeploymentId,
 	type DeploymentEntry,
 } from "../state/index.js";

--- a/packages/launchfile/tsconfig.json
+++ b/packages/launchfile/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
+    "noUnusedLocals": true,
     "noUncheckedIndexedAccess": true,
     "isolatedModules": true,
     "declaration": true,

--- a/providers/aws/tsconfig.json
+++ b/providers/aws/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
+    "noUnusedLocals": true,
     "noUncheckedIndexedAccess": true,
     "isolatedModules": true,
     "declaration": true,

--- a/providers/docker/tsconfig.json
+++ b/providers/docker/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
+    "noUnusedLocals": true,
     "noUncheckedIndexedAccess": true,
     "isolatedModules": true,
     "declaration": true,

--- a/providers/macos-dev/src/__tests__/env-writer.test.ts
+++ b/providers/macos-dev/src/__tests__/env-writer.test.ts
@@ -5,7 +5,7 @@ import {
 	resolveComponentEnv,
 	generateSecrets,
 } from "../env-writer.js";
-import { resolveExpression, type NormalizedComponent, type NormalizedLaunch, type Secret } from "@launchfile/sdk";
+import type { NormalizedComponent, NormalizedLaunch, Secret } from "@launchfile/sdk";
 import type { ResourceProperties } from "../resources/types.js";
 import { storagePaths } from "../storage.js";
 

--- a/providers/macos-dev/tsconfig.json
+++ b/providers/macos-dev/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
+    "noUnusedLocals": true,
     "noUncheckedIndexedAccess": true,
     "isolatedModules": true,
     "declaration": true,

--- a/sdk/src/schema.ts
+++ b/sdk/src/schema.ts
@@ -64,7 +64,6 @@ const RequirementSchema = z.union([
 
 // --- Support (same shape as Requirement) ---
 
-const SupportObjectSchema = RequirementObjectSchema;
 const SupportSchema = RequirementSchema;
 
 // --- EnvVar ---

--- a/sdk/tsconfig.json
+++ b/sdk/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
+    "noUnusedLocals": true,
     "noUncheckedIndexedAccess": true,
     "isolatedModules": true,
     "declaration": true,


### PR DESCRIPTION
Removes the dead locals that CodeQL's `js/unused-local-variable` quality rule targets, and adds the compiler flag that stops them coming back.

## How the list was produced

GitHub's code-quality alerts are not exposed through the REST API — `code-scanning/alerts` returns 0 open alerts and the SARIF for the latest `main` analysis contains only the two `js/insecure-randomness` results. So the findings below come from reproducing the rule locally: `tsc --noUnusedLocals` over every tracked `.ts`/`.js`/`.mjs` file in the repo (`git ls-files` confirms nothing sits outside the tsconfig scopes plus `smoke-tests/` and `www-shared/`, both checked explicitly and both clean). The mapping to the CodeQL alerts is by rule semantics, not by reading the alert list — **unverified that this is exactly the set on the alert page**.

## The findings

All four are genuine dead code — none is a false positive worth dismissing:

| File | Symbol | Why it's dead |
|----------------------------------------------------------|-----------------------|------------------------------------------------------------------|
| `sdk/src/schema.ts:67`                                   | `SupportObjectSchema` | Alias of `RequirementObjectSchema`; grep finds no other reference and it is not in the export list |
| `providers/macos-dev/src/__tests__/env-writer.test.ts:8` | `resolveExpression`   | Imported from the SDK; the import line is its only occurrence in the file |
| `packages/launchfile/src/commands/up.ts:14`              | `deploymentDir`       | Imported from `../state/index.js`; only `down.ts:28` calls it     |
| `catalog/test/src/screenshot.ts:11`                      | `mkdirSync`           | Imported from `node:fs`; the import line is its only occurrence   |

`SupportSchema` (the alias that *is* used — `schema.ts:198`, `:229`, and the export list at `:257`) is untouched.

## The systemic part

Each affected `tsconfig.json` now sets `"noUnusedLocals": true`, so this class of finding fails `bun run typecheck` in CI rather than surfacing as a code-quality alert after merge. Applied to `sdk`, all three `providers/*`, `packages/launchfile`, and `catalog/test`. The two Astro sites are left alone — `tsc` does not parse `.astro` frontmatter, so the flag would cover only their handful of plain `.ts` files, which are already clean.

## Verification

Typecheck, build, and tests run green in every package the flag was added to:

| Package | typecheck | build | tests |
|-----------------------|-----------|-------|-----------|
| `sdk`                 | pass      | pass  | 237 pass  |
| `providers/docker`    | pass      | pass  | 85 pass   |
| `providers/macos-dev` | pass      | pass  | 89 pass   |
| `providers/aws`       | pass      | pass  | 33 pass   |
| `packages/launchfile` | pass      | pass  | 34 pass   |

`catalog/test` reports 41 `tsc` errors, all missing-Node-types noise (`TS2591`, `TS2868`, `TS2339`, `TS7006`, `TS2345`). Running the same sources against `main`'s tsconfig — i.e. without `noUnusedLocals` — produces an identical error set, so none of them come from this change. It has no `typecheck` script and `ci.yml` does not gate it. No `TS6133` remains anywhere in the repo.

## Scope note

No runtime behaviour changes — every removal is a symbol that was never read. No changeset: nothing published changes shape (`SupportObjectSchema` was never part of the public surface).

Commits are split one-per-top-level-directory per the repo's `git subtree split` convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
