### PR TITLE
chore: run CI on every pull request, not only those based on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,13 @@
 name: CI
 
 on:
+  # Every pull request, whatever its base. A base filter of [main] silently
+  # skips stacked PRs, which merge into a sibling branch and inherit no run
+  # from it: GitHub retargets an open PR when its base merges, but that fires
+  # `pull_request.edited`, which is not a default trigger type. Nothing holds
+  # the filter up on the other side either — CI reads no secret and carries a
+  # read-only token, so a run costs minutes and nothing else.
   pull_request:
-    branches: [main]
 
 # Least privilege: every job here only reads the checked-out code (build/test/
 # validate). No job writes to the repo, comments, or deploys, so the workflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,11 @@ name: CI
 on:
   # Every pull request, whatever its base. A base filter of [main] silently
   # skips stacked PRs, which merge into a sibling branch and inherit no run
-  # from it: GitHub retargets an open PR when its base merges, but that fires
-  # `pull_request.edited`, which is not a default trigger type. Nothing holds
-  # the filter up on the other side either — CI reads no secret and carries a
-  # read-only token, so a run costs minutes and nothing else.
+  # from it. Retargeting does not rescue them either: with no `types:` key
+  # this runs on `opened`, `synchronize`, and `reopened` only, and a base
+  # change is none of the three (`synchronize` tracks the head branch).
+  # Nothing holds the filter up on the other side — CI reads no secret and
+  # carries a read-only token, so a run costs minutes and nothing else.
   pull_request:
 
 # Least privilege: every job here only reads the checked-out code (build/test/


### PR DESCRIPTION
Removes the `branches: [main]` filter from the CI trigger, so every pull request gets a run regardless of its base.

## The problem

A PR based on a sibling branch gets **no CI at all**. #177 is the live example:

```
$ gh pr view 177 --json baseRefName,statusCheckRollup
{ "baseRefName": "chore/gov-resource-registry", "statusCheckRollup": [] }
```

Its base is another branch, so `ci.yml` never fired. That PR changes the AWS provider's emitted Terraform — resource type (`random_password` → `random_bytes`), attribute (`.result` → `.hex`), and provider constraint (`~> 3.0` → `~> 3.6`) — which is precisely what `aws-terraform-validate` exists to catch. Its own comment makes the case:

> This is the conformance gate the unit tests can't give us: they assert structure, `terraform validate` asserts the output actually parses.

That gate has not run on it.

## Retargeting does not rescue it

A workflow that specifies no `types:` runs on three activity types only. GitHub's wording:

> By default, a workflow only runs when a `pull_request` event's activity type is `opened`, `synchronize`, or `reopened`.

Changing a pull request's base is none of the three — `synchronize` tracks updates to the *head* branch. So when the base merges and GitHub retargets the open PR onto `main`, no run starts until someone pushes. (Which activity type a retarget emits is not something I could confirm from the published docs, and it does not matter here: none of the three defaults describe it.)

Nothing holds the filter up on the other side either. `main` is currently unprotected — `GET /repos/launchfile/launchfile/branches/main/protection` returns `404 Branch not protected` — so no required check stands in the way. The stack can reach `main` having never been built.

## Why dropping the filter, rather than widening it

Adding base-branch patterns works until the next branch naming convention. Removing the filter costs nothing on the other side: no job in this workflow reads a secret (the only repository secrets, `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`, are referenced solely by `deploy-dev.yml` and `deploy-org.yml`, both `push: main` / `workflow_dispatch`), and the workflow token is `contents: read`. A run costs Actions minutes and nothing else.

`on.pull_request` with no value is the documented form for "all activity types, all branches". The `Workflow Lint` job — the strict Python `yaml.safe_load` pass over `.github/workflows/*.yml` — is green on this PR, so the edited file parses under the checker that actually guards it.

## Scope

This is the CI-trigger half of #187. The repository-settings half — enabling the existing `Protect main` ruleset and requiring these checks — needs an admin and is tracked there.

**Sequencing note:** land this before enabling required checks on `main`. Until it merges, no stacked PR produces those check runs, so requiring them would block the open `gov-*` queue on checks that cannot report.

Refs #187
