### PR TITLE
Potential fix for code scanning alert no. 11: Unsafe shell command constructed from library input

### DIFF
--- a/providers/docker/src/state.ts
+++ b/providers/docker/src/state.ts
@@ -56,8 +56,21 @@ export function composePath(slug: string): string {
 	return join(stateDir(slug), "docker-compose.yml");
 }
 
+const SAFE_SLUG_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+const MAX_SLUG_LENGTH = 63;
+
+function normalizeSlugForProject(slug: string): string {
+	const normalized = slug.trim().toLowerCase();
+	if (!normalized || normalized.length > MAX_SLUG_LENGTH || !SAFE_SLUG_PATTERN.test(normalized)) {
+		throw new Error(
+			`Invalid slug "${slug}". Expected lowercase letters/digits/hyphens, max ${MAX_SLUG_LENGTH} chars.`,
+		);
+	}
+	return normalized;
+}
+
 export function composeProject(slug: string): string {
-	return `launchfile-${slug}`;
+	return `launchfile-${normalizeSlugForProject(slug)}`;
 }
 
 function hashContent(content: string): string {


### PR DESCRIPTION
Potential fix for [https://github.com/launchfile/launchfile/security/code-scanning/11](https://github.com/launchfile/launchfile/security/code-scanning/11)

General fix: **validate and canonicalize the Docker compose project-name input** before embedding it into command arguments. Centralize this in `composeProject(slug)` so all existing call sites inherit the protection without behavioral drift elsewhere.

Best concrete fix here: in `providers/docker/src/state.ts`, add strict slug normalization/validation used by `composeProject`:
- Trim + lowercase the slug.
- Enforce a conservative allowlist pattern (`^[a-z0-9][a-z0-9-]*$`) and length bound.
- Throw on invalid input.
- Build project name from validated slug only.

This preserves existing functionality for valid slugs while preventing unsafe/invalid project names from propagating to all Docker command invocations (`up/down/status/logs/bootstrap`) and addresses all alert variants at one source.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
