### PR TITLE
providers: run `bootstrap` through a POSIX shell, and escape paperclip's shell variables

### DIFF
--- a/catalog/apps/paperclip/Launchfile
+++ b/catalog/apps/paperclip/Launchfile
@@ -52,13 +52,19 @@ commands:
   # authenticated (hence the sed). When the templated file-placement
   # primitive lands (held proposal, see issue #16), those two steps
   # collapse into a declarative file write.
+  #
+  # PAPERCLIP_HOME, CFG and BETTER_AUTH_URL are expanded by the shell inside
+  # the container, not by the Launchfile resolver. A bare `$NAME` is a
+  # deployment-time reference (P-9) and resolves to "" when it names nothing
+  # in the Launchfile, so each one is escaped `$$NAME` — the literal-`$`
+  # escape — to reach the shell intact.
   bootstrap:
     command: >-
-      CFG="$PAPERCLIP_HOME/instances/default/config.json";
-      test -f "$CFG" || {
+      CFG="$$PAPERCLIP_HOME/instances/default/config.json";
+      test -f "$$CFG" || {
       timeout 30 pnpm paperclipai onboard --yes >/dev/null 2>&1;
-      sed -i "s/\"deploymentMode\": \"local_trusted\"/\"deploymentMode\": \"authenticated\"/" "$CFG"; };
-      pnpm paperclipai auth bootstrap-ceo --base-url "$BETTER_AUTH_URL"
+      sed -i "s/\"deploymentMode\": \"local_trusted\"/\"deploymentMode\": \"authenticated\"/" "$$CFG"; };
+      pnpm paperclipai auth bootstrap-ceo --base-url "$$BETTER_AUTH_URL"
     capture:
       invite_link:
         pattern: "https?://\\S+invite\\S*"

--- a/providers/docker/src/__tests__/bootstrap.test.ts
+++ b/providers/docker/src/__tests__/bootstrap.test.ts
@@ -1,6 +1,15 @@
-import { describe, it, expect } from "vitest";
-import { extractCaptures, parseDuration, computeAppProperties } from "../bootstrap.js";
-import { readLaunch, resolveExpression, type CaptureEntry } from "@launchfile/sdk";
+import { readFileSync } from "node:fs";
+import { describe, it, expect, vi } from "vitest";
+import {
+	type BootstrapExec,
+	computeAppProperties,
+	DEFAULT_BOOTSTRAP_TIMEOUT_MS,
+	extractCaptures,
+	parseDuration,
+	planBootstraps,
+	runBootstraps,
+} from "../bootstrap.js";
+import { type CaptureEntry, readLaunch, resolveExpression } from "@launchfile/sdk";
 
 describe("extractCaptures (D-34, docker provider)", () => {
 	it("extracts invite link pattern from CLI output", () => {
@@ -72,6 +81,148 @@ describe("parseDuration (docker provider)", () => {
 	it("rejects whitespace forms (ratified grammar, D-48)", () => {
 		expect(() => parseDuration("5 m")).toThrow(/invalid duration/);
 		expect(() => parseDuration(" 10s ")).toThrow(/invalid duration/);
+	});
+});
+
+/**
+ * The exact command `catalog/apps/paperclip/Launchfile` intends the container
+ * shell to run. `$$NAME` in the file resolves to `$NAME` here, and nothing
+ * else in the string changes.
+ */
+const PAPERCLIP_BOOTSTRAP = String.raw`CFG="$PAPERCLIP_HOME/instances/default/config.json"; test -f "$CFG" || { timeout 30 pnpm paperclipai onboard --yes >/dev/null 2>&1; sed -i "s/\"deploymentMode\": \"local_trusted\"/\"deploymentMode\": \"authenticated\"/" "$CFG"; }; pnpm paperclipai auth bootstrap-ceo --base-url "$BETTER_AUTH_URL"`;
+
+const CATALOG_PAPERCLIP = new URL(
+	"../../../../catalog/apps/paperclip/Launchfile",
+	import.meta.url,
+);
+
+describe("planBootstraps — command interpretation (SPEC.md § Command interpretation)", () => {
+	const plan = (command: string) =>
+		planBootstraps(
+			readLaunch(
+				`version: launch/v1\nname: acme\nimage: acme:1\ncommands:\n  start: serve\n  bootstrap: ${JSON.stringify(command)}\n`,
+			),
+			{ hostPorts: {}, secrets: {} },
+		)[0]!;
+
+	it("keeps shell operators intact instead of splitting them into argv", () => {
+		const item = plan("rails db:migrate && rails db:seed");
+		expect(item.argv).toEqual(["sh", "-c", "rails db:migrate && rails db:seed"]);
+	});
+
+	it("passes the command as exactly one argv element", () => {
+		const item = plan('sed -i "s/a/b/" f.json; echo done');
+		expect(item.argv).toHaveLength(3);
+		expect(item.argv[2]).toBe('sed -i "s/a/b/" f.json; echo done');
+	});
+
+	it("resolves $app.* before the shell sees the command", () => {
+		const item = planBootstraps(
+			readLaunch(
+				"version: launch/v1\nname: acme\nimage: acme:1\nprovides:\n  - { protocol: http, port: 3000, exposed: true }\ncommands:\n  start: serve\n  bootstrap: 'seed --url $app.url'\n",
+			),
+			{ hostPorts: { default: 8080 }, secrets: {} },
+		)[0]!;
+		expect(item.argv).toEqual(["sh", "-c", "seed --url http://localhost:8080"]);
+	});
+
+	it.each(["   ", "\n\t ", "\t"])(
+		"reports a command that resolves to whitespace only (%j)",
+		(command) => {
+			expect(plan(command).error).toBe("empty command");
+		},
+	);
+
+	it("reports an unparseable timeout instead of substituting a default", () => {
+		const item = planBootstraps(
+			readLaunch(
+				"version: launch/v1\nname: acme\nimage: acme:1\ncommands:\n  start: serve\n  bootstrap:\n    command: seed\n    timeout: '5 m'\n",
+			),
+			{ hostPorts: {}, secrets: {} },
+		)[0]!;
+		expect(item.error).toMatch(/invalid duration/);
+	});
+
+	it("honors a declared timeout and defaults when absent", () => {
+		expect(plan("seed").timeoutMs).toBe(DEFAULT_BOOTSTRAP_TIMEOUT_MS);
+		const item = planBootstraps(
+			readLaunch(
+				"version: launch/v1\nname: acme\nimage: acme:1\ncommands:\n  start: serve\n  bootstrap:\n    command: seed\n    timeout: 5m\n",
+			),
+			{ hostPorts: {}, secrets: {} },
+		)[0]!;
+		expect(item.timeoutMs).toBe(300_000);
+	});
+});
+
+describe("paperclip bootstrap regression (issue #185)", () => {
+	it("resolves the catalog Launchfile to the authored shell script, byte for byte", () => {
+		const launch = readLaunch(readFileSync(CATALOG_PAPERCLIP, "utf8"));
+		const item = planBootstraps(launch, {
+			hostPorts: { default: 3100 },
+			secrets: {},
+		})[0]!;
+
+		// Exact string, not argc: three blanked substitutions still produce 27
+		// argv tokens, so an argc assertion passes on a broken command.
+		expect(item.command).toBe(PAPERCLIP_BOOTSTRAP);
+		expect(item.argv).toEqual(["sh", "-c", PAPERCLIP_BOOTSTRAP]);
+		expect(item.error).toBeUndefined();
+	});
+});
+
+describe("runBootstraps — docker exec argv shape", () => {
+	it("hands docker compose exec the command as a single sh -c element", async () => {
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		const calls: { cmd: string; args: string[]; timeoutMs: number }[] = [];
+		const exec: BootstrapExec = async (cmd, args, opts) => {
+			calls.push({ cmd, args, timeoutMs: opts.timeoutMs });
+			return { exitCode: 0, stdout: "https://acme.test/invite/abc", stderr: "" };
+		};
+
+		const launch = readLaunch(readFileSync(CATALOG_PAPERCLIP, "utf8"));
+		const plan = planBootstraps(launch, { hostPorts: { default: 3100 }, secrets: {} });
+		const results = await runBootstraps(plan, { project: "lf-paperclip", exec });
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]!.cmd).toBe("docker");
+		expect(calls[0]!.args).toEqual([
+			"compose",
+			"-p",
+			"lf-paperclip",
+			"exec",
+			"-T",
+			"paperclip",
+			"sh",
+			"-c",
+			PAPERCLIP_BOOTSTRAP,
+		]);
+		expect(results[0]!.ok).toBe(true);
+		expect(results[0]!.captures.invite_link).toBe("https://acme.test/invite/abc");
+		vi.restoreAllMocks();
+	});
+
+	it("reports a plan item that cannot run without invoking docker", async () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		const exec: BootstrapExec = async () => {
+			throw new Error("must not run");
+		};
+		const results = await runBootstraps(
+			[
+				{
+					component: "default",
+					service: "acme",
+					command: "",
+					argv: ["sh", "-c", ""],
+					timeoutMs: DEFAULT_BOOTSTRAP_TIMEOUT_MS,
+					error: "empty command",
+				},
+			],
+			{ project: "lf-acme", exec },
+		);
+		expect(results[0]!.ok).toBe(false);
+		expect(results[0]!.stderr).toBe("empty command");
+		vi.restoreAllMocks();
 	});
 });
 

--- a/providers/docker/src/bootstrap.ts
+++ b/providers/docker/src/bootstrap.ts
@@ -2,12 +2,18 @@
  * Bootstrap command execution for the Docker provider.
  *
  * Implements the `commands.bootstrap` lifecycle stage introduced by D-34
- * against a running docker compose project. Commands are argv-split and
- * run via `docker compose -p <project> exec -T <service> <argv...>` with
- * spawn({ shell: false }), avoiding shell-injection exposure. Stdout is
- * captured against the regex patterns declared in commands.bootstrap.capture.
+ * against a running docker compose project, via
+ * `docker compose -p <project> exec -T <service> sh -c <command>`.
  *
- * Spec: /spec/SPEC.md § Bootstrap stage.
+ * The command runs through a POSIX shell inside the container
+ * (SPEC.md § Command interpretation), so `&&`, `;`, pipes, redirection,
+ * grouping and variable expansion behave as authors write them. The string is
+ * passed as a single argv element to `sh -c` — it is never interpolated into a
+ * shell string on this side, so nothing the app declares can affect the compose
+ * invocation itself. Stdout is captured against the regex patterns declared in
+ * commands.bootstrap.capture.
+ *
+ * Spec: /spec/SPEC.md § Bootstrap stage, /spec/PROVIDERS.md §10 item 11.
  */
 
 import { spawn } from "node:child_process";
@@ -22,6 +28,9 @@ import {
 import { redactSecrets } from "./redact.js";
 import { loadState, composeProject } from "./state.js";
 
+/** Default budget for a bootstrap command when no `timeout` is declared. */
+export const DEFAULT_BOOTSTRAP_TIMEOUT_MS = 120_000;
+
 /** Result of running one bootstrap command against a compose service. */
 export interface BootstrapResult {
 	component: string;
@@ -33,6 +42,25 @@ export interface BootstrapResult {
 	captureMeta: Record<string, CaptureEntry>;
 	stdout: string;
 	stderr: string;
+}
+
+/** One planned bootstrap execution, in component declaration order. */
+export interface BootstrapPlanItem {
+	component: string;
+	service: string;
+	/** The $-resolved command string. */
+	command: string;
+	/** `["sh", "-c", command]` — the command as a single argv element. */
+	argv: string[];
+	timeoutMs: number;
+	capture?: Record<string, CaptureEntry>;
+	/**
+	 * Set when the item cannot run at all (empty command, unparseable
+	 * timeout). Bootstrap failures are reported, never thrown
+	 * (SPEC.md § Failure semantics), so a bad item stays in the plan and
+	 * carries its own diagnosis.
+	 */
+	error?: string;
 }
 
 function stripAnsi(s: string): string {
@@ -105,29 +133,89 @@ function serviceNameFor(launchName: string, componentName: string): string {
 	return componentName === "default" ? launchName : `${launchName}-${componentName}`;
 }
 
-interface RunOpts {
-	cwd?: string;
-	timeoutMs: number;
+/**
+ * Build the bootstrap plan for a deployment. Pure — no I/O — so selection,
+ * expression resolution, argv shape and timeout handling are unit-testable.
+ */
+export function planBootstraps(
+	launch: NormalizedLaunch,
+	opts: {
+		/** Component name → allocated host port (for $app.* resolution). */
+		hostPorts: Record<string, number>;
+		secrets: Record<string, string>;
+		/** Restrict to this single component; undefined = all. */
+		component?: string;
+	},
+): BootstrapPlanItem[] {
+	const resolverContext: ResolverContext = {
+		secrets: opts.secrets,
+		app: computeAppProperties(launch, opts.hostPorts),
+	};
+
+	const plan: BootstrapPlanItem[] = [];
+	for (const [name, component] of Object.entries(launch.components)) {
+		if (opts.component && name !== opts.component) continue;
+
+		const bootstrap = component.commands?.bootstrap;
+		if (!bootstrap) continue;
+
+		// Resolve $-expressions in the command string so $app.url becomes
+		// http://localhost:<hostPort> before the shell sees it. A `$$` escape
+		// becomes a literal `$` here and reaches the shell intact (SPEC.md
+		// § References, `$$`).
+		const command = resolveExpression(bootstrap.command, resolverContext);
+		const service = serviceNameFor(launch.name, name);
+		const base = {
+			component: name,
+			service,
+			command,
+			// `sh -c <command>` — one argv element, so the shell interprets the
+			// command and nothing else (SPEC.md § Command interpretation).
+			argv: ["sh", "-c", command],
+			capture: bootstrap.capture,
+		};
+
+		if (command.trim() === "") {
+			plan.push({
+				...base,
+				timeoutMs: DEFAULT_BOOTSTRAP_TIMEOUT_MS,
+				error: "empty command",
+			});
+			continue;
+		}
+
+		let timeoutMs = DEFAULT_BOOTSTRAP_TIMEOUT_MS;
+		if (bootstrap.timeout !== undefined) {
+			try {
+				timeoutMs = parseDuration(bootstrap.timeout);
+			} catch (err) {
+				// An unparseable timeout is surfaced, never silently replaced
+				// with a default (PROVIDERS.md §10.10).
+				plan.push({
+					...base,
+					timeoutMs: DEFAULT_BOOTSTRAP_TIMEOUT_MS,
+					error: err instanceof Error ? err.message : String(err),
+				});
+				continue;
+			}
+		}
+
+		plan.push({ ...base, timeoutMs });
+	}
+
+	return plan;
 }
 
-async function runDockerExec(
-	composeProjectName: string,
-	service: string,
-	argv: string[],
-	opts: RunOpts,
-): Promise<{ exitCode: number; stdout: string; stderr: string }> {
-	const dockerArgs = [
-		"compose",
-		"-p",
-		composeProjectName,
-		"exec",
-		"-T",
-		service,
-		...argv,
-	];
+/** Minimal exec contract so tests can inject a fake runner. */
+export type BootstrapExec = (
+	cmd: string,
+	args: string[],
+	opts: { timeoutMs: number; cwd?: string },
+) => Promise<{ exitCode: number; stdout: string; stderr: string }>;
 
-	return new Promise((resolveP) => {
-		const child = spawn("docker", dockerArgs, {
+const defaultExec: BootstrapExec = (cmd, args, opts) =>
+	new Promise((resolveP) => {
+		const child = spawn(cmd, args, {
 			cwd: opts.cwd,
 			shell: false,
 			stdio: ["ignore", "pipe", "pipe"],
@@ -172,6 +260,92 @@ async function runDockerExec(
 			}
 		});
 	});
+
+/**
+ * Execute a bootstrap plan against a running compose project. Every item
+ * runs; a failure is reported in its result and never thrown
+ * (SPEC.md § Failure semantics).
+ */
+export async function runBootstraps(
+	plan: BootstrapPlanItem[],
+	opts: { project: string; cwd?: string; exec?: BootstrapExec },
+): Promise<BootstrapResult[]> {
+	const exec = opts.exec ?? defaultExec;
+	const results: BootstrapResult[] = [];
+
+	for (const item of plan) {
+		if (item.error) {
+			console.error(`  ✗ Bootstrap [${item.component}]: ${item.error}`);
+			results.push({
+				component: item.component,
+				service: item.service,
+				command: item.command,
+				ok: false,
+				exitCode: 1,
+				captures: {},
+				captureMeta: item.capture ?? {},
+				stdout: "",
+				stderr: item.error,
+			});
+			continue;
+		}
+
+		console.log(
+			`\n  ↓ Bootstrap [${item.component}] via docker compose exec ${item.service}`,
+		);
+		// `$secrets.*` / `$<resource>.password` / `$<resource>.url` resolve to
+		// live credentials here, so the echoed command is scrubbed (CWE-532).
+		console.log(`    $ ${redactSecrets(item.command)}`);
+
+		const { exitCode, stdout, stderr } = await exec(
+			"docker",
+			[
+				"compose",
+				"-p",
+				opts.project,
+				"exec",
+				"-T",
+				item.service,
+				...item.argv,
+			],
+			{ timeoutMs: item.timeoutMs, cwd: opts.cwd },
+		);
+
+		const captures = item.capture ? extractCaptures(stdout, item.capture) : {};
+
+		results.push({
+			component: item.component,
+			service: item.service,
+			command: item.command,
+			ok: exitCode === 0,
+			exitCode,
+			captures,
+			captureMeta: item.capture ?? {},
+			stdout,
+			stderr,
+		});
+
+		if (Object.keys(captures).length > 0) {
+			console.log("\n  Captured:");
+			for (const [key, value] of Object.entries(captures)) {
+				const meta = item.capture?.[key];
+				const displayValue = meta?.sensitive ? "***" : value;
+				const desc = meta?.description ? ` — ${meta.description}` : "";
+				console.log(`    ${key}: ${displayValue}${desc}`);
+			}
+		}
+
+		if (exitCode !== 0) {
+			console.error(
+				`  ✗ Bootstrap [${item.component}] failed with exit code ${exitCode}`,
+			);
+			if (stderr) console.error(redactSecrets(stderr));
+		} else {
+			console.log(`  ✓ Bootstrap [${item.component}] complete`);
+		}
+	}
+
+	return results;
 }
 
 /**
@@ -184,116 +358,23 @@ export async function dockerBootstrap(opts: {
 	launch: NormalizedLaunch;
 	slug: string;
 	component?: string;
+	exec?: BootstrapExec;
 }): Promise<BootstrapResult[]> {
 	const state = await loadState(opts.slug);
 	if (!state) {
 		throw new Error(`No docker state found for "${opts.slug}". Run \`launchfile up\` first.`);
 	}
 
-	const project = composeProject(opts.slug);
-	const appProperties = computeAppProperties(opts.launch, state.ports);
-	const resolverContext: ResolverContext = {
+	const plan = planBootstraps(opts.launch, {
+		hostPorts: state.ports,
 		secrets: state.secrets,
-		app: appProperties,
-	};
+		component: opts.component,
+	});
 
-	const results: BootstrapResult[] = [];
-
-	for (const [name, component] of Object.entries(opts.launch.components)) {
-		if (opts.component && name !== opts.component) continue;
-
-		const bootstrap = component.commands?.bootstrap;
-		if (!bootstrap) continue;
-
-		// Resolve $-expressions in the command string so $app.url becomes
-		// http://localhost:<hostPort> before argv split.
-		const resolvedCommand = resolveExpression(bootstrap.command, resolverContext);
-		const argv = resolvedCommand.trim().split(/\s+/).filter(Boolean);
-		if (argv.length === 0) {
-			results.push({
-				component: name,
-				service: serviceNameFor(opts.launch.name, name),
-				command: resolvedCommand,
-				ok: false,
-				exitCode: 1,
-				captures: {},
-				captureMeta: bootstrap.capture ?? {},
-				stdout: "",
-				stderr: "empty command",
-			});
-			continue;
-		}
-
-		const service = serviceNameFor(opts.launch.name, name);
-
-		// Bootstrap failures are reported, not thrown (SPEC.md \u00a7 Failure
-		// semantics) \u2014 an unparseable timeout is surfaced the same way,
-		// never silently replaced with a default (PROVIDERS.md \u00a710.10).
-		let timeoutMs = 120_000;
-		if (bootstrap.timeout !== undefined) {
-			try {
-				timeoutMs = parseDuration(bootstrap.timeout);
-			} catch (err) {
-				const message = err instanceof Error ? err.message : String(err);
-				console.error(`  \u2717 Bootstrap [${name}]: ${message}`);
-				results.push({
-					component: name,
-					service,
-					command: resolvedCommand,
-					ok: false,
-					exitCode: 1,
-					captures: {},
-					captureMeta: bootstrap.capture ?? {},
-					stdout: "",
-					stderr: message,
-				});
-				continue;
-			}
-		}
-
-		console.log(`\n  \u2193 Bootstrap [${name}] via docker compose exec ${service}`);
-		// `$secrets.*` / `$<resource>.password` / `$<resource>.url` resolve to
-		// live credentials here, so the echoed command is scrubbed (CWE-532).
-		console.log(`    $ ${redactSecrets(resolvedCommand)}`);
-
-		const { exitCode, stdout, stderr } = await runDockerExec(
-			project,
-			service,
-			argv,
-			{ timeoutMs },
-		);
-
-		const captures = bootstrap.capture ? extractCaptures(stdout, bootstrap.capture) : {};
-
-		results.push({
-			component: name,
-			service,
-			command: resolvedCommand,
-			ok: exitCode === 0,
-			exitCode,
-			captures,
-			captureMeta: bootstrap.capture ?? {},
-			stdout,
-			stderr,
-		});
-
-		if (Object.keys(captures).length > 0) {
-			console.log("\n  Captured:");
-			for (const [key, value] of Object.entries(captures)) {
-				const meta = bootstrap.capture?.[key];
-				const displayValue = meta?.sensitive ? "***" : value;
-				const desc = meta?.description ? ` — ${meta.description}` : "";
-				console.log(`    ${key}: ${displayValue}${desc}`);
-			}
-		}
-
-		if (exitCode !== 0) {
-			console.error(`  \u2717 Bootstrap [${name}] failed with exit code ${exitCode}`);
-			if (stderr) console.error(redactSecrets(stderr));
-		} else {
-			console.log(`  \u2713 Bootstrap [${name}] complete`);
-		}
-	}
+	const results = await runBootstraps(plan, {
+		project: composeProject(opts.slug),
+		exec: opts.exec,
+	});
 
 	if (results.length === 0) {
 		const target = opts.component ? ` for component "${opts.component}"` : "";

--- a/providers/macos-dev/src/__tests__/bootstrap.test.ts
+++ b/providers/macos-dev/src/__tests__/bootstrap.test.ts
@@ -1,7 +1,15 @@
+import { readFileSync } from "node:fs";
 import { describe, it, expect } from "vitest";
 import { parseDuration as parseHealthDuration } from "../health.js";
-import { extractCaptures, parseDuration } from "../bootstrap.js";
-import type { CaptureEntry } from "@launchfile/sdk";
+import {
+	BOOTSTRAP_SHELL,
+	DEFAULT_BOOTSTRAP_TIMEOUT_MS,
+	extractCaptures,
+	parseDuration,
+	planBootstraps,
+} from "../bootstrap.js";
+import { buildResolverContext, computeAppProperties } from "../env-writer.js";
+import { type CaptureEntry, readLaunch, type ResolverContext } from "@launchfile/sdk";
 
 describe("extractCaptures (D-34)", () => {
 	it("extracts a single-group regex from stdout", () => {
@@ -124,5 +132,102 @@ describe("health durations use the ratified grammar (D-48)", () => {
 		expect(() => parseHealthDuration("5 minutes")).toThrow(/invalid duration/);
 		expect(() => parseHealthDuration("1.5h")).toThrow(/invalid duration/);
 		expect(() => parseHealthDuration("30 s")).toThrow(/invalid duration/);
+	});
+});
+
+/**
+ * The exact command `catalog/apps/paperclip/Launchfile` intends the shell to
+ * run. `$$NAME` in the file resolves to `$NAME` here, and nothing else in the
+ * string changes.
+ */
+const PAPERCLIP_BOOTSTRAP = String.raw`CFG="$PAPERCLIP_HOME/instances/default/config.json"; test -f "$CFG" || { timeout 30 pnpm paperclipai onboard --yes >/dev/null 2>&1; sed -i "s/\"deploymentMode\": \"local_trusted\"/\"deploymentMode\": \"authenticated\"/" "$CFG"; }; pnpm paperclipai auth bootstrap-ceo --base-url "$BETTER_AUTH_URL"`;
+
+const CATALOG_PAPERCLIP = new URL(
+	"../../../../catalog/apps/paperclip/Launchfile",
+	import.meta.url,
+);
+
+function contextFor(
+	launch: ReturnType<typeof readLaunch>,
+	ports: Record<string, number>,
+): ResolverContext {
+	return buildResolverContext({}, ports, {}, computeAppProperties(launch, ports));
+}
+
+describe("planBootstraps — command interpretation (SPEC.md § Command interpretation)", () => {
+	const plan = (command: string) => {
+		const launch = readLaunch(
+			`version: launch/v1\nname: acme\nimage: acme:1\ncommands:\n  start: serve\n  bootstrap: ${JSON.stringify(command)}\n`,
+		);
+		return planBootstraps(launch, contextFor(launch, {}))[0]!;
+	};
+
+	it("keeps shell operators intact instead of splitting them into argv", () => {
+		const item = plan("rails db:migrate && rails db:seed");
+		expect(item.argv).toEqual([
+			BOOTSTRAP_SHELL,
+			"-c",
+			"rails db:migrate && rails db:seed",
+		]);
+	});
+
+	it("passes the command as exactly one argv element", () => {
+		const item = plan('sed -i "s/a/b/" f.json; echo done');
+		expect(item.argv).toHaveLength(3);
+		expect(item.argv[0]).toBe("/bin/sh");
+		expect(item.argv[2]).toBe('sed -i "s/a/b/" f.json; echo done');
+	});
+
+	it("resolves $app.* before the shell sees the command", () => {
+		const launch = readLaunch(
+			"version: launch/v1\nname: acme\nimage: acme:1\nprovides:\n  - { protocol: http, port: 3000, exposed: true }\ncommands:\n  start: serve\n  bootstrap: 'seed --url $app.url'\n",
+		);
+		const item = planBootstraps(launch, contextFor(launch, { default: 8080 }))[0]!;
+		expect(item.argv).toEqual([BOOTSTRAP_SHELL, "-c", "seed --url http://localhost:8080"]);
+	});
+
+	it.each(["   ", "\n\t ", "\t"])(
+		"reports a command that resolves to whitespace only (%j)",
+		(command) => {
+			expect(plan(command).error).toBe("empty command");
+		},
+	);
+
+	it("reports an unparseable timeout instead of substituting a default", () => {
+		const launch = readLaunch(
+			"version: launch/v1\nname: acme\nimage: acme:1\ncommands:\n  start: serve\n  bootstrap:\n    command: seed\n    timeout: '5 m'\n",
+		);
+		const item = planBootstraps(launch, contextFor(launch, {}))[0]!;
+		expect(item.error).toMatch(/invalid duration/);
+	});
+
+	it("honors a declared timeout and defaults when absent", () => {
+		expect(plan("seed").timeoutMs).toBe(DEFAULT_BOOTSTRAP_TIMEOUT_MS);
+		const launch = readLaunch(
+			"version: launch/v1\nname: acme\nimage: acme:1\ncommands:\n  start: serve\n  bootstrap:\n    command: seed\n    timeout: 5m\n",
+		);
+		expect(planBootstraps(launch, contextFor(launch, {}))[0]!.timeoutMs).toBe(300_000);
+	});
+
+	it("restricts the plan to a named component", () => {
+		const launch = readLaunch(
+			"version: launch/v1\nname: acme\ncomponents:\n  api:\n    image: acme/api:1\n    commands:\n      start: serve\n      bootstrap: api-seed\n  web:\n    image: acme/web:1\n    commands:\n      start: serve\n      bootstrap: web-seed\n",
+		);
+		const plan = planBootstraps(launch, contextFor(launch, {}), { component: "web" });
+		expect(plan).toHaveLength(1);
+		expect(plan[0]!.argv[2]).toBe("web-seed");
+	});
+});
+
+describe("paperclip bootstrap regression (issue #185)", () => {
+	it("resolves the catalog Launchfile to the authored shell script, byte for byte", () => {
+		const launch = readLaunch(readFileSync(CATALOG_PAPERCLIP, "utf8"));
+		const item = planBootstraps(launch, contextFor(launch, { default: 3100 }))[0]!;
+
+		// Exact string, not argc: three blanked substitutions still produce 27
+		// argv tokens, so an argc assertion passes on a broken command.
+		expect(item.command).toBe(PAPERCLIP_BOOTSTRAP);
+		expect(item.argv).toEqual([BOOTSTRAP_SHELL, "-c", PAPERCLIP_BOOTSTRAP]);
+		expect(item.error).toBeUndefined();
 	});
 });

--- a/providers/macos-dev/src/bootstrap.ts
+++ b/providers/macos-dev/src/bootstrap.ts
@@ -6,11 +6,12 @@
  * stdout via regex patterns, re-runnable, and reports failures rather than
  * deploy-failing. Spec: /spec/SPEC.md § Bootstrap stage.
  *
- * The command is split into argv via whitespace and run through spawn()
- * with shell:false to avoid shell-injection exposure. This means shell
- * metacharacters (pipes, redirects, &&, quoted args with spaces) are not
- * supported — apps that need shell features should wrap them in an
- * image-level script and invoke that script.
+ * The command runs through a POSIX shell (SPEC.md § Command interpretation,
+ * PROVIDERS.md §10 item 11), so `&&`, `;`, pipes, redirection, grouping and
+ * variable expansion behave as authors write them. It is passed as a single
+ * argv element to `/bin/sh -c` via spawn({ shell: false }) — it is never
+ * interpolated into a command string on this side, so the only interpreter
+ * that sees it is the `sh` this provider spawns.
  */
 
 import { readFile } from "node:fs/promises";
@@ -21,6 +22,8 @@ import {
 	readLaunch,
 	resolveExpression,
 	type CaptureEntry,
+	type NormalizedLaunch,
+	type ResolverContext,
 } from "@launchfile/sdk";
 import { loadState, saveState } from "./state.js";
 import {
@@ -31,6 +34,15 @@ import {
 } from "./env-writer.js";
 import { redactSecrets } from "./redact.js";
 import { getProvisioner, type ResourceProperties } from "./resources/index.js";
+
+/** Default budget for a bootstrap command when no `timeout` is declared. */
+export const DEFAULT_BOOTSTRAP_TIMEOUT_MS = 120_000;
+
+/**
+ * The interpreter every bootstrap command runs under. `/bin/sh` is the POSIX
+ * shell guaranteed present on macOS.
+ */
+export const BOOTSTRAP_SHELL = "/bin/sh";
 
 /**
  * Result of running one bootstrap command. Captures may be empty even on
@@ -94,22 +106,105 @@ export function extractCaptures(
  */
 export const parseDuration = parseDurationMs;
 
+/** One planned bootstrap execution, in component declaration order. */
+export interface BootstrapPlanItem {
+	component: string;
+	/** The $-resolved command string. */
+	command: string;
+	/** `["/bin/sh", "-c", command]` — the command as a single argv element. */
+	argv: string[];
+	timeoutMs: number;
+	capture?: Record<string, CaptureEntry>;
+	/**
+	 * Set when the item cannot run at all (empty command, unparseable
+	 * timeout). Bootstrap failures are reported, never thrown
+	 * (SPEC.md § Failure semantics), so a bad item stays in the plan and
+	 * carries its own diagnosis.
+	 */
+	error?: string;
+}
+
 /**
- * Run one command using argv-split (no-shell) execution. Returns the
+ * Build the bootstrap plan for a launch. Pure — no I/O — so selection,
+ * expression resolution, argv shape and timeout handling are unit-testable.
+ */
+export function planBootstraps(
+	launch: NormalizedLaunch,
+	context: ResolverContext,
+	opts: { component?: string } = {},
+): BootstrapPlanItem[] {
+	const plan: BootstrapPlanItem[] = [];
+
+	for (const [name, component] of Object.entries(launch.components)) {
+		if (opts.component && name !== opts.component) continue;
+
+		// `bootstrap` is mode-invariant (D-38): the same command runs from
+		// source or artifact. A path or binary that differs by mode belongs in
+		// storage:/env/PATH, not a separate command.
+		const bootstrap = component.commands?.bootstrap;
+		if (!bootstrap) continue;
+
+		// Resolve $-expressions in the command string (e.g. $app.url) at
+		// invocation time. Bootstrap runs after start, so the resolved URL
+		// already reflects the actual allocated port. A `$$` escape becomes a
+		// literal `$` here and reaches the shell intact (SPEC.md § References).
+		const command = resolveExpression(bootstrap.command, context);
+		const base = {
+			component: name,
+			command,
+			// `/bin/sh -c <command>` — one argv element, so the shell interprets
+			// the command and nothing else (SPEC.md § Command interpretation).
+			argv: [BOOTSTRAP_SHELL, "-c", command],
+			capture: bootstrap.capture,
+		};
+
+		if (command.trim() === "") {
+			plan.push({
+				...base,
+				timeoutMs: DEFAULT_BOOTSTRAP_TIMEOUT_MS,
+				error: "empty command",
+			});
+			continue;
+		}
+
+		let timeoutMs = DEFAULT_BOOTSTRAP_TIMEOUT_MS;
+		if (bootstrap.timeout !== undefined) {
+			try {
+				timeoutMs = parseDuration(bootstrap.timeout);
+			} catch (err) {
+				// An unparseable timeout is surfaced, never silently replaced
+				// with a default (PROVIDERS.md §10.10).
+				plan.push({
+					...base,
+					timeoutMs: DEFAULT_BOOTSTRAP_TIMEOUT_MS,
+					error: err instanceof Error ? err.message : String(err),
+				});
+				continue;
+			}
+		}
+
+		plan.push({ ...base, timeoutMs });
+	}
+
+	return plan;
+}
+
+/** Minimal exec contract so tests can inject a fake runner. */
+export type BootstrapExec = (
+	cmd: string,
+	args: string[],
+	opts: { cwd: string; env: Record<string, string>; timeoutMs: number },
+) => Promise<{ exitCode: number; stdout: string; stderr: string }>;
+
+/**
+ * Run one command. `cmd`/`args` cross the process boundary as an argv vector
+ * with shell:false — the command string is a single element of it, never
+ * interpolated into a string another shell would re-parse. Returns the
  * structured result; does not throw on command failure.
  */
-async function runOnce(
-	command: string,
-	opts: { cwd: string; env: Record<string, string>; timeoutMs: number },
-): Promise<{ exitCode: number; stdout: string; stderr: string }> {
-	const parts = command.trim().split(/\s+/).filter(Boolean);
-	if (parts.length === 0) {
-		return { exitCode: 1, stdout: "", stderr: "empty command" };
-	}
-	const [file, ...args] = parts;
-
-	return new Promise((resolveP) => {
-		const child = spawn(file!, args, {
+const defaultExec: BootstrapExec = (cmd, args, opts) =>
+	new Promise((resolveP) => {
+		const child = spawn(cmd, args, {
 			cwd: opts.cwd,
 			env: { ...process.env as Record<string, string>, ...opts.env },
 			shell: false,
@@ -155,7 +250,6 @@ async function runOnce(
 			}
 		});
 	});
-}
 
 /**
  * Public entry point for `launch bootstrap`. Loads the Launchfile, rebuilds
@@ -169,7 +263,7 @@ async function runOnce(
  * semantics in SPEC.md § Bootstrap stage.
  */
 export async function launchBootstrap(
-	opts: { component?: string; projectDir?: string } = {},
+	opts: { component?: string; projectDir?: string; exec?: BootstrapExec } = {},
 ): Promise<BootstrapResult[]> {
 	const projectDir = opts.projectDir ?? process.cwd();
 
@@ -209,89 +303,73 @@ export async function launchBootstrap(
 		appProperties,
 	);
 
+	const exec = opts.exec ?? defaultExec;
+	const plan = planBootstraps(launch, context, { component: opts.component });
 	const results: BootstrapResult[] = [];
 
-	for (const [name, component] of Object.entries(launch.components)) {
-		if (opts.component && name !== opts.component) continue;
+	for (const item of plan) {
+		const name = item.component;
 
-		// `bootstrap` is mode-invariant (D-38): the same command runs from
-		// source or artifact. A path or binary that differs by mode belongs in
-		// storage:/env/PATH, not a separate command.
-		const bootstrap = component.commands?.bootstrap;
-		if (!bootstrap) continue;
-
-		// Resolve $-expressions in the command string (e.g. $app.url) at
-		// invocation time. Bootstrap runs after start, so the resolved URL
-		// already reflects the actual allocated port.
-		const resolvedCommand = resolveExpression(bootstrap.command, context);
+		// Bootstrap failures are reported, not thrown (SPEC.md \u00a7 Failure
+		// semantics) \u2014 an unparseable timeout is surfaced the same way,
+		// never silently replaced with a default (PROVIDERS.md \u00a710.10).
+		if (item.error) {
+			console.error(`  \u2717 Bootstrap [${name}]: ${item.error}`);
+			results.push({
+				component: name,
+				command: item.command,
+				ok: false,
+				exitCode: 1,
+				captures: {},
+				captureMeta: item.capture ?? {},
+				stdout: "",
+				stderr: item.error,
+			});
+			continue;
+		}
 
 		// Resolve env vars so the subprocess gets the same environment as
 		// the running component. Minted generator values come from the store
 		// `up` persists (D-49); a value minted here (a generator declared
 		// after the last `up`) is persisted before the command runs, so
 		// `up`/`env`/`bootstrap` keep agreeing on it.
+		const component = launch.components[name]!;
 		const env = resolveComponentEnv(component, context, resourceMap);
 		const minted = await resolveGenerators(component, env, name, (state.generatedEnv ??= {}));
 		if (minted) await saveState(projectDir, state);
 		const port = state.ports[name];
 		if (port && !env.PORT) env.PORT = String(port);
 
-		// Bootstrap failures are reported, not thrown (SPEC.md \u00a7 Failure
-		// semantics) \u2014 an unparseable timeout is surfaced the same way,
-		// never silently replaced with a default (PROVIDERS.md \u00a710.10).
-		let timeoutMs = 120_000;
-		if (bootstrap.timeout !== undefined) {
-			try {
-				timeoutMs = parseDuration(bootstrap.timeout);
-			} catch (err) {
-				const message = err instanceof Error ? err.message : String(err);
-				console.error(`  \u2717 Bootstrap [${name}]: ${message}`);
-				results.push({
-					component: name,
-					command: resolvedCommand,
-					ok: false,
-					exitCode: 1,
-					captures: {},
-					captureMeta: bootstrap.capture ?? {},
-					stdout: "",
-					stderr: message,
-				});
-				continue;
-			}
-		}
-
 		console.log(`\n  \u2193 Bootstrap [${name}]`);
 		// `$secrets.*` / `$<resource>.password` / `$<resource>.url` resolve to live
 		// credentials here, so the echoed command is scrubbed (CWE-532).
-		console.log(`    $ ${redactSecrets(resolvedCommand)}`);
+		console.log(`    $ ${redactSecrets(item.command)}`);
 
-		const { exitCode, stdout, stderr } = await runOnce(resolvedCommand, {
+		const [file, ...args] = item.argv;
+		const { exitCode, stdout, stderr } = await exec(file!, args, {
 			cwd: projectDir,
 			env,
-			timeoutMs,
+			timeoutMs: item.timeoutMs,
 		});
 
-		const captures = bootstrap.capture
-			? extractCaptures(stdout, bootstrap.capture)
-			: {};
+		const captures = item.capture ? extractCaptures(stdout, item.capture) : {};
 
-		const result: BootstrapResult = {
+		results.push({
 			component: name,
-			command: resolvedCommand,
+			command: item.command,
 			ok: exitCode === 0,
 			exitCode,
 			captures,
-			captureMeta: bootstrap.capture ?? {},
+			captureMeta: item.capture ?? {},
 			stdout,
 			stderr,
-		};
-		results.push(result);
+		});
 
 		// Print captures inline so the user sees them immediately.
 		if (Object.keys(captures).length > 0) {
 			console.log("\n  Captured:");
 			for (const [key, value] of Object.entries(captures)) {
-				const meta = bootstrap.capture?.[key];
+				const meta = item.capture?.[key];
 				const displayValue = meta?.sensitive ? "***" : value;
 				const desc = meta?.description ? ` — ${meta.description}` : "";
 				console.log(`    ${key}: ${displayValue}${desc}`);


### PR DESCRIPTION
Closes #185

`commands.bootstrap` was the last command slot on either reference provider that split its command string on whitespace and exec'd `argv[0]`. `PROVIDERS.md` §10 item 11 forbids that outright, `SPEC.md` § Command interpretation requires a POSIX shell, and `D-48` ratification (4) already overruled the argv-split rationale both file headers advertised. This brings both providers into conformance and corrects the one catalog file that the fix alone would still leave broken.

Three files. No spec change, no schema change, no new `D-*`.

---

## Corrections to the issue, carried from the steward verdict

**C1 — `release.ts` was already fixed; the issue was stale on half its scope.** The issue cites `providers/docker/src/release.ts:107` as argv-splitting. That was true when it was filed and false at `86684d3`: `planReleases` has built `["sh", "-c", command]` since #180 (`70b8f67`). The third review on #180 flagged the staleness and asked for the narrowing that never reached the issue body. Scope here is `bootstrap` only, on both providers.

**C2 — No `D-*` is needed. This is conformance, not a spec gap.** Three merged normative statements already cover it: `SPEC.md:491` § Command interpretation, `DESIGN.md` D-48 ratification (4) (which names paperclip as the motivating case), and `PROVIDERS.md` §10 item 11. Adding a decision entry would duplicate D-48(4) and split the record, so `D-56` stays unallocated for this topic.

**C3 — `sh -c` alone does not make paperclip's bootstrap work.** `$$` escaping in the Launchfile is required, and it is the half that actually mattered. Detail below.

---

## The two defects

### 1. Both providers argv-split the bootstrap command

`providers/docker/src/bootstrap.ts` split on `/\s+/` and passed the tokens to `docker compose exec`; `providers/macos-dev/src/bootstrap.ts` did the same into `spawn(file, args, { shell: false })`. Against paperclip's multi-statement script the first token is `CFG="$PAPERCLIP_HOME/instances/default/config.json";`, and the container tries to execute a binary by that name.

Observed against the running container, using the pre-fix argv shape:

```
OCI runtime exec failed: exec failed: unable to start container process:
exec: "CFG=\"/paperclip/instances/default/config.json\";": stat ...: no such file or directory
```

Both providers now hand the command to a shell as a single argv element:

| Provider | Invocation |
|---|---|
| `@launchfile/docker` | `docker compose -p <project> exec -T <service> sh -c <command>` |
| `@launchfile/macos-dev` | `spawn("/bin/sh", ["-c", command], { shell: false })` |

The command is never interpolated into a string on this side of the boundary, so nothing the app declares can affect the invocation itself. On docker the only interpreter that sees it is the `sh` inside the app's own container — the same container the provider already runs the app's `start` command in, so no privilege exists after the change that did not exist before it. On macos-dev the host shell now runs `bootstrap`, as it already ran `build`, `install`, `dev`, `start` and `release` from the same Launchfile via `provider.ts:438,454`; `bootstrap` was the lone outlier. Per the verdict, macos-dev uses the argv-vector `spawn` shape rather than routing through its `shell.ts` (`child_process.exec` on a command string) — see follow-up F2.

**One behavior delta, stated honestly:** `bootstrap` now requires `sh` in the image, where previously `argv[0]` was exec'd directly. This is the same delta D-48 note 4 recorded for `release`. paperclip's image is Node/pnpm-based and has it. A missing shell surfaces as `exec: sh: not found` and is reported to the invoker, per the `bootstrap` disposition in § Failure semantics.

### 2. paperclip's Launchfile blanked its own shell variables

`bootstrap.command` is resolved before it reaches any provider. Per P-9 a bare `$NAME` is always a deployment-time reference, and `sdk/src/resolver.ts:286,293` substitute `""` for a reference that resolves to nothing. paperclip's script uses three **shell** variables — `$PAPERCLIP_HOME`, `$CFG`, `$BETTER_AUTH_URL` — none in a reserved namespace. All three were blanked. Observed, running the verbatim file at `86684d3` through `resolveExpression`:

```
CFG="/instances/default/config.json"; test -f "" || { timeout 30 pnpm paperclipai onboard --yes >/dev/null 2>&1;
sed -i "s/…/…/" ""; }; pnpm paperclipai auth bootstrap-ceo --base-url ""
```

That is what `sh -c` would have received. `test -f ""` is false so the setup branch always ran; `sed -i … ""` failed on an empty filename; the CEO invite got an empty `--base-url`. Confirmed live against the container — the pre-fix string still prints `sed: can't read : No such file or directory`.

The remedy is in the Launchfile, not the resolver: `$$` is the literal-`$` escape, and it round-trips byte-identically. Changing resolver semantics instead would violate P-9 ("one rule, no exceptions").

**Blast radius, measured:** `lintLaunch` + a bare-`$ref`-in-commands sweep over all **113** catalog Launchfiles (`catalog/apps/**` and `catalog/drafts/**`). paperclip is the only match. One-file correction, not a migration.

---

## Testability

Neither provider had a test touching the bootstrap argv path — both suites were green while the command was mangled, which is the failure mode this PR exists to end. Each provider now exposes a pure `planBootstraps` plus an injectable exec, mirroring `planReleases` / `ReleaseExec` in `release.ts`:

- `providers/docker/src/bootstrap.ts` — `planBootstraps()`, `BootstrapExec`, `runBootstraps()`; `dockerBootstrap()` is now state-load + plan + run.
- `providers/macos-dev/src/bootstrap.ts` — `planBootstraps()`, `BootstrapExec`; `launchBootstrap()` walks the plan.

An empty command and an unparseable `timeout` stay reported rather than thrown (§ Failure semantics, `PROVIDERS.md` §10.10) — they now travel as an `error` on the plan item instead of branching inside the runner.

## Test evidence

**tests pass (614/614)** across every package CI builds, run as CI runs them (`bun test`) plus `tsc --noEmit`:

| Package | Typecheck | Tests | Delta |
|---|---|---|---|
| `sdk` | pass | 299/299 | — |
| `providers/docker` | pass | 135/135 | +11 |
| `providers/macos-dev` | pass | 128/128 | +10 |
| `packages/launchfile` | pass | 42/42 | — |
| `catalog/test` | — | 10/10 | — |

New assertions, per the verdict's required-evidence list:

1. **Docker argv shape** — the vector handed to `docker compose exec -T` is asserted in full: `["compose","-p",project,"exec","-T",service,"sh","-c",<command>]`, command as a single tail element with `&&`, `;`, `||`, brace groups and redirections intact.
2. **macos-dev argv shape** — `["/bin/sh","-c",<command>]`, one element.
3. **Testability prerequisite** — the plan/exec extraction above; (1) and (2) could not be written without it.
4. **Empty-command rejection survives** on both, over `"   "`, `"\n\t "`, `"\t"`.
5. **The paperclip regression test** — the verbatim `catalog/apps/paperclip/Launchfile` goes through resolve → plan on **both** providers and is asserted **on the exact string**, not on `argc`. This is deliberate: 27 argv tokens survive three empty substitutions, so an argc assertion passes on a broken command and would have let defect 2 through.
6. **No catalog regression** — `lintLaunch` over all 113 Launchfiles: zero warnings, zero parse errors.
7. **Behavioral verification** — below.
8. **Typecheck and full suites run separately** per package, so a typecheck failure cannot hide behind green Vitest.

## verified live

Real deploy of the patched catalog file on the Docker provider — CLI run from this branch against the branch's own SDK and provider builds. The deployed file is a byte-identical copy of `catalog/apps/paperclip/Launchfile` with one line changed, `name: paperclip` → `name: gov23-bootstrap-paperclip`, so the run gets its own compose project (`launchfile-gov23-bootstrap-paperclip`) and cannot collide with anything else on the host. `name` appears nowhere in the bootstrap command.

```
$ launchfile up ./gov23-bootstrap-paperclip --docker --name gov23-bootstrap
  ✓ Health check passed
  gov23-bootstrap-paperclip is running at http://localhost:3100

$ launchfile bootstrap gov23-bootstrap
  ↓ Bootstrap [default] via docker compose exec gov23-bootstrap-paperclip
    $ CFG="$PAPERCLIP_HOME/instances/default/config.json"; test -f "$CFG" || { timeout 30 pnpm
      paperclipai onboard --yes >/dev/null 2>&1; sed -i "s/…/…/" "$CFG"; }; pnpm paperclipai
      auth bootstrap-ceo --base-url "$BETTER_AUTH_URL"

  Captured:
    invite_link: *** — One-time invite link — open in your browser to register the CEO account
  ✓ Bootstrap [default] complete
```

Exit code 0. What was observed beyond the green tick:

- The echoed command carries `$PAPERCLIP_HOME`, `$CFG` and `$BETTER_AUTH_URL` **unblanked** — the `$$` escape round-tripped.
- The cold path ran: `/paperclip/instances/default/config.json` was created by this run, and `grep` on it shows `"deploymentMode": "authenticated"` — so `onboard --yes` and the `sed` both executed, which is the branch that was previously guaranteed to run and guaranteed to fail.
- Re-running the resolved command shows the CLI receiving `--base-url "http://localhost:3100"` — the container's real `BETTER_AUTH_URL`, not `""` — and printing `Invite URL: http://localhost:3100/invite/pcp_bootstrap_…` (token redacted here; `capture.invite_link` is `sensitive: true`, which is why the CLI prints `***`).
- `capture.invite_link` produced a value. An empty capture would not have printed the line at all.

Negative controls, both observed on the same container:

- Pre-fix argv split → `OCI runtime exec failed … exec: "CFG=\"/paperclip/…\";"`.
- Pre-fix blanked command → `sed: can't read : No such file or directory`.

Teardown: `launchfile down gov23-bootstrap --destroy` removed all containers, volumes and state; `docker ps -a`, `docker volume ls` and `launchfile list` show nothing left. No container this run did not create was touched.

## Docs

`www-dev/src/pages/learn/lifecycle-commands.astro` already teaches § Command interpretation for command strings generally and carves out no exception for `bootstrap` — confirmed, nothing to change. `www-org` auto-renders. Follow-up F3 proposes the one missing sentence, in `SPEC.md`, about `$$` in commands.

## Commits

Ordered so every commit is green on its own: the catalog escape lands first, because the exact-string regression test added in the provider commit asserts the escaped form.

| SHA | Commit |
|---|---|
| `6f5b764` | `catalog: escape paperclip's shell variables so they reach the shell` |
| `831853b` | `providers: run bootstrap through a POSIX shell on docker and macos-dev` |

## Follow-ups (filed separately, not blockers)

- **F1** — `validate` has no rule for an unresolvable `$ref` in a command; the resolver substitutes `""` silently. That silence is why this bug survived as long as it did.
- **F2** — `providers/macos-dev/src/shell.ts:44` uses `child_process.exec(commandString)`. Moving it to the `execFile(cmd, args)` shape docker uses removes a CWE-78 surface from the only provider that executes on the host.
- **F3** — `SPEC.md` § Command interpretation lists "variable expansion" as available without noting that a bare `$NAME` is consumed by the resolver first and must be written `$$NAME` to reach the shell.

**Cited:** `P-5`, `P-9`, `P-13` · `D-34`, `D-48` ratification (4) · `SPEC.md` § Command interpretation (`:491`), § Failure semantics, `:891` (`$$` escape) · `PROVIDERS.md` §10.8, §10.10, §10 item 11
