### PR TITLE
spec: say what the D-50 slot is actually reserved for

### DIFF
--- a/spec/DESIGN.md
+++ b/spec/DESIGN.md
@@ -566,7 +566,9 @@ Composition rule: a *derived* expression over a *minted* input — the `APP_KEY:
 
 ### D-50: Reserved — no decision recorded
 
-**Status**: Reserved; no decision recorded. No proposal claims this number — it was vacated while [#196](https://github.com/launchfile/launchfile/pull/196) was open, when the decision now recorded as D-51 was renumbered twice (D-43 → D-50 → D-51) to clear numbers already claimed by other decisions and to match the number [#197](https://github.com/launchfile/launchfile/pull/197) carries for it. The number is held rather than reused so the published list stays stable.
+**Status**: Reserved; no decision recorded. The proposal that would occupy this slot — host mounts for operator-supplied storage content — was **rejected as shaped**: it declared a host path (`storage.<name>.source`) in the file, which fails [P-1](#p-1-app-focused-not-infra-focused)'s portability test and places a home-#2 value ([D-36](#d-36-the-three-homes-of-a-varying-value-p-1-litmus-refinement)) in the app's own file. A reshaped successor — declaring *intent* that content is operator-provided, with the path bound by the orchestrator and refusal when unbound — is tracked in [#207](https://github.com/launchfile/launchfile/issues/207) and is intended for this number.
+
+The number was also transiently held by the decision now recorded as [D-51](#d-51-unexecuted-schedule-is-reported-loudly-not-silently-accepted), which was renumbered twice (D-43 → D-50 → D-51) to clear numbers other decisions had already claimed. It is held rather than reused so the published list stays stable.
 
 ---
 


### PR DESCRIPTION
Corrects the `D-50` placeholder, which described the slot as unclaimed.

## The problem

The entry read:

> No proposal claims this number — it was vacated while #196 was open, when the decision now recorded as D-51 was renumbered twice.

That is accurate about D-51's renumbering and wrong about the slot. A proposal does claim D-50: host mounts for operator-supplied storage content (`storage.<name>.source` + `readonly`). It was **rejected as shaped**, and a reshaped successor is intended for the same number.

As published, the next person reading the decision list would reasonably conclude D-50 is free and reuse it.

## The fix

The entry now states:

- what was proposed and why it was rejected — a host path in the file fails P-1's portability test and puts a D-36 home-#2 value in the app's own file
- that a reshaped successor is intended for this number, linked to **#207**
- the D-51 renumbering, kept as secondary history rather than the whole story

This matches how **D-45** already records its own deferred slot: it names issue #171 and says the number is held pending rework.

## Scope

Prose only. No schema, no field, no code. `www-org` auto-renders `DESIGN.md`, so the corrected text publishes with no site change.
