### PR TITLE
providers: fail fast when Postgres never becomes ready

### DIFF
--- a/providers/macos-dev/src/__tests__/postgres-provisioner.test.ts
+++ b/providers/macos-dev/src/__tests__/postgres-provisioner.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { PostgresProvisioner, type ShellRunner } from "../resources/postgres.js";
+import type { NormalizedRequirement } from "@launchfile/sdk";
+import type { ProvisionOpts } from "../resources/types.js";
+
+const REQ = { type: "postgres" } as NormalizedRequirement;
+const OPTS = { appName: "my-app" } as ProvisionOpts;
+
+/**
+ * Records every command issued. `okFor` decides the exit status of shellOk
+ * calls; anything not matched succeeds, so each test states only the failure
+ * it cares about.
+ */
+function recorder(okFor: (cmd: string) => boolean = () => true) {
+	const commands: string[] = [];
+	const deps: ShellRunner = {
+		shell: async (command: string) => {
+			commands.push(command);
+			return { exitCode: 0, stdout: "", stderr: "" };
+		},
+		shellOk: async (command: string) => {
+			commands.push(command);
+			return okFor(command);
+		},
+	};
+	return { commands, deps };
+}
+
+describe("PostgresProvisioner readiness gate", () => {
+	it("throws when pg_isready does not report ready within the timeout", async () => {
+		const { deps } = recorder((cmd) => !cmd.startsWith("pg_isready --timeout"));
+		const provisioner = new PostgresProvisioner(deps);
+
+		await expect(provisioner.provision(REQ, OPTS)).rejects.toThrow(
+			/did not accept connections within 10s/,
+		);
+	});
+
+	it("issues no psql or createdb command when the server never becomes ready", async () => {
+		const { commands, deps } = recorder(
+			(cmd) => !cmd.startsWith("pg_isready --timeout"),
+		);
+		const provisioner = new PostgresProvisioner(deps);
+
+		await expect(provisioner.provision(REQ, OPTS)).rejects.toThrow();
+
+		// The point of failing fast: nothing downstream runs against a dead server.
+		expect(commands.filter((c) => c.startsWith("psql"))).toEqual([]);
+		expect(commands.filter((c) => c.startsWith("createdb"))).toEqual([]);
+	});
+
+	it("provisions the database when the server reports ready", async () => {
+		const { commands, deps } = recorder();
+		const provisioner = new PostgresProvisioner(deps);
+
+		const { properties, state } = await provisioner.provision(REQ, OPTS);
+
+		expect(commands).toContain("pg_isready --timeout=10");
+		expect(properties.name).toBe("launchfile_my_app");
+		expect(properties.user).toBe("launchfile_my_app");
+		expect(properties.host).toBe("localhost");
+		expect(properties.port).toBe(5432);
+		expect(state.dbName).toBe("launchfile_my_app");
+	});
+
+	it("skips brew startup when postgres is already running", async () => {
+		const { commands, deps } = recorder();
+		const provisioner = new PostgresProvisioner(deps);
+
+		await provisioner.provision(REQ, OPTS);
+
+		expect(commands.filter((c) => c.startsWith("brew"))).toEqual([]);
+	});
+
+	it("starts postgres via brew when it is not already running", async () => {
+		// `pg_isready -q` is the liveness probe; failing it forces the brew path,
+		// while the later `--timeout` readiness check still succeeds.
+		const { commands, deps } = recorder((cmd) => cmd !== "pg_isready -q");
+		const provisioner = new PostgresProvisioner(deps);
+
+		await provisioner.provision(REQ, OPTS);
+
+		expect(commands).toContain("brew services start postgresql");
+	});
+
+	it("defaults to the real shell when no deps are injected", () => {
+		// Guards the registry, which constructs the provisioner with no arguments.
+		expect(() => new PostgresProvisioner()).not.toThrow();
+		expect(new PostgresProvisioner().type).toBe("postgres");
+	});
+});

--- a/providers/macos-dev/src/resources/postgres.ts
+++ b/providers/macos-dev/src/resources/postgres.ts
@@ -16,16 +16,33 @@ import type { ProvisionOpts, ResourceProperties, ResourceProvisioner } from "./t
 
 const DEFAULT_PORT = 5432;
 const DEFAULT_HOST = "localhost";
+const READY_TIMEOUT_SECONDS = 10;
 
 // Security: validate identifiers before interpolating into shell/SQL commands.
 // Only alphanumeric + underscore — safe for SQL identifiers and shell args.
 const SAFE_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
+/**
+ * The shell surface this provisioner runs against. Injecting it lets tests
+ * drive the provisioning sequence without a live Postgres or Homebrew.
+ */
+export interface ShellRunner {
+	shell: typeof shell;
+	shellOk: typeof shellOk;
+}
+
 export class PostgresProvisioner implements ResourceProvisioner {
 	readonly type = "postgres";
+	readonly #shell: ShellRunner["shell"];
+	readonly #shellOk: ShellRunner["shellOk"];
+
+	constructor(deps: Partial<ShellRunner> = {}) {
+		this.#shell = deps.shell ?? shell;
+		this.#shellOk = deps.shellOk ?? shellOk;
+	}
 
 	async isRunning(): Promise<boolean> {
-		return shellOk("pg_isready -q");
+		return this.#shellOk("pg_isready -q");
 	}
 
 	async provision(
@@ -37,16 +54,26 @@ export class PostgresProvisioner implements ResourceProvisioner {
 		if (!(await this.isRunning())) {
 			console.log("  Starting PostgreSQL via brew...");
 			// Try to start; if not installed, install first
-			const started = await shellOk("brew services start postgresql");
+			const started = await this.#shellOk("brew services start postgresql");
 			if (!started) {
 				// Try versioned formula
-				await shell("brew install postgresql@16");
-				await shell("brew services start postgresql@16");
+				await this.#shell("brew install postgresql@16");
+				await this.#shell("brew services start postgresql@16");
 			}
 		}
 
-		// Wait for ready
-		await shell("pg_isready --timeout=10", { allowFailure: true });
+		// pg_isready blocks until the server answers or the timeout expires, so a
+		// false here means Postgres never came up — every psql call below would
+		// fail with a connection error that says nothing about the real cause.
+		const ready = await this.#shellOk(
+			`pg_isready --timeout=${READY_TIMEOUT_SECONDS}`,
+		);
+		if (!ready) {
+			throw new Error(
+				`PostgreSQL did not accept connections within ${READY_TIMEOUT_SECONDS}s. ` +
+					`Check \`brew services list\` and \`pg_isready\`.`,
+			);
+		}
 
 		// Determine database and user names
 		const resourceName = req.name ?? req.type;
@@ -57,18 +84,18 @@ export class PostgresProvisioner implements ResourceProvisioner {
 		const port = DEFAULT_PORT;
 
 		// Create user (idempotent)
-		await shell(
+		await this.#shell(
 			`psql -h ${DEFAULT_HOST} -p ${port} postgres -c "DO \\$\\$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '${user}') THEN CREATE ROLE ${user} WITH LOGIN PASSWORD '${password}' CREATEDB; END IF; END \\$\\$;"`,
 			// silent: this command embeds the generated DB password; don't echo it (CWE-532).
 			{ allowFailure: true, silent: true },
 		);
 
 		// Create database (idempotent)
-		const dbExists = await shellOk(
+		const dbExists = await this.#shellOk(
 			`psql -h ${DEFAULT_HOST} -p ${port} postgres -tAc "SELECT 1 FROM pg_database WHERE datname='${dbName}'"`,
 		);
 		if (!dbExists) {
-			await shell(
+			await this.#shell(
 				`createdb -h ${DEFAULT_HOST} -p ${port} -O ${user} ${dbName}`,
 				{ allowFailure: true },
 			);
@@ -85,7 +112,7 @@ export class PostgresProvisioner implements ResourceProvisioner {
 					console.warn(`  Skipping invalid extension name: ${ext}`);
 					continue;
 				}
-				await shell(
+				await this.#shell(
 					`psql -h ${DEFAULT_HOST} -p ${port} ${dbName} -c "CREATE EXTENSION IF NOT EXISTS \\"${ext}\\";"`,
 					{ allowFailure: true },
 				);
@@ -119,12 +146,12 @@ export class PostgresProvisioner implements ResourceProvisioner {
 	async destroy(state: ResourceState): Promise<void> {
 		// Security: state values come from disk (state.json) — validate before SQL interpolation
 		if (state.dbName && SAFE_IDENTIFIER.test(state.dbName)) {
-			await shell(`dropdb -h ${DEFAULT_HOST} --if-exists ${state.dbName}`, {
+			await this.#shell(`dropdb -h ${DEFAULT_HOST} --if-exists ${state.dbName}`, {
 				allowFailure: true,
 			});
 		}
 		if (state.user && SAFE_IDENTIFIER.test(state.user)) {
-			await shell(
+			await this.#shell(
 				`psql -h ${DEFAULT_HOST} postgres -c "DROP ROLE IF EXISTS ${state.user};"`,
 				{ allowFailure: true },
 			);


### PR DESCRIPTION
Picks up the one hunk removed from #161, this time with tests behind it.

## The behaviour

`pg_isready --timeout=10` blocks until the server answers or the timeout expires. Its exit code was being discarded:

```ts
await shell("pg_isready --timeout=10", { allowFailure: true });
```

So when Postgres never came up, provisioning carried on and every `psql` call below failed with a connection error that said nothing about the real cause. This checks the result and stops with one message naming the next command to run.

This was originally bundled into #161 as a "code quality" fix. It is a behaviour change, so it belongs on its own with a test — that is what this is.

## Why the constructor changed

Nothing could test `provision()`: it reaches `shell`/`shellOk` through module imports, and the suite has no shell-mocking setup. Rather than add `vi.mock`, the provisioner now takes its shell surface through the constructor, defaulting to the real implementations:

```ts
constructor(deps: Partial<ShellRunner> = {}) {
    this.#shell = deps.shell ?? shell;
    this.#shellOk = deps.shellOk ?? shellOk;
}
```

`resources/index.ts` constructs it with no arguments and is unaffected — there is a test asserting that path still works. This follows the repo's preference for dependency injection over module mocking, and it makes the whole provisioning sequence testable, not just this one branch.

## Verification

The two readiness tests were confirmed to fail against the old tolerant behaviour before being kept — temporarily restoring `allowFailure: true`:

```
× throws when pg_isready does not report ready within the timeout
× issues no psql or createdb command when the server never becomes ready
AssertionError: promise resolved "{ properties: { …(6) }, …(1) }" instead of rejecting
Tests  2 failed | 4 passed (6)
```

With the fix in place: `typecheck` clean, `build` clean, **95/95 tests pass** (up from 89 — 6 new).

The four non-readiness tests pass either way; they cover the surrounding sequence (brew skip/start, generated identifiers) so the injection seam does not go untested.

## Note on ordering

This branches from `main`, not from #161. The two touch adjacent lines in `provision()`, so whichever merges second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
