### PR TITLE
Potential fix for code scanning alert no. 53: Insecure randomness

### DIFF
--- a/providers/docker/src/compose-generator.ts
+++ b/providers/docker/src/compose-generator.ts
@@ -63,7 +63,19 @@ function generateUuid(): string {
 }
 
 function generatePort(): string {
-	return String(10000 + Math.floor(Math.random() * 55000));
+	const min = 10000;
+	const range = 55000; // 10000..64999
+	const maxUint32 = 0x100000000;
+	const limit = maxUint32 - (maxUint32 % range); // avoid modulo bias
+
+	const buf = new Uint32Array(1);
+	let n: number;
+	do {
+		crypto.getRandomValues(buf);
+		n = buf[0]!;
+	} while (n >= limit);
+
+	return String(min + (n % range));
 }
 
 /**


### PR DESCRIPTION
Potential fix for [https://github.com/launchfile/launchfile/security/code-scanning/53](https://github.com/launchfile/launchfile/security/code-scanning/53)

Use a cryptographically secure random source for `generatePort()` instead of `Math.random()`.  
Best fix with minimal functional change: keep the same port range (`10000` to `64999`, size `55000`) and use rejection sampling with `crypto.getRandomValues` to avoid modulo bias when mapping random bytes to that range.

Edit only `providers/docker/src/compose-generator.ts`, replacing the body of `generatePort()`.

No new dependencies are needed; the file already uses `crypto.getRandomValues`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
