### PR TITLE
sdk: carry the D-30 storage size hint through parse (P-5 conformance)

### DIFF
--- a/sdk/src/__tests__/reader-writer.test.ts
+++ b/sdk/src/__tests__/reader-writer.test.ts
@@ -226,6 +226,34 @@ storage:
 		});
 	});
 
+	it("reads the D-30 size hint the published schema defines", () => {
+		const result = readLaunch(`
+name: my-app
+storage:
+  data:
+    path: /data
+    size: 10GB
+    persistent: true
+`);
+		expect(result.components.default?.storage?.data).toEqual({
+			path: "/data",
+			size: "10GB",
+			persistent: true,
+		});
+	});
+
+	it("carries the size hint through parse → serialize", () => {
+		const yaml = `version: launch/v1
+name: my-app
+image: nginx
+storage:
+  data:
+    path: /data
+    size: 512MB
+`;
+		expect(writeLaunch(readLaunch(yaml))).toContain("size: 512MB");
+	});
+
 	// Secrets
 	it("reads secrets block and passes to normalized output", () => {
 		const result = readLaunch(`

--- a/sdk/src/schema.ts
+++ b/sdk/src/schema.ts
@@ -156,6 +156,10 @@ const CommandsSchema = z.record(z.string(), CommandValueSchema);
 
 const StorageVolumeSchema = z.object({
 	path: z.string().max(1024),
+	// D-30 size hint. Declared in the published JSON Schema; omitting it here
+	// meant zod's strip mode deleted it on every parse, so a documented field
+	// silently vanished through parse → serialize.
+	size: z.string().max(256).optional(),
 	persistent: z.boolean().optional(),
 });
 

--- a/sdk/src/schema.ts
+++ b/sdk/src/schema.ts
@@ -156,9 +156,9 @@ const CommandsSchema = z.record(z.string(), CommandValueSchema);
 
 const StorageVolumeSchema = z.object({
 	path: z.string().max(1024),
-	// D-30 size hint. Declared in the published JSON Schema; omitting it here
-	// meant zod's strip mode deleted it on every parse, so a documented field
-	// silently vanished through parse → serialize.
+	// D-30 size hint. Every field the published JSON Schema declares must be
+	// listed here too: zod strips unlisted keys, so an omission silently
+	// deletes a documented field through parse → serialize.
 	size: z.string().max(256).optional(),
 	persistent: z.boolean().optional(),
 });

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -242,6 +242,8 @@ export interface Host {
 export interface StorageVolume {
 	/** Mount path inside the container */
 	path: string;
+	/** Minimum size hint, e.g. "512MB", "10GB" (D-30) */
+	size?: string;
 	/** Whether data should survive restarts */
 	persistent?: boolean;
 }


### PR DESCRIPTION
`$defs.storageVolume` in the published JSON Schema defines `size` as a minimum-size hint (D-30). `StorageVolumeSchema` never listed it, and zod strips unknown keys by default — so every parse deleted the field, with no diagnostic either way.

Two normative artifacts disagreeing about the same input is what **P-5** forbids: the same file does not translate the same way through the published schema and the reference parser.

## Before / after

```yaml
storage:
  data:
    path: /data
    size: 10GB
    persistent: true
```

| | `size` survives `parse → serialize`? |
|---|---|
| before | **no** — silently deleted |
| after | yes |

Reader and writer already pass `storage` through wholesale, so listing the field on the schema and the type is the whole fix.

## Provenance

Found while investigating unknown-field preservation (#171). The steward's verdict on that RFC asked for it to be split, and identified this half as a plain conformance bug needing no `D-*`:

> **A** — Bug: SDK ↔ JSON Schema conformance. Add `size` to `StorageVolumeSchema` (`sdk/src/schema.ts:157`). Pure `P-5` conformance. — *Needs a `D-*`? No*
> A is shippable today with no Author decision.

So it lands on its own rather than waiting on the preservation RFC. This PR is **only** step A — it takes no position on whether unknown fields should be preserved, opens no `$defs`, and changes no validation behavior for any other field.

## Tests

Two added: one that the hint is read, one that it survives the round-trip. Both fail on `main`.

- sdk 247/247
- providers/docker 85/85
- providers/macos-dev 95/95
- packages/launchfile 34/34
