### PR TITLE
sdk: carry metadata fields through the schema + parseRepository helper

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -128,6 +128,7 @@ isExpression("$$escaped");      // false (literal $)
 | `resolveExpression(value, context)` | Resolve expression against a context → string |
 | `isExpression(value)` | Check if a string contains `$` references |
 | `parseDotPath(path)` | Parse `"a.b.c"` → `["a", "b", "c"]` |
+| `parseRepository(repository)` | Split a `repository` value at its `#` fragment → `{ url, ref }` |
 | `LaunchSchema` | Zod schema for direct validation |
 
 ## Types

--- a/sdk/src/__tests__/repository.test.ts
+++ b/sdk/src/__tests__/repository.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { readLaunch } from "../reader.js";
+import { parseRepository } from "../repository.js";
+import { writeLaunch } from "../writer.js";
+
+// The metadata fields (repository/website/logo/keywords) are declared in the
+// JSON Schema and used across the catalog; the Zod schema must carry them so
+// providers can read the source origin (D-43) and round-trips preserve them.
+
+describe("parseRepository", () => {
+	it("returns the bare URL with no ref when there is no fragment", () => {
+		expect(parseRepository("https://github.com/hedgedoc/hedgedoc")).toEqual({
+			url: "https://github.com/hedgedoc/hedgedoc",
+		});
+	});
+
+	it("splits a branch fragment into url and ref", () => {
+		expect(parseRepository("https://github.com/hedgedoc/hedgedoc#develop")).toEqual({
+			url: "https://github.com/hedgedoc/hedgedoc",
+			ref: "develop",
+		});
+	});
+
+	it("accepts tag and SHA refs", () => {
+		expect(parseRepository("https://github.com/example/app#v2.1.0").ref).toBe("v2.1.0");
+		expect(parseRepository("https://github.com/example/app#a1b2c3d").ref).toBe("a1b2c3d");
+	});
+
+	it("splits at the first '#' only", () => {
+		expect(parseRepository("https://github.com/example/app#feature#x")).toEqual({
+			url: "https://github.com/example/app",
+			ref: "feature#x",
+		});
+	});
+
+	it("treats an empty fragment as no ref", () => {
+		expect(parseRepository("https://github.com/example/app#")).toEqual({
+			url: "https://github.com/example/app",
+		});
+	});
+});
+
+describe("metadata fields", () => {
+	const yaml = `
+name: my-app
+description: "An app"
+repository: https://github.com/example/my-app#main
+website: https://example.com
+logo: https://example.com/logo.png
+keywords: [blog, cms]
+image: ghcr.io/example/my-app:latest
+`;
+
+	it("carries repository, website, logo, and keywords through normalization", () => {
+		const launch = readLaunch(yaml);
+		expect(launch.repository).toBe("https://github.com/example/my-app#main");
+		expect(launch.website).toBe("https://example.com");
+		expect(launch.logo).toBe("https://example.com/logo.png");
+		expect(launch.keywords).toEqual(["blog", "cms"]);
+	});
+
+	it("preserves metadata through a read → write → read round-trip", () => {
+		const roundTripped = readLaunch(writeLaunch(readLaunch(yaml)));
+		expect(roundTripped.repository).toBe("https://github.com/example/my-app#main");
+		expect(roundTripped.website).toBe("https://example.com");
+		expect(roundTripped.logo).toBe("https://example.com/logo.png");
+		expect(roundTripped.keywords).toEqual(["blog", "cms"]);
+	});
+
+	it("leaves metadata undefined when absent", () => {
+		const launch = readLaunch("name: bare-app\nimage: x/y:1\n");
+		expect(launch.repository).toBeUndefined();
+		expect(launch.keywords).toBeUndefined();
+	});
+});

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,6 +1,8 @@
 export { cmdInspect, cmdSchema, cmdValidate } from "./commands.js";
 export { lintLaunch } from "./lint.js";
 export { readLaunch, validateLaunch } from "./reader.js";
+export { parseRepository } from "./repository.js";
+export type { RepositoryRef } from "./repository.js";
 export {
 	deriveAppUrlProperties,
 	isExpression,

--- a/sdk/src/reader.ts
+++ b/sdk/src/reader.ts
@@ -60,6 +60,10 @@ function normalizeLaunch(launch: Launch): NormalizedLaunch {
 		generator: launch.generator,
 		name: launch.name,
 		description: launch.description,
+		repository: launch.repository,
+		website: launch.website,
+		logo: launch.logo,
+		keywords: launch.keywords,
 		secrets: launch.secrets,
 		components: {},
 	};

--- a/sdk/src/repository.ts
+++ b/sdk/src/repository.ts
@@ -1,0 +1,28 @@
+/**
+ * Parse a `repository` field value into its origin URL and baseline ref.
+ *
+ * On a git-hosted URL, everything after the first `#` is a git ref — a
+ * branch, tag, or commit SHA (SPEC.md § Repository, D-43). A bare URL means
+ * the repository's default branch. The fragment rule is defined for
+ * git-hosted URLs only; callers decide whether the URL is git-hosted — this
+ * helper only splits.
+ *
+ * The baseline ref is a default, never a lock: an orchestrator-supplied
+ * source always overrides it (PROVIDERS.md § Source acquisition).
+ */
+
+export interface RepositoryRef {
+	/** Origin URL with the fragment removed */
+	url: string;
+	/** Baseline ref (branch, tag, or commit SHA); undefined = default branch */
+	ref?: string;
+}
+
+export function parseRepository(repository: string): RepositoryRef {
+	const hash = repository.indexOf("#");
+	if (hash === -1) return { url: repository };
+	const url = repository.slice(0, hash);
+	const ref = repository.slice(hash + 1);
+	if (ref === "") return { url };
+	return { url, ref };
+}

--- a/sdk/src/schema.ts
+++ b/sdk/src/schema.ts
@@ -215,6 +215,12 @@ export const LaunchSchema = z.object({
 	name: NameSchema,
 	description: z.string().max(4096).optional(),
 
+	// Metadata
+	repository: z.string().max(1024).optional(),
+	website: z.string().max(1024).optional(),
+	logo: z.string().max(1024).optional(),
+	keywords: z.array(z.string().max(128)).max(64).optional(),
+
 	// App-wide secrets
 	secrets: z.record(z.string(), SecretSchema).optional(),
 

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -320,6 +320,16 @@ export interface Launch {
 	/** Brief description */
 	description?: string;
 
+	// --- Metadata ---
+	/** Canonical source origin URL. On a git-hosted URL, a '#' fragment names the baseline ref (branch/tag/SHA) — see parseRepository() */
+	repository?: string;
+	/** Project homepage URL */
+	website?: string;
+	/** Logo image URL */
+	logo?: string;
+	/** Discovery tags for catalog listings */
+	keywords?: string[];
+
 	// --- App-wide secrets (shared across components) ---
 	/** Named secrets generated once and referenced via $secrets.name */
 	secrets?: Record<string, Secret>;
@@ -428,6 +438,14 @@ export interface NormalizedLaunch {
 	generator?: string;
 	name: string;
 	description?: string;
+	/** Canonical source origin URL, with optional '#' baseline-ref fragment — see parseRepository() */
+	repository?: string;
+	/** Project homepage URL */
+	website?: string;
+	/** Logo image URL */
+	logo?: string;
+	/** Discovery tags for catalog listings */
+	keywords?: string[];
 	/** App-wide secrets shared across components */
 	secrets?: Record<string, Secret>;
 	/** All components (single-component apps are normalized to a "default" component) */

--- a/sdk/src/writer.ts
+++ b/sdk/src/writer.ts
@@ -39,6 +39,10 @@ function denormalizeLaunch(launch: NormalizedLaunch): Record<string, unknown> {
 	if (launch.generator) result.generator = launch.generator;
 	result.name = launch.name;
 	if (launch.description) result.description = launch.description;
+	if (launch.repository) result.repository = launch.repository;
+	if (launch.website) result.website = launch.website;
+	if (launch.logo) result.logo = launch.logo;
+	if (launch.keywords && launch.keywords.length > 0) result.keywords = launch.keywords;
 	if (launch.secrets && Object.keys(launch.secrets).length > 0) result.secrets = launch.secrets;
 
 	if (isSingle) {


### PR DESCRIPTION
Follow-up from #152 (D-43), as tracked in that PR's body.

## What changed

- **`LaunchSchema`** declares the four metadata fields the JSON Schema already documents — `repository`, `website`, `logo`, `keywords`. Zod's default object semantics stripped them on parse (verified: `git log -S "repository"` over `sdk/src/schema.ts` is empty — they were never declared), so `NormalizedLaunch` returned them as `undefined` and a provider using the reference SDK could not read the app's source origin. D-43 made that gap load-bearing.
- **Reader/writer**: normalization carries the fields and denormalization writes them back, so read → write → read round-trips preserve them.
- **`parseRepository()`** (new, exported): splits a `repository` value at the first `#` into `{ url, ref }` per the D-43 fragment rule — empty fragment means no ref; callers decide git-hostedness; the baseline ref is a default the orchestrator always overrides.

## Verification

- SDK typecheck + build + **245/245** tests (8 new in `repository.test.ts`: fragment splitting incl. tag/SHA/first-`#`-only/empty-fragment cases, normalization passthrough, round-trip preservation, absent-field behavior).
- Downstream against the rebuilt SDK: providers/docker **85/85**, providers/macos-dev **89/89**, CLI **34/34**, all typechecks green.
- Verified live: `catalog/apps/wikijs`'s `repository` now flows through `readLaunch` (previously `undefined`), and `parseRepository("…hedgedoc#develop")` returns `{ url: "…hedgedoc", ref: "develop" }`.

Purely additive: no existing field changes meaning, no validation tightens beyond generous length caps, all existing tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)