### PR TITLE
chore: enable noUnusedLocals on both Astro sites

### DIFF
--- a/www-dev/tsconfig.json
+++ b/www-dev/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
+    "noUnusedLocals": true,
     "paths": {
       "@/*": ["./src/*"],
       "@shared/*": ["../www-shared/*"]

--- a/www-org/tsconfig.json
+++ b/www-org/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
+    "noUnusedLocals": true,
     "paths": {
       "@/*": ["./src/*"],
       "@shared/*": ["../www-shared/*"]


### PR DESCRIPTION
Follow-up to #153, which enabled `noUnusedLocals` on the six TypeScript packages but deliberately skipped the two Astro sites. This closes that gap.

## Why the sites were skipped, and why that reasoning was wrong

#153 left the sites alone on the grounds that `tsc` does not parse `.astro` frontmatter, so the flag would only cover their handful of plain `.ts` files. That premise is true for bare `tsc` but irrelevant here — both sites run **`astro check`** as their `typecheck` script, and `astro check` *does* typecheck `.astro` frontmatter.

Verified rather than assumed. With the flag on, planting `const CANARY_UNUSED = 42;` in `www-dev/src/pages/index.astro`:

```
src/pages/index.astro:2:7 - error ts(6133): 'CANARY_UNUSED' is declared but its value is never read.
Result (29 files): 1 error
```

Removing the canary returns the file to byte-identical with `main` and the check back to 0 errors. So the flag is live and it reaches component and page scripts, not just standalone `.ts`.

## Result

| Site | `astro check` | `build` |
|-----------|--------------------------|---------|
| `www-dev` | 0 errors (29 files)      | pass    |
| `www-org` | 0 errors (17 files)      | pass    |

No source changes — neither site had dead locals to remove. This is purely the guard, so the next one fails CI instead of landing.

## Note on the original CodeQL alerts

Both sites are clean today, and CodeQL has never reported an `.astro` path in this repo (checked every alert, all states: 19 `.ts`, 22 `.yml`, 0 `.astro`). That is consistent with the CodeQL JS extractor not handling `.astro`, but it is weak evidence — absence of alerts is not proof of absence of coverage, and I did not verify the extractor's supported-extension list. Either way this flag now covers that surface locally regardless of what CodeQL does with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
