### PR TITLE
providers: preserve env-level generator values across runs (D-49)

### DIFF
--- a/providers/docker/src/__tests__/compose-generator.test.ts
+++ b/providers/docker/src/__tests__/compose-generator.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { parse } from "yaml";
 import { readLaunch } from "@launchfile/sdk";
 import { launchToCompose } from "../compose-generator.js";
 
@@ -426,6 +427,131 @@ secrets:
 		expect(result.secrets["session-id"]).toMatch(
 			/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
 		);
+	});
+});
+
+describe("env-level generator preservation (D-49, #186)", () => {
+	const appYaml = `
+name: envgen
+image: nginx
+env:
+  APP_KEY:
+    generator: secret
+`;
+
+	function envOf(yamlText: string, service: string): Record<string, string> {
+		const doc = parse(yamlText) as {
+			services: Record<string, { environment?: Record<string, string> }>;
+		};
+		return doc.services[service]?.environment ?? {};
+	}
+
+	it("reuses the persisted value instead of re-minting when state holds one", () => {
+		const launch = readLaunch(appYaml);
+		const generatedEnv = { "default.APP_KEY": "a".repeat(64) };
+
+		const result = launchToCompose(launch, { generatedEnv });
+
+		expect(envOf(result.yaml, "envgen").APP_KEY).toBe("a".repeat(64));
+		expect(result.generatedEnv).toEqual({ "default.APP_KEY": "a".repeat(64) });
+	});
+
+	it("mints and returns the value for persistence when state holds none", () => {
+		const launch = readLaunch(appYaml);
+
+		const result = launchToCompose(launch, {});
+
+		const value = envOf(result.yaml, "envgen").APP_KEY!;
+		expect(value).toMatch(/^[0-9a-f]{64}$/);
+		// result.generatedEnv is what provider.ts writes back to state before
+		// saveState — the write-back is the invariant, not just the env value.
+		expect(result.generatedEnv["default.APP_KEY"]).toBe(value);
+	});
+
+	it("does not persist `generator: port` and does not read a stale port from the store", () => {
+		const launch = readLaunch(`
+name: envgen
+image: nginx
+env:
+  APP_PORT:
+    generator: port
+`);
+		// Even a (never-written-by-us) port entry in the store is ignored —
+		// the port branch re-allocates unconditionally.
+		const generatedEnv: Record<string, string> = { "default.APP_PORT": "1" };
+
+		const result = launchToCompose(launch, { generatedEnv });
+
+		const value = envOf(result.yaml, "envgen").APP_PORT!;
+		expect(String(value)).toMatch(/^\d+$/);
+		expect(String(value)).not.toBe("1");
+		expect(result.generatedEnv["default.APP_PORT"]).toBe("1"); // untouched, never re-written
+	});
+
+	it("preserves `generator: uuid` values across calls", () => {
+		const launch = readLaunch(`
+name: envgen
+image: nginx
+env:
+  INSTANCE_ID:
+    generator: uuid
+`);
+		const generatedEnv: Record<string, string> = {};
+
+		const first = envOf(launchToCompose(launch, { generatedEnv }).yaml, "envgen").INSTANCE_ID!;
+		expect(first).toMatch(/^[0-9a-f-]{36}$/);
+
+		const second = envOf(launchToCompose(launch, { generatedEnv }).yaml, "envgen").INSTANCE_ID!;
+		expect(second).toBe(first);
+	});
+
+	it("does not leak env-level values into $secrets.*", () => {
+		const launch = readLaunch(`
+name: envgen
+image: nginx
+env:
+  APP_KEY:
+    generator: secret
+  LEAK_CHECK:
+    default: "$secrets.APP_KEY"
+`);
+		const result = launchToCompose(launch, {});
+
+		const env = envOf(result.yaml, "envgen");
+		expect(env.APP_KEY).toMatch(/^[0-9a-f]{64}$/);
+		// APP_KEY is declared only under env:, so it is not a secrets name —
+		// the reference resolves to empty, and result.secrets stays clean.
+		expect(env.LEAK_CHECK ?? "").toBe("");
+		expect(result.secrets.APP_KEY).toBeUndefined();
+	});
+
+	it("keys per component: same variable name on two components stays independent and stable", () => {
+		const launch = readLaunch(`
+name: envgen2
+components:
+  web:
+    image: nginx
+    env:
+      SHARED_KEY:
+        generator: secret
+  worker:
+    image: nginx
+    env:
+      SHARED_KEY:
+        generator: secret
+`);
+		const generatedEnv: Record<string, string> = {};
+
+		const r1 = launchToCompose(launch, { generatedEnv });
+		const web1 = envOf(r1.yaml, "envgen2-web").SHARED_KEY!;
+		const worker1 = envOf(r1.yaml, "envgen2-worker").SHARED_KEY!;
+		expect(web1).not.toBe(worker1); // two declarations, two mintings (D-25)
+		expect(r1.generatedEnv["web.SHARED_KEY"]).toBe(web1);
+		expect(r1.generatedEnv["worker.SHARED_KEY"]).toBe(worker1);
+
+		const r2 = launchToCompose(launch, { generatedEnv });
+		expect(envOf(r2.yaml, "envgen2-web").SHARED_KEY).toBe(web1);
+		expect(envOf(r2.yaml, "envgen2-worker").SHARED_KEY).toBe(worker1);
 	});
 });
 

--- a/providers/docker/src/__tests__/env-generator-lifecycle.test.ts
+++ b/providers/docker/src/__tests__/env-generator-lifecycle.test.ts
@@ -35,7 +35,10 @@ async function readState(slug: string): Promise<DockerState> {
 	return JSON.parse(await readFile(join(stateDir(slug), "state.json"), "utf8")) as DockerState;
 }
 
-describe.runIf(prereqs.ok)("env-level generator lifecycle — real up/down (D-49, #186)", () => {
+// describe.runIf is a vitest-only API; CI's bun test runner doesn't provide it.
+const describeIfPrereqsOk = prereqs.ok ? describe : describe.skip;
+
+describeIfPrereqsOk("env-level generator lifecycle — real up/down (D-49, #186)", () => {
 	let dir: string;
 	let slug: string | undefined;
 

--- a/providers/docker/src/__tests__/env-generator-lifecycle.test.ts
+++ b/providers/docker/src/__tests__/env-generator-lifecycle.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Behavioral coverage for env-level generator preservation (D-49, #186):
+ * two consecutive REAL `launchfile up` runs must give the container the same
+ * minted value, through the actual saveState → loadState → reuse path that
+ * pure `launchToCompose` tests stub out. A --dry-run pair proves nothing here:
+ * dry-run returns before saveState.
+ *
+ * Uses a dedicated tiny app (alpine + sleep) under the compose project
+ * `launchfile-gov23-envgen`, torn down via the provider's own destroy path.
+ * Skipped when Docker is not available — the rest of the suite stays runnable
+ * anywhere.
+ */
+
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { checkPrereqs } from "../prereqs.js";
+import { dockerDown, dockerUp } from "../provider.js";
+import { composePath, stateDir, type DockerState } from "../state.js";
+
+const prereqs = await checkPrereqs();
+
+const LAUNCHFILE = `version: launch/v1
+name: gov23-envgen
+image: alpine:3.20
+commands:
+  start: sleep 300
+env:
+  GOV23_TOKEN:
+    generator: secret
+`;
+
+async function readState(slug: string): Promise<DockerState> {
+	return JSON.parse(await readFile(join(stateDir(slug), "state.json"), "utf8")) as DockerState;
+}
+
+describe.runIf(prereqs.ok)("env-level generator lifecycle — real up/down (D-49, #186)", () => {
+	let dir: string;
+	let slug: string | undefined;
+
+	beforeAll(async () => {
+		dir = await mkdtemp(join(tmpdir(), "gov23-envgen-"));
+		await writeFile(join(dir, "Launchfile"), LAUNCHFILE);
+	});
+
+	afterAll(async () => {
+		// Safety net if the test failed mid-way: remove the containers and
+		// state we created, via the provider's own destroy path. Touches only
+		// the launchfile-gov23-envgen compose project.
+		if (slug) await dockerDown({ slug, destroy: true }).catch(() => {});
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	it("preserves the value across down + a second real up; destroy discards it", async () => {
+		// Run 1: mints and persists.
+		const up1 = await dockerUp(dir, {});
+		slug = up1.slug;
+		expect(slug).toBe("gov23-envgen");
+
+		const state1 = await readState(slug);
+		const first = state1.generatedEnv?.["default.GOV23_TOKEN"];
+		expect(first).toMatch(/^[0-9a-f]{64}$/);
+		// The running container's compose file carries the same value.
+		expect(await readFile(composePath(slug), "utf8")).toContain(first!);
+
+		// `down` (no --destroy) preserves the value.
+		await dockerDown({ slug });
+		expect((await readState(slug)).generatedEnv?.["default.GOV23_TOKEN"]).toBe(first);
+
+		// Run 2: a real second `up` reuses it — saveState → loadState → reuse.
+		await dockerUp(dir, {});
+		expect((await readState(slug)).generatedEnv?.["default.GOV23_TOKEN"]).toBe(first);
+		expect(await readFile(composePath(slug), "utf8")).toContain(first!);
+
+		// `down --destroy` discards the value with the rest of the state dir.
+		await dockerDown({ slug, destroy: true });
+		await expect(stat(stateDir(slug))).rejects.toThrow();
+		// Destroyed — the afterAll safety net must not run dockerDown again
+		// (a missing state makes it process.exit(1), killing the worker).
+		slug = undefined;
+	}, 300_000);
+});

--- a/providers/docker/src/__tests__/state.test.ts
+++ b/providers/docker/src/__tests__/state.test.ts
@@ -10,6 +10,7 @@ import {
 	stateDir,
 	type DockerState,
 } from "../state.js";
+import { clearRegisteredSecrets, redactSecrets, REDACTED } from "../redact.js";
 
 // state.ts keys everything off homedir() → ~/.launchfile/docker/<slug>.
 // node:os.homedir() honors $HOME on POSIX, so redirect it to a temp dir to
@@ -102,5 +103,45 @@ describe("docker state — backward compatibility", () => {
 		expect(src).not.toBeNull();
 		expect(src!.slug).toBe("legacy");
 		expect(src!.sourcePath).toBeUndefined();
+	});
+
+	it("loads a state file without a generatedEnv key and behaves as a first run (D-49)", async () => {
+		const state = initState("older", "older", "name: older\n");
+		expect("generatedEnv" in state).toBe(false);
+		await saveState("older", state);
+
+		const loaded = await loadState("older");
+		expect(loaded).not.toBeNull();
+		expect(loaded!.generatedEnv).toBeUndefined();
+		// launchToCompose defaults with `?? {}` — an empty store means "mint".
+		expect(loaded!.generatedEnv ?? {}).toEqual({});
+	});
+});
+
+describe("docker state — env-level generator values (D-49, #186)", () => {
+	afterEach(() => {
+		clearRegisteredSecrets();
+	});
+
+	it("round-trips the generatedEnv store", async () => {
+		const state = initState("envgen", "envgen", "name: envgen\n");
+		state.generatedEnv = { "default.APP_KEY": "b".repeat(64) };
+		await saveState("envgen", state);
+
+		const loaded = await loadState("envgen");
+		expect(loaded!.generatedEnv).toEqual({ "default.APP_KEY": "b".repeat(64) });
+	});
+
+	it("registers reloaded generatedEnv values with the redactor (D-18)", async () => {
+		const value = "c".repeat(64);
+		const state = initState("envgen", "envgen", "name: envgen\n");
+		state.generatedEnv = { "default.APP_KEY": value };
+		await saveState("envgen", state);
+
+		// A second process reuses (never re-mints) the value, so nothing but
+		// the loader can make it scrubbable in that process.
+		clearRegisteredSecrets();
+		await loadState("envgen");
+		expect(redactSecrets(`token=${value}`)).toBe(`token=${REDACTED}`);
 	});
 });

--- a/providers/docker/src/compose-generator.ts
+++ b/providers/docker/src/compose-generator.ts
@@ -395,6 +395,11 @@ function computeAppProperties(
 export interface ComposeOpts {
 	/** Pre-existing secrets to reuse (mutated with new secrets) */
 	secrets?: Record<string, string>;
+	/**
+	 * Persisted `env:`-level generator values to reuse, keyed
+	 * `<component>.<ENV_NAME>` (mutated with newly minted values).
+	 */
+	generatedEnv?: Record<string, string>;
 	/** Host port overrides, keyed by component name */
 	hostPorts?: Record<string, number>;
 	/** Docker network name */
@@ -412,6 +417,8 @@ export interface ComposeResult {
 	builds: string[];
 	/** Secrets generated during composition (save to state) */
 	secrets: Record<string, string>;
+	/** `env:`-level generator values minted or reused during composition (save to state) */
+	generatedEnv: Record<string, string>;
 	/** Map of component name → exposed host port */
 	ports: Record<string, number>;
 	/** Map of component name → generated compose service name (skipped components absent) */
@@ -428,6 +435,7 @@ export function launchToCompose(
 	const services: Record<string, Record<string, unknown>> = {};
 	const volumes: Record<string, Record<string, unknown>> = {};
 	const secrets = opts.secrets ?? {};
+	const generatedEnv = opts.generatedEnv ?? {};
 	const ports: Record<string, number> = {};
 	const componentServices: Record<string, string> = {};
 
@@ -596,7 +604,7 @@ export function launchToCompose(
 
 		if (component.env) {
 			for (const [key, envVar] of Object.entries(component.env)) {
-				const value = resolveEnvVar(envVar, componentContext, key);
+				const value = resolveEnvVar(envVar, componentContext, key, componentName, generatedEnv);
 				if (value !== undefined) {
 					env[key] = value;
 				}
@@ -711,6 +719,7 @@ export function launchToCompose(
 		images: [...new Set(images)],
 		builds,
 		secrets,
+		generatedEnv,
 		ports,
 		services: componentServices,
 	};
@@ -721,12 +730,28 @@ export function launchToCompose(
 function resolveEnvVar(
 	envVar: NormalizedEnvVar,
 	context: ResolverContext,
-	key?: string,
+	key: string,
+	componentName: string,
+	generatedEnv: Record<string, string>,
 ): string | undefined {
 	if (envVar.generator) {
-		if (envVar.generator === "secret") return generateSecret();
-		if (envVar.generator === "uuid") return generateUuid();
+		// `port` is exempt from preservation (D-49): ports are re-allocated
+		// each run, and a preserved port produces a bind conflict rather than
+		// continuity.
 		if (envVar.generator === "port") return generatePort();
+
+		// Minted values are preserved (D-49): reuse the value state holds,
+		// mint and record otherwise. Keyed per declaration
+		// (`<component>.<ENV_NAME>`, D-25) — never by bare variable name — so
+		// same-named variables on different components stay independent, and
+		// kept out of `secrets` so these names never resolve as
+		// `$secrets.<name>`.
+		const stateKey = `${componentName}.${key}`;
+		const existing = generatedEnv[stateKey];
+		if (existing !== undefined) return existing;
+		const value = envVar.generator === "secret" ? generateSecret() : generateUuid();
+		generatedEnv[stateKey] = value;
+		return value;
 	}
 
 	if (envVar.default !== undefined) {

--- a/providers/docker/src/provider.ts
+++ b/providers/docker/src/provider.ts
@@ -161,6 +161,7 @@ export async function dockerUp(source: string, opts: DockerUpOpts = {}): Promise
 		// Generate compose
 		const result = launchToCompose(launch, {
 			secrets: state.secrets,
+			generatedEnv: state.generatedEnv,
 			hostPorts,
 			projectDir: resolved.dir,
 		});
@@ -179,6 +180,7 @@ export async function dockerUp(source: string, opts: DockerUpOpts = {}): Promise
 
 		// Update state
 		state.secrets = result.secrets;
+		state.generatedEnv = result.generatedEnv;
 		state.ports = result.ports;
 
 		const upResult: DockerUpResult = {

--- a/providers/docker/src/state.ts
+++ b/providers/docker/src/state.ts
@@ -25,6 +25,18 @@ export interface DockerState {
 	secrets: Record<string, string>;
 	ports: Record<string, number>;
 	/**
+	 * Minted `env:`-level generator values (D-49: generate once, then
+	 * preserve), keyed `<component>.<ENV_NAME>` — one entry per declaration
+	 * (D-25), so same-named variables on different components hold independent
+	 * values. `generator: port` values are never stored here (ports are
+	 * re-allocated each run). Kept disjoint from `secrets`, which is already a
+	 * shared namespace of declared secret names and backing-service password
+	 * keys — env-var names must not join it or become resolvable as
+	 * `$secrets.<name>`. Optional for backward compatibility: older state
+	 * files omit it and load as a first run.
+	 */
+	generatedEnv?: Record<string, string>;
+	/**
 	 * Where the Launchfile came from, persisted so post-launch operations
 	 * (bootstrap, inspect) can re-read it without depending on the caller's
 	 * cwd (#25). Optional for backward compatibility — state files written by
@@ -71,6 +83,7 @@ export async function loadState(slug: string): Promise<DockerState | null> {
 		// Persisted secrets are reused across runs, so a value generated in an
 		// earlier process still has to be scrubbable in this one (D-18).
 		registerSecrets(Object.values(state.secrets ?? {}));
+		registerSecrets(Object.values(state.generatedEnv ?? {}));
 		return state;
 	} catch {
 		return null;

--- a/providers/macos-dev/src/__tests__/dry-run.test.ts
+++ b/providers/macos-dev/src/__tests__/dry-run.test.ts
@@ -58,7 +58,7 @@ describe("dry-run against catalog", () => {
 		const context = buildResolverContext(resourceMap, ports, {}, {});
 
 		const env = resolveComponentEnv(component, context, resourceMap);
-		await resolveGenerators(component, env);
+		await resolveGenerators(component, env, "default", {});
 
 		// DATABASE_URL should be resolved from postgres $url
 		expect(env.DATABASE_URL).toBe(
@@ -128,7 +128,7 @@ describe("dry-run against catalog", () => {
 		// Resolve env for each component — should not throw
 		for (const [name, component] of Object.entries(launch.components)) {
 			const env = resolveComponentEnv(component, context, resourceMap);
-			await resolveGenerators(component, env);
+			await resolveGenerators(component, env, name, {});
 			// Every component should have at least some env vars
 			expect(Object.keys(env).length, `${name} should have env vars`).toBeGreaterThan(0);
 		}

--- a/providers/macos-dev/src/__tests__/env-generator-lifecycle.test.ts
+++ b/providers/macos-dev/src/__tests__/env-generator-lifecycle.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Behavioral coverage for env-level generator preservation (D-49, #186):
+ * two consecutive REAL `launch up` runs must hand the component the same
+ * minted value, through the actual saveState → loadState → reuse path that
+ * pure resolver tests stub out. Also proves the three-call-site agreement:
+ * `env` reports the value the running component received.
+ *
+ * Skipped when the host lacks this provider's prerequisites (brew/git) —
+ * everything else in the suite stays runnable anywhere.
+ */
+
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { checkPrereqs } from "../prereqs.js";
+import { launchDown, launchEnv, launchUp } from "../provider.js";
+import type { LaunchState } from "../state.js";
+
+const prereqs = await checkPrereqs();
+
+// Host-safe: the only process started is a plain `sleep`, owned and stopped
+// by this test via the provider's own down path.
+const LAUNCHFILE = `version: launch/v1
+name: gov23-envgen-macos
+commands:
+  start: sleep 60
+env:
+  GOV23_TOKEN:
+    generator: secret
+`;
+
+function parseEnvFile(content: string): Record<string, string> {
+	const env: Record<string, string> = {};
+	for (const line of content.split("\n")) {
+		const eq = line.indexOf("=");
+		if (line.startsWith("#") || eq === -1) continue;
+		env[line.slice(0, eq)] = line.slice(eq + 1).replace(/^"|"$/g, "");
+	}
+	return env;
+}
+
+async function readState(dir: string): Promise<LaunchState> {
+	return JSON.parse(await readFile(join(dir, ".launchfile", "state.json"), "utf8")) as LaunchState;
+}
+
+describe.runIf(prereqs.ok)("env-level generator lifecycle — real up/down (D-49, #186)", () => {
+	let dir: string;
+
+	beforeAll(async () => {
+		dir = await mkdtemp(join(tmpdir(), "gov23-envgen-macos-"));
+		await writeFile(join(dir, "Launchfile"), LAUNCHFILE);
+	});
+
+	afterAll(async () => {
+		// Safety net if the test failed mid-way: stop the sleep we spawned and
+		// remove all state, via the provider's own destroy path.
+		await launchDown({ destroy: true, projectDir: dir }).catch(() => {});
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	it("preserves the value across down + a second real up, `env` agrees, destroy discards", async () => {
+		// Run 1: mints and persists.
+		await launchUp({ projectDir: dir });
+		const first = parseEnvFile(await readFile(join(dir, ".env.local"), "utf8")).GOV23_TOKEN!;
+		expect(first).toMatch(/^[0-9a-f]{64}$/);
+		expect((await readState(dir)).generatedEnv?.["default.GOV23_TOKEN"]).toBe(first);
+
+		// `down` (no --destroy) preserves the value.
+		await launchDown({ projectDir: dir });
+		expect((await readState(dir)).generatedEnv?.["default.GOV23_TOKEN"]).toBe(first);
+
+		// Run 2: a real second `up` reuses it — saveState → loadState → reuse.
+		await launchUp({ projectDir: dir });
+		expect(parseEnvFile(await readFile(join(dir, ".env.local"), "utf8")).GOV23_TOKEN).toBe(first);
+
+		// `env` reports the value the running component received, not a fresh mint.
+		const lines: string[] = [];
+		const logSpy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+			lines.push(args.map(String).join(" "));
+		});
+		try {
+			await launchEnv({ projectDir: dir });
+		} finally {
+			logSpy.mockRestore();
+		}
+		const printed = lines.find((line) => line.startsWith("GOV23_TOKEN="));
+		expect(printed).toBe(`GOV23_TOKEN=${first}`);
+
+		// `down --destroy` discards the value with the rest of the state dir.
+		await launchDown({ destroy: true, projectDir: dir });
+		await expect(stat(join(dir, ".launchfile"))).rejects.toThrow();
+	}, 120_000);
+});

--- a/providers/macos-dev/src/__tests__/env-generator-lifecycle.test.ts
+++ b/providers/macos-dev/src/__tests__/env-generator-lifecycle.test.ts
@@ -44,7 +44,10 @@ async function readState(dir: string): Promise<LaunchState> {
 	return JSON.parse(await readFile(join(dir, ".launchfile", "state.json"), "utf8")) as LaunchState;
 }
 
-describe.runIf(prereqs.ok)("env-level generator lifecycle — real up/down (D-49, #186)", () => {
+// describe.runIf is a vitest-only API; CI's bun test runner doesn't provide it.
+const describeIfPrereqsOk = prereqs.ok ? describe : describe.skip;
+
+describeIfPrereqsOk("env-level generator lifecycle — real up/down (D-49, #186)", () => {
 	let dir: string;
 
 	beforeAll(async () => {

--- a/providers/macos-dev/src/__tests__/env-writer.test.ts
+++ b/providers/macos-dev/src/__tests__/env-writer.test.ts
@@ -6,7 +6,7 @@ import {
 	resolveGenerators,
 	generateSecrets,
 } from "../env-writer.js";
-import { readLaunch } from "@launchfile/sdk";
+import { readLaunch, resolveExpression } from "@launchfile/sdk";
 import type { NormalizedComponent, NormalizedLaunch, Secret } from "@launchfile/sdk";
 import type { ResourceProperties } from "../resources/types.js";
 import { storagePaths } from "../storage.js";
@@ -300,7 +300,7 @@ describe("provenance precedence — generator outranks default (D-49)", () => {
 		// would give the same file two different values across providers (P-5).
 		const c = comp("  FOO:\n    default: author-literal\n    generator: secret\n");
 		const env = resolveComponentEnv(c, ctx(), {});
-		await resolveGenerators(c, env);
+		await resolveGenerators(c, env, "default", {});
 		expect(env.FOO).not.toBe("author-literal");
 		expect(env.FOO).toMatch(/^[0-9a-f]{64}$/);
 	});
@@ -308,14 +308,110 @@ describe("provenance precedence — generator outranks default (D-49)", () => {
 	it("still uses the default when no generator is declared", async () => {
 		const c = comp("  FOO:\n    default: author-literal\n");
 		const env = resolveComponentEnv(c, ctx(), {});
-		await resolveGenerators(c, env);
+		await resolveGenerators(c, env, "default", {});
 		expect(env.FOO).toBe("author-literal");
 	});
 
 	it("leaves a bare required declaration unset for the operator", async () => {
 		const c = comp("  FOO:\n    required: true\n");
 		const env = resolveComponentEnv(c, ctx(), {});
-		await resolveGenerators(c, env);
+		await resolveGenerators(c, env, "default", {});
 		expect(env.FOO).toBeUndefined();
+	});
+});
+
+describe("env-level generator preservation (D-49, #186)", () => {
+	const comp = (envYaml: string) =>
+		readLaunch(`version: launch/v1\nname: p\ncommands:\n  start: run\nenv:\n${envYaml}`)
+			.components.default!;
+
+	it("reuses the persisted value instead of re-minting when state holds one", async () => {
+		const c = comp("  APP_KEY:\n    generator: secret\n");
+		const store = { "default.APP_KEY": "a".repeat(64) };
+		const env: Record<string, string> = {};
+
+		const minted = await resolveGenerators(c, env, "default", store);
+
+		expect(env.APP_KEY).toBe("a".repeat(64));
+		expect(minted).toBe(false);
+	});
+
+	it("mints and writes the value back to the store when state holds none", async () => {
+		const c = comp("  APP_KEY:\n    generator: secret\n");
+		const store: Record<string, string> = {};
+		const env: Record<string, string> = {};
+
+		const minted = await resolveGenerators(c, env, "default", store);
+
+		expect(env.APP_KEY).toMatch(/^[0-9a-f]{64}$/);
+		// The write-back is the invariant: a minted value the caller cannot
+		// persist would re-mint on the next run.
+		expect(store["default.APP_KEY"]).toBe(env.APP_KEY);
+		expect(minted).toBe(true);
+	});
+
+	it("does not persist `generator: port` and does not read a stale port from the store", async () => {
+		const c = comp("  APP_PORT:\n    generator: port\n");
+		// Even a (never-written-by-us) port entry in the store is ignored —
+		// the port branch re-allocates unconditionally.
+		const store: Record<string, string> = { "default.APP_PORT": "1" };
+		const env: Record<string, string> = {};
+
+		const minted = await resolveGenerators(c, env, "default", store);
+
+		expect(env.APP_PORT).toMatch(/^\d+$/);
+		expect(env.APP_PORT).not.toBe("1");
+		expect(store["default.APP_PORT"]).toBe("1"); // untouched, never re-written
+		expect(minted).toBe(false);
+	});
+
+	it("preserves `generator: uuid` values", async () => {
+		const c = comp("  INSTANCE_ID:\n    generator: uuid\n");
+		const store: Record<string, string> = {};
+		const env1: Record<string, string> = {};
+		await resolveGenerators(c, env1, "default", store);
+		expect(env1.INSTANCE_ID).toMatch(/^[0-9a-f-]{36}$/);
+
+		const env2: Record<string, string> = {};
+		await resolveGenerators(c, env2, "default", store);
+		expect(env2.INSTANCE_ID).toBe(env1.INSTANCE_ID);
+	});
+
+	it("does not leak env-level values into $secrets.*", async () => {
+		const c = comp("  APP_KEY:\n    generator: secret\n");
+		const store: Record<string, string> = {};
+		const env: Record<string, string> = {};
+		await resolveGenerators(c, env, "default", store);
+
+		// The resolver context is built from state.secrets, which the env
+		// store is disjoint from — a name declared only under env: must not
+		// resolve as a $secrets reference.
+		const context = buildResolverContext({}, {}, {}, NO_APP);
+		expect(resolveExpression("$secrets.APP_KEY", context)).toBe("");
+	});
+
+	it("keys per component: same variable name on two components stays independent and stable", async () => {
+		const launch = readLaunch(
+			`version: launch/v1\nname: p\ncomponents:\n  web:\n    commands:\n      start: run\n    env:\n      SHARED_KEY:\n        generator: secret\n  worker:\n    commands:\n      start: run\n    env:\n      SHARED_KEY:\n        generator: secret\n`,
+		);
+		const store: Record<string, string> = {};
+
+		const run = async (): Promise<Record<string, string>> => {
+			const values: Record<string, string> = {};
+			for (const [name, component] of Object.entries(launch.components)) {
+				const env: Record<string, string> = {};
+				await resolveGenerators(component, env, name, store);
+				values[name] = env.SHARED_KEY!;
+			}
+			return values;
+		};
+
+		const first = await run();
+		expect(first.web).not.toBe(first.worker); // two declarations, two mintings (D-25)
+		expect(store["web.SHARED_KEY"]).toBe(first.web);
+		expect(store["worker.SHARED_KEY"]).toBe(first.worker);
+
+		const second = await run();
+		expect(second).toEqual(first); // both stable across runs
 	});
 });

--- a/providers/macos-dev/src/__tests__/state.test.ts
+++ b/providers/macos-dev/src/__tests__/state.test.ts
@@ -1,8 +1,9 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { initState, hashLaunchfile, loadState, saveState, type LaunchState } from "../state.js";
+import { clearRegisteredSecrets, redactSecrets, REDACTED } from "../redact.js";
 
 describe("initState", () => {
 	it("creates a state with correct app name", () => {
@@ -81,6 +82,61 @@ describe("state persistence of processes (issue #49)", () => {
 			expect(loaded?.processes).toBeUndefined();
 			// `down` reads `state.processes ?? {}` — prove that defaulting works.
 			expect(loaded?.processes ?? {}).toEqual({});
+		});
+	});
+});
+
+describe("state persistence of env-level generator values (D-49, #186)", () => {
+	async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+		const dir = await mkdtemp(join(tmpdir(), "launchfile-state-"));
+		try {
+			return await fn(dir);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	}
+
+	afterEach(() => {
+		clearRegisteredSecrets();
+	});
+
+	it("round-trips the generatedEnv store", async () => {
+		await withTempDir(async (dir) => {
+			const state = initState("my-app", "name: my-app");
+			state.generatedEnv = { "default.APP_KEY": "b".repeat(64) };
+			await saveState(dir, state);
+
+			const loaded = await loadState(dir);
+			expect(loaded?.generatedEnv).toEqual({ "default.APP_KEY": "b".repeat(64) });
+		});
+	});
+
+	it("loads a state.json without a generatedEnv key and behaves as a first run", async () => {
+		await withTempDir(async (dir) => {
+			const legacy: LaunchState = initState("legacy", "name: legacy");
+			expect("generatedEnv" in legacy).toBe(false);
+			await saveState(dir, legacy);
+
+			const loaded = await loadState(dir);
+			expect(loaded).not.toBeNull();
+			expect(loaded?.generatedEnv).toBeUndefined();
+			// Every reader defaults with `?? {}` — an empty store means "mint".
+			expect(loaded?.generatedEnv ?? {}).toEqual({});
+		});
+	});
+
+	it("registers reloaded generatedEnv values with the redactor (D-18)", async () => {
+		await withTempDir(async (dir) => {
+			const value = "c".repeat(64);
+			const state = initState("my-app", "name: my-app");
+			state.generatedEnv = { "default.APP_KEY": value };
+			await saveState(dir, state);
+
+			// A second process reuses (never re-mints) the value, so nothing but
+			// the loader can make it scrubbable in that process.
+			clearRegisteredSecrets();
+			await loadState(dir);
+			expect(redactSecrets(`token=${value}`)).toBe(`token=${REDACTED}`);
 		});
 	});
 });

--- a/providers/macos-dev/src/bootstrap.ts
+++ b/providers/macos-dev/src/bootstrap.ts
@@ -22,7 +22,7 @@ import {
 	resolveExpression,
 	type CaptureEntry,
 } from "@launchfile/sdk";
-import { loadState } from "./state.js";
+import { loadState, saveState } from "./state.js";
 import {
 	buildResolverContext,
 	computeAppProperties,
@@ -226,9 +226,13 @@ export async function launchBootstrap(
 		const resolvedCommand = resolveExpression(bootstrap.command, context);
 
 		// Resolve env vars so the subprocess gets the same environment as
-		// the running component.
+		// the running component. Minted generator values come from the store
+		// `up` persists (D-49); a value minted here (a generator declared
+		// after the last `up`) is persisted before the command runs, so
+		// `up`/`env`/`bootstrap` keep agreeing on it.
 		const env = resolveComponentEnv(component, context, resourceMap);
-		await resolveGenerators(component, env);
+		const minted = await resolveGenerators(component, env, name, (state.generatedEnv ??= {}));
+		if (minted) await saveState(projectDir, state);
 		const port = state.ports[name];
 		if (port && !env.PORT) env.PORT = String(port);
 

--- a/providers/macos-dev/src/env-writer.ts
+++ b/providers/macos-dev/src/env-writer.ts
@@ -200,21 +200,52 @@ export async function generateSecrets(
 }
 
 /**
- * Generate values for env vars that have generators.
- * Mutates the env record in place.
+ * Resolve values for env vars that declare generators, preserving minted
+ * values across runs (D-49: generate once, then preserve).
+ *
+ * A `secret` or `uuid` value is read from `generatedEnv` when present, and
+ * minted and written into it when absent. The store is keyed
+ * `<component>.<ENV_NAME>` — one entry per declaration (D-25), so two
+ * components declaring the same variable name hold independent values.
+ * `generator: port` is exempt: ports have their own preserved home
+ * (`state.ports`) and allocator, and a preserved port produces a bind
+ * conflict rather than continuity.
+ *
+ * Mutates `env` and `generatedEnv` in place. Returns true when a new value
+ * was minted into `generatedEnv` — the caller must then persist the state
+ * before handing the value to anything, so every site that mints persists.
  */
 export async function resolveGenerators(
 	component: NormalizedComponent,
 	env: Record<string, string>,
-): Promise<void> {
-	if (!component.env) return;
+	componentName: string,
+	generatedEnv: Record<string, string>,
+): Promise<boolean> {
+	if (!component.env) return false;
 
+	let minted = false;
 	for (const [key, envVar] of Object.entries(component.env)) {
 		if (env[key] !== undefined) continue;
-		if (envVar.generator) {
+		if (!envVar.generator) continue;
+
+		if (envVar.generator === "port") {
 			env[key] = await generateValue(envVar.generator);
+			continue;
 		}
+
+		const stateKey = `${componentName}.${key}`;
+		const existing = generatedEnv[stateKey];
+		if (existing !== undefined) {
+			env[key] = existing;
+			continue;
+		}
+
+		const value = await generateValue(envVar.generator);
+		env[key] = value;
+		generatedEnv[stateKey] = value;
+		minted = true;
 	}
+	return minted;
 }
 
 /**
@@ -253,6 +284,7 @@ export async function writeAllEnvFiles(
 	resourceMap: Record<string, ResourceProperties>,
 	componentPorts: Record<string, number>,
 	projectDir: string,
+	generatedEnv: Record<string, string>,
 ): Promise<Record<string, Record<string, string>>> {
 	const allEnvs: Record<string, Record<string, string>> = {};
 	const componentNames = Object.keys(launch.components);
@@ -260,7 +292,7 @@ export async function writeAllEnvFiles(
 
 	for (const [name, component] of Object.entries(launch.components)) {
 		const env = resolveComponentEnv(component, context, resourceMap);
-		await resolveGenerators(component, env);
+		await resolveGenerators(component, env, name, generatedEnv);
 
 		// Inject PORT if not already set and component has provides
 		const port = componentPorts[name];

--- a/providers/macos-dev/src/provider.ts
+++ b/providers/macos-dev/src/provider.ts
@@ -392,9 +392,13 @@ export async function launchUp(opts: LaunchUpOpts = {}): Promise<void> {
 	const allEnvs: Record<string, Record<string, string>> = {};
 	const isSingleComponent = componentNames.length === 1 && componentNames[0] === "default";
 
+	// Minted env-level generator values live in state (D-49) so a redeploy
+	// reuses them; saveState below (step 13) persists anything minted here.
+	const generatedEnv = (state.generatedEnv ??= {});
+
 	for (const [name, component] of Object.entries(launch.components)) {
 		const env = resolveComponentEnv(component, context, resourceMap, componentStorage[name]);
-		await resolveGenerators(component, env);
+		await resolveGenerators(component, env, name, generatedEnv);
 
 		const port = componentPorts[name];
 		if (port && !env.PORT) {
@@ -642,6 +646,15 @@ export async function launchEnv(opts: { component?: string; projectDir?: string 
 	const appProperties = computeAppProperties(launch, state.ports);
 	const context = buildResolverContext(resourceMap, state.ports, state.secrets, appProperties);
 
+	// `env` reports what the running app has, so it reads minted generator
+	// values from the same store `up` persists to (D-49). A value can still be
+	// minted here — a generator declared after the last `up` — and then it is
+	// persisted below, before printing, so `up`, `env`, and `bootstrap` all
+	// keep answering with the same value.
+	const generatedEnv = (state.generatedEnv ??= {});
+	let minted = false;
+	const resolvedEnvs: [string, Record<string, string>][] = [];
+
 	for (const [name, component] of Object.entries(launch.components)) {
 		if (opts.component && name !== opts.component) continue;
 
@@ -655,11 +668,19 @@ export async function launchEnv(opts: { component?: string; projectDir?: string 
 		}
 
 		const env = resolveComponentEnv(component, context, resourceMap, storageCtx);
-		await resolveGenerators(component, env);
+		minted = (await resolveGenerators(component, env, name, generatedEnv)) || minted;
 
 		const port = state.ports[name];
 		if (port && !env.PORT) env.PORT = String(port);
 
+		resolvedEnvs.push([name, env]);
+	}
+
+	if (minted) {
+		await saveState(projectDir, state);
+	}
+
+	for (const [name, env] of resolvedEnvs) {
 		console.log(`\n# ${name}`);
 		for (const [key, value] of Object.entries(env).sort(([a], [b]) => a.localeCompare(b))) {
 			console.log(`${key}=${value}`);

--- a/providers/macos-dev/src/state.ts
+++ b/providers/macos-dev/src/state.ts
@@ -58,6 +58,16 @@ export interface LaunchState {
 	 * persistence existed simply omit this, and `down` tolerates its absence.
 	 */
 	processes?: Record<string, ProcessState>;
+	/**
+	 * Minted `env:`-level generator values (D-49: generate once, then
+	 * preserve), keyed `<component>.<ENV_NAME>` — one entry per declaration
+	 * (D-25), so same-named variables on different components hold independent
+	 * values. `generator: port` values are never stored here (ports are
+	 * re-allocated each run). Disjoint from `secrets` on purpose: these names
+	 * must not become resolvable as `$secrets.<name>`. Optional for backward
+	 * compatibility: older state files omit it and load as a first run.
+	 */
+	generatedEnv?: Record<string, string>;
 }
 
 const STATE_DIR = ".launchfile";
@@ -85,6 +95,10 @@ export async function loadState(projectDir: string): Promise<LaunchState | null>
 		// the redactor before anything can echo them.
 		registerSecrets(Object.values(state.secrets ?? {}));
 		registerSecrets(Object.values(state.resources ?? {}).map((r) => r.password));
+		// A value minted in an earlier run and merely reused in this one never
+		// passes through generateValue()'s registration, so the loader is the
+		// only place it can become scrubbable (D-18).
+		registerSecrets(Object.values(state.generatedEnv ?? {}));
 		return state;
 	} catch {
 		return null;

--- a/www-dev/src/pages/learn/env-and-secrets.astro
+++ b/www-dev/src/pages/learn/env-and-secrets.astro
@@ -101,7 +101,7 @@ const fireflyYaml = fireflyYamlRaw.replace(/^#.*\n/gm, "").trim();
 <Callout type="info" title="What happens to these values over time?">
   <p>Where a value comes from decides how the platform treats it later:</p>
   <ul>
-    <li><strong>Generated values</strong> (<code>generator: secret</code>) are created once and then preserved — a redeploy never regenerates them, because that would invalidate sessions and encrypted data. <em>Not yet true of inline <code>env:</code> generators in the reference providers: today a redeploy mints a fresh value. Tracked in <a href="https://github.com/launchfile/launchfile/issues/186">#186</a>.</em></li>
+    <li><strong>Generated values</strong> (<code>generator: secret</code>) are created once and then preserved — a redeploy never regenerates them, because that would invalidate sessions and encrypted data.</li>
     <li><strong>Expression defaults</strong> (like <code>$app.url</code>) are kept up to date by the platform — if your app's domain changes, the value follows, unless you've overridden it.</li>
     <li><strong>Literal defaults</strong> are just starting values — the platform or deployer can override them per environment.</li>
     <li><strong>Values you supply</strong> (required or optional, with no default) are yours alone — the platform never writes or changes them. <em>Not yet true of the Docker provider, which today substitutes a placeholder guessed from the variable's name for an unsupplied <code>required:</code> value. The AWS provider no longer does. Tracked in <a href="https://github.com/launchfile/launchfile/issues/191">#191</a> and <a href="https://github.com/launchfile/launchfile/issues/192">#192</a>.</em></li>


### PR DESCRIPTION
Closes #186

Both reference providers re-minted `env:`-level `generator:` values on every `up`. [D-49](https://github.com/launchfile/launchfile/blob/main/spec/DESIGN.md) classifies a `generator:` declaration as minted — generate once, then preserve — and `SPEC.md:358`/`:430` state it normatively. D-49's own *Conformance at adoption* note names this gap and cites #186. 23 shipped catalog apps (26 declarations) carry the failure mode the decision was written to prevent: `outline`'s `SECRET_KEY` rotating invalidates everything encrypted under it; `miniflux`'s `ADMIN_PASSWORD` locks the operator out.

Two commits, one per top-level directory. No spec, schema, or parser change (P-6, P-13). Provider behavior only (P-11); the same file now gets the same lifecycle treatment on every provider (P-5).

---

## What changed

Preservation is a state-layer property, not a generator-layer one — the shape the aws provider already demonstrates by delegating to Terraform state. Both providers now persist minted env values in their existing state file, mirroring how each already preserves declared secrets.

### The state key (verdict R1, R2, R3)

- **New `generatedEnv` key** on `LaunchState` (macos-dev) and `DockerState` (docker), keyed **`<component>.<ENV_NAME>`** — one entry per declaration (D-25). Two components declaring the same variable are two declarations and stay two independent, individually stable values.
- **Disjoint from `state.secrets`**, deliberately. On macos-dev, `state.secrets` feeds `buildResolverContext`, so reusing it would make `$secrets.<ENV_NAME>` resolve for names never declared under `secrets:` — inventing spec surface. On docker, `state.secrets` is already a shared namespace with backing-service password keys (`getPassword("postgres")`); env-var names do not join it. A test on each provider asserts `$secrets.<NAME>` still resolves to `""` for an env-only name.
- **Optional-on-read** (the `processes?` precedent): a state file without the key loads unchanged and behaves as a first run. Covered by tests on both providers.

### Every site that mints persists (verdict R4, C2)

macos-dev had three minting sites, and within a single deployment they disagreed — `launchfile env` printed a value the running app never had. `resolveGenerators` is now state-aware and reports whether it minted; all three call sites read the same store, and whichever mints first persists before the value is used or printed:

| Call site | Verb | Now |
|---|---|---|
| `provider.ts` step 12 | `up` | reads/mints into `state.generatedEnv`; `saveState` (step 13) persists before build/start |
| `provider.ts` `launchEnv` | `env` | reads the same store; a fresh mint (generator added after the last `up`) is persisted **before** printing |
| `bootstrap.ts` | `bootstrap` | reads the same store; a fresh mint is persisted **before** the command runs |

docker: `resolveEnvVar`'s generator branch is guarded exactly the way the top-level `secrets:` branch is, and the store round-trips `opts.generatedEnv` → `result.generatedEnv` → `state.generatedEnv` — the same path `opts.secrets` takes — so `saveState` records it before any service starts.

### Exemption and redaction (verdict R5, R6)

- **`generator: port` is exempt** (D-49 in terms): never persisted, always re-allocated. No catalog file exercises this, so tests on both providers are the coverage — including that a stale port entry in the store is never read back.
- **Both `loadState` paths register reused values with the redactor** (D-18). A value minted in run 1 and merely reused in run 2 never passes through `registerSecret()` in run 2 unless the loader does it. Tested on both providers by clearing the registry, reloading, and asserting the scrub.

### Lifecycle

`down` preserves the store; `down --destroy` / destroy discards it with the rest of the state directory. Both behaviors are asserted in the live lifecycle tests.

### What this deliberately does not fix (verdict R3, C3)

`catalog/drafts/chatwoot` (`SECRET_KEY_BASE` under `web` + `sidekiq`) and `catalog/drafts/dify` (`SECRET_KEY` under `api` + `worker`) still diverge across components — per-declaration keying freezes that rather than papering over it. That is an **authoring** bug: a value shared across components belongs in the top-level `secrets:` block as `$secrets.<name>`, which both providers already persist. Filed separately (follow-up issue).

### Boundaries honored (verdict N1–N5)

- No output file (`.env.local`, `.launchfile/env/*.env`, `docker-compose.yml`) is read back as a source of truth — the state file is the only store.
- Nothing is persisted outside the existing state file; the `0o600`-in-`0o700` posture and `.gitignore` safety net are untouched.
- Zero spec/schema/parser change; `spec/` is untouched, including D-49's *Conformance at adoption* paragraph — closing #186 is the record that the gap closed.
- No preemption of PROVIDERS.md §8's unified `DeploymentState`: a per-provider key only.
- aws and `catalog/test/src/launch-to-compose.ts` untouched, per the verdict's per-provider table.

### Documentation-site gate (verdict C1)

`www-dev/src/pages/learn/env-and-secrets.astro` — the caveat sentence ("*Not yet true of inline `env:` generators… Tracked in #186*") is **deleted**, in its own `www-dev:` commit. Leaving it would make the docs understate the providers once this lands. Verified the built site no longer contains the caveat or the #186 link. `www-org` needs nothing (renders unchanged spec files).

---

## Tests

All ten items of the verdict's required test evidence are implemented, per provider where applicable: reuse (1), write-back (2), `port` exemption (3), `uuid` preservation (4), legacy state file (5), no `$secrets.*` leakage (6), redaction-on-reload (7), per-component independence (8), the real two-`up` lifecycle (9), and the macos-dev `up`-then-`env` agreement (10).

**tests pass:**

| Suite | Before (origin/main @ 86684d3) | After |
|---|---|---|
| `providers/macos-dev` | 118/118 | **128/128** |
| `providers/docker` | 124/124 | **134/134** |
| `sdk` (untouched) | 299/299 | 299/299 |
| `providers/aws` (untouched) | 50/50 | 50/50 |
| `packages/launchfile` (untouched) | 42/42 | 42/42 |

`typecheck` and `build` pass in both providers; `www-dev` typecheck + full Astro build pass (24 pages).

**verified live** (test 9 — real runs, not dry-runs; docker `--dry-run` returns before `saveState`, so a dry-run pair proves nothing):

- **docker**: two consecutive real `launchfile up` runs of a dedicated alpine app (compose project `launchfile-gov23-envgen`, `sleep` command) against a live Docker daemon (29.7.2). The 64-hex `GOV23_TOKEN` in `~/.launchfile/docker/gov23-envgen/state.json` and in the written `docker-compose.yml` was byte-identical across both runs (exercising `saveState` → `loadState` → reuse); `down` preserved it; `down --destroy` removed the state directory (asserted). No `gov23-envgen` containers or state remained afterwards (checked `docker ps -a` and the state dir).
- **macos-dev**: two consecutive real `launch up` runs (spawned `sleep` process) in a temp project. The 64-hex value in `.env.local` was identical across both runs; `down` preserved it in `state.json`; `launchfile env` printed exactly the value the running component received (test 10 / C2); `down --destroy` removed `.launchfile/` (asserted).

Both lifecycle tests are committed and auto-skip (`describe.runIf`) on hosts without the provider's prerequisites, so the rest of each suite stays runnable anywhere; on CI's ubuntu runners Docker is present and the docker lifecycle runs for real.

---

Steward refs: D-49 (minted → preserve; `port` exempt), D-25 (per-component declarations decide the key shape), D-18 (redaction obligation on reload), D-20 (running-instance state belongs to the orchestrator), P-5, P-6, P-11, P-13.
