### PR TITLE
catalog: drop schedule: from diun and nextcloud-cron drafts

### DIFF
--- a/catalog/drafts/diun/Launchfile
+++ b/catalog/drafts/diun/Launchfile
@@ -4,7 +4,6 @@ name: diun
 description: "Docker image update notifier"
 
 image: crazymax/diun:latest
-schedule: "0 */6 * * *"
 env:
   DIUN_WATCH_SCHEDULE:
     default: "0 */6 * * *"

--- a/catalog/drafts/nextcloud/Launchfile
+++ b/catalog/drafts/nextcloud/Launchfile
@@ -30,9 +30,8 @@ components:
 
   cron:
     image: nextcloud:latest
-    schedule: "*/5 * * * *"
     commands:
       start: "cron.sh"
     depends_on:
       - "app"
-    restart: "no"
+    restart: always


### PR DESCRIPTION
Closes #200

## What

`catalog/drafts/diun/Launchfile` and `catalog/drafts/nextcloud/Launchfile` were the entire catalog usage of the `schedule:` field. Both apps self-schedule internally — diun via `DIUN_WATCH_SCHEDULE`, nextcloud's cron component via `busybox crond -f` inside `cron.sh` — so the field was declaring a cron expression that nothing acting on the Launchfile ever reads or executes. It also triggers D-51's "provider doesn't execute `schedule`" warning at launch, which is a false positive for these two apps: they aren't in the invisible-gap state that warning exists to catch.

This PR:
- Deletes `schedule: "0 */6 * * *"` from `diun`'s top-level Launchfile. `restart: always` was already correct and is untouched.
- Deletes `schedule: "*/5 * * * *"` from `nextcloud`'s `cron` component, and fixes that component's `restart: "no"` to `restart: always` — it's a foreground daemon meant to stay up, matching nextcloud's own upstream reference compose for the identical process.

After this merges, catalog usage of `schedule:` drops to zero; the field's only remaining demonstration in the repo is `spec/examples/cron-job.yaml`.

## Why this matters beyond the two drafts

This is a precondition for #199 (turning on docker-provider `schedule:` execution). Without this fix, executing `schedule:` against either draft as currently written would spawn a fresh long-lived daemon (`diun`, `busybox crond -f`) on every tick, with no bound on accumulation. Landing this first removes that landmine independent of when #199's execution work ships.

## Verification

Both files pass SDK schema validation (`sdk/src/cli.ts validate`):

```
$ bun run src/cli.ts validate ../catalog/drafts/diun/Launchfile
✓ diun is valid
  components: default

$ bun run src/cli.ts validate ../catalog/drafts/nextcloud/Launchfile
✓ nextcloud is valid
  components: app, cron
  requires:   postgres, redis
```

`git grep -n "schedule:" -- catalog/` after the change returns only `catalog/test/README.md:64` — a general note about the test harness's behavior toward the field, not a declaration in any Launchfile. Zero catalog Launchfiles declare `schedule:` after this PR.

Per `catalog/CLAUDE.md`, `drafts/` is untested work-in-progress; schema validation is the documented bar for a draft-tier correction like this one. No live `docker compose up` run performed (not required by convention here — no new capability, no new failure surface).
