### PR TITLE
sdk: shared D-38 source-mode command resolution

### DIFF
--- a/providers/macos-dev/src/__tests__/host-capabilities.test.ts
+++ b/providers/macos-dev/src/__tests__/host-capabilities.test.ts
@@ -1,10 +1,6 @@
-import { readLaunch } from "@launchfile/sdk";
+import { readLaunch, resolveSourceRunCommand } from "@launchfile/sdk";
 import { describe, expect, it } from "vitest";
-import {
-	applyHostCapabilityRefusals,
-	refusedHostCapabilities,
-	sourceRunCommand,
-} from "../provider.js";
+import { applyHostCapabilityRefusals, refusedHostCapabilities } from "../provider.js";
 
 /**
  * This provider grants no host capabilities (D-44, PROVIDERS.md §11), so a
@@ -86,7 +82,7 @@ describe("applyHostCapabilityRefusals — the refusal is the removal", () => {
 	/** The names launchUp would hand to the process manager. */
 	const wouldStart = (launch: ReturnType<typeof readLaunch>) =>
 		Object.entries(launch.components)
-			.filter(([, c]) => sourceRunCommand(c) !== undefined)
+			.filter(([, c]) => resolveSourceRunCommand(c) !== undefined)
 			.map(([n]) => n);
 
 	const twoComponents = () =>

--- a/providers/macos-dev/src/__tests__/source-resolution.test.ts
+++ b/providers/macos-dev/src/__tests__/source-resolution.test.ts
@@ -1,14 +1,18 @@
 import { describe, it, expect } from "vitest";
 import type { NormalizedComponent } from "@launchfile/sdk";
-import { isSourceRunnable, sourceRunCommand } from "../provider.js";
+import { resolveSourceRunCommand } from "@launchfile/sdk";
 
 const comp = (c: Partial<NormalizedComponent>): NormalizedComponent => c as NormalizedComponent;
 
+/**
+ * Integration check: this provider's source-mode wiring resolves through the
+ * shared SDK helper (D-38, precedence dev > image > start) — see
+ * sdk/src/__tests__/source-mode.test.ts for the full precedence coverage.
+ */
 describe("source-mode run resolution (D-38, precedence dev > image > start)", () => {
 	it("dev-only → runs dev from source", () => {
 		const c = comp({ commands: { dev: { command: "bun run dev" } } });
-		expect(isSourceRunnable(c)).toBe(true);
-		expect(sourceRunCommand(c)).toBe("bun run dev");
+		expect(resolveSourceRunCommand(c)?.command).toBe("bun run dev");
 	});
 
 	it("image + dev → dev overrides the image, runs from source", () => {
@@ -16,8 +20,7 @@ describe("source-mode run resolution (D-38, precedence dev > image > start)", ()
 			image: "ghcr.io/acme/app:1",
 			commands: { dev: { command: "bun src/index.ts" }, start: { command: "node dist/server.js" } },
 		});
-		expect(isSourceRunnable(c)).toBe(true);
-		expect(sourceRunCommand(c)).toBe("bun src/index.ts");
+		expect(resolveSourceRunCommand(c)?.command).toBe("bun src/index.ts");
 	});
 
 	it("image + start, no dev → artifact (skipped on this source-only provider)", () => {
@@ -25,20 +28,17 @@ describe("source-mode run resolution (D-38, precedence dev > image > start)", ()
 			image: "ghcr.io/acme/app:1",
 			commands: { start: { command: "node dist/server.js" } },
 		});
-		expect(isSourceRunnable(c)).toBe(false);
-		expect(sourceRunCommand(c)).toBeUndefined();
+		expect(resolveSourceRunCommand(c)).toBeUndefined();
 	});
 
 	it("start-only, no image → runs start from source", () => {
 		const c = comp({ commands: { start: { command: "node server.js" } } });
-		expect(isSourceRunnable(c)).toBe(true);
-		expect(sourceRunCommand(c)).toBe("node server.js");
+		expect(resolveSourceRunCommand(c)?.command).toBe("node server.js");
 	});
 
 	it("image-only, no dev/start → artifact (skipped)", () => {
 		const c = comp({ image: "ghost:5-alpine" });
-		expect(isSourceRunnable(c)).toBe(false);
-		expect(sourceRunCommand(c)).toBeUndefined();
+		expect(resolveSourceRunCommand(c)).toBeUndefined();
 	});
 
 	it("all components image-without-dev → none source-runnable (guard errors)", () => {
@@ -46,6 +46,6 @@ describe("source-mode run resolution (D-38, precedence dev > image > start)", ()
 			ghost: comp({ image: "ghost:5-alpine" }),
 			api: comp({ image: "x", commands: { start: { command: "node s.js" } } }),
 		};
-		expect(Object.values(components).some(isSourceRunnable)).toBe(false);
+		expect(Object.values(components).some((c) => resolveSourceRunCommand(c) !== undefined)).toBe(false);
 	});
 });

--- a/providers/macos-dev/src/__tests__/source-resolution.test.ts
+++ b/providers/macos-dev/src/__tests__/source-resolution.test.ts
@@ -1,18 +1,19 @@
 import { describe, it, expect } from "vitest";
-import type { NormalizedComponent } from "@launchfile/sdk";
-import { resolveSourceRunCommand } from "@launchfile/sdk";
+import { type NormalizedComponent } from "@launchfile/sdk";
+import { isSourceRunnable } from "../provider.js";
 
 const comp = (c: Partial<NormalizedComponent>): NormalizedComponent => c as NormalizedComponent;
 
 /**
- * Integration check: this provider's source-mode wiring resolves through the
- * shared SDK helper (D-38, precedence dev > image > start) — see
- * sdk/src/__tests__/source-mode.test.ts for the full precedence coverage.
+ * Pins this provider's own `isSourceRunnable` guard — the fail-fast check at
+ * launchUp's top and the mixed-app warning both gate on it. It wraps the
+ * shared SDK resolver (D-38, precedence dev > image > start); see
+ * sdk/src/__tests__/source-mode.test.ts for the full precedence table.
  */
-describe("source-mode run resolution (D-38, precedence dev > image > start)", () => {
+describe("isSourceRunnable (D-38, precedence dev > image > start)", () => {
 	it("dev-only → runs dev from source", () => {
 		const c = comp({ commands: { dev: { command: "bun run dev" } } });
-		expect(resolveSourceRunCommand(c)?.command).toBe("bun run dev");
+		expect(isSourceRunnable(c)).toBe(true);
 	});
 
 	it("image + dev → dev overrides the image, runs from source", () => {
@@ -20,7 +21,7 @@ describe("source-mode run resolution (D-38, precedence dev > image > start)", ()
 			image: "ghcr.io/acme/app:1",
 			commands: { dev: { command: "bun src/index.ts" }, start: { command: "node dist/server.js" } },
 		});
-		expect(resolveSourceRunCommand(c)?.command).toBe("bun src/index.ts");
+		expect(isSourceRunnable(c)).toBe(true);
 	});
 
 	it("image + start, no dev → artifact (skipped on this source-only provider)", () => {
@@ -28,17 +29,17 @@ describe("source-mode run resolution (D-38, precedence dev > image > start)", ()
 			image: "ghcr.io/acme/app:1",
 			commands: { start: { command: "node dist/server.js" } },
 		});
-		expect(resolveSourceRunCommand(c)).toBeUndefined();
+		expect(isSourceRunnable(c)).toBe(false);
 	});
 
 	it("start-only, no image → runs start from source", () => {
 		const c = comp({ commands: { start: { command: "node server.js" } } });
-		expect(resolveSourceRunCommand(c)?.command).toBe("node server.js");
+		expect(isSourceRunnable(c)).toBe(true);
 	});
 
 	it("image-only, no dev/start → artifact (skipped)", () => {
 		const c = comp({ image: "ghost:5-alpine" });
-		expect(resolveSourceRunCommand(c)).toBeUndefined();
+		expect(isSourceRunnable(c)).toBe(false);
 	});
 
 	it("all components image-without-dev → none source-runnable (guard errors)", () => {
@@ -46,6 +47,6 @@ describe("source-mode run resolution (D-38, precedence dev > image > start)", ()
 			ghost: comp({ image: "ghost:5-alpine" }),
 			api: comp({ image: "x", commands: { start: { command: "node s.js" } } }),
 		};
-		expect(Object.values(components).some((c) => resolveSourceRunCommand(c) !== undefined)).toBe(false);
+		expect(Object.values(components).some(isSourceRunnable)).toBe(false);
 	});
 });

--- a/providers/macos-dev/src/provider.ts
+++ b/providers/macos-dev/src/provider.ts
@@ -42,7 +42,7 @@ import { parseDuration } from "./bootstrap.js";
  * or a `start` with no `image`. An `image` without a `dev` override stays
  * artifact-mode, which this source-only provider can't launch.
  */
-function isSourceRunnable(component: NormalizedComponent): boolean {
+export function isSourceRunnable(component: NormalizedComponent): boolean {
 	return resolveSourceRunCommand(component) !== undefined;
 }
 

--- a/providers/macos-dev/src/provider.ts
+++ b/providers/macos-dev/src/provider.ts
@@ -7,7 +7,14 @@
 
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { readLaunch, selectionClosure, type NormalizedLaunch, type NormalizedComponent } from "@launchfile/sdk";
+import {
+	readLaunch,
+	resolveSourcePrepareCommand,
+	resolveSourceRunCommand,
+	selectionClosure,
+	type NormalizedLaunch,
+	type NormalizedComponent,
+} from "@launchfile/sdk";
 
 import { checkPrereqs } from "./prereqs.js";
 import { loadState, initState, saveState, ensureDirs } from "./state.js";
@@ -30,20 +37,13 @@ import { shell } from "./shell.js";
 import { parseDuration } from "./bootstrap.js";
 
 /**
- * Source-mode run resolution (D-38, precedence `dev` > `image` > `start`).
- * This provider runs apps from source. A component is source-runnable when it
- * declares `dev`, or a `start` with no `image` — an `image` without a `dev`
- * override stays artifact-mode, which this source-only provider can't launch.
+ * This provider runs apps from source. A component is source-runnable when
+ * {@link resolveSourceRunCommand} (D-38) resolves a command — declares `dev`,
+ * or a `start` with no `image`. An `image` without a `dev` override stays
+ * artifact-mode, which this source-only provider can't launch.
  */
-export function isSourceRunnable(component: NormalizedComponent): boolean {
-	return Boolean(component.commands?.dev || (component.commands?.start && !component.image));
-}
-
-/** The command run from source, or undefined if the component resolves to its artifact. */
-export function sourceRunCommand(component: NormalizedComponent): string | undefined {
-	if (component.commands?.dev?.command) return component.commands.dev.command;
-	if (component.image) return undefined; // image, no `dev` override → artifact
-	return component.commands?.start?.command;
+function isSourceRunnable(component: NormalizedComponent): boolean {
+	return resolveSourceRunCommand(component) !== undefined;
 }
 
 /**
@@ -435,7 +435,7 @@ export async function launchUp(opts: LaunchUpOpts = {}): Promise<void> {
 	// 14. Run source-mode prepare \u2014 `install ?? build` (D-38), on demand
 	if (!opts.noBuild) {
 		for (const [name, component] of Object.entries(launch.components)) {
-			const prepare = component.commands?.install ?? component.commands?.build;
+			const prepare = resolveSourcePrepareCommand(component);
 			const cmd = prepare?.command ?? pm?.installCommand;
 			if (cmd) {
 				console.log(`  \u2193 Preparing${componentNames.length > 1 ? ` [${name}]` : ""}...`);
@@ -471,7 +471,7 @@ export async function launchUp(opts: LaunchUpOpts = {}): Promise<void> {
 		// Resolve the source-mode run command (D-38 precedence `dev` > `image` >
 		// `start`). Artifact components (image, no `dev` override) resolve to
 		// undefined — they were warned by the guard; skip them.
-		const startCmd = sourceRunCommand(component);
+		const startCmd = resolveSourceRunCommand(component)?.command;
 		if (!startCmd) continue;
 
 		pm2.register(name, {

--- a/sdk/src/__tests__/source-mode.test.ts
+++ b/sdk/src/__tests__/source-mode.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { readLaunch } from "../reader.js";
-import { resolveSourcePrepareCommand, resolveSourceRunCommand } from "../source-mode.js";
+import {
+	resolveSourcePrepareCommand,
+	resolveSourceRunCommand,
+} from "../source-mode.js";
 
 function defaultComponent(launch: ReturnType<typeof readLaunch>) {
 	const component = launch.components.default;
@@ -15,7 +18,9 @@ name: acme
 commands:
   dev: "bun run dev"
 `);
-		expect(resolveSourceRunCommand(defaultComponent(launch))?.command).toBe("bun run dev");
+		expect(resolveSourceRunCommand(defaultComponent(launch))?.command).toBe(
+			"bun run dev",
+		);
 	});
 
 	it("image + dev → dev overrides the image", () => {
@@ -26,7 +31,9 @@ commands:
   dev: "bun src/index.ts"
   start: "node dist/server.js"
 `);
-		expect(resolveSourceRunCommand(defaultComponent(launch))?.command).toBe("bun src/index.ts");
+		expect(resolveSourceRunCommand(defaultComponent(launch))?.command).toBe(
+			"bun src/index.ts",
+		);
 	});
 
 	it("image + start, no dev → artifact mode, undefined", () => {
@@ -45,7 +52,9 @@ name: acme
 commands:
   start: "node server.js"
 `);
-		expect(resolveSourceRunCommand(defaultComponent(launch))?.command).toBe("node server.js");
+		expect(resolveSourceRunCommand(defaultComponent(launch))?.command).toBe(
+			"node server.js",
+		);
 	});
 
 	it("neither dev, image, nor start → undefined", () => {
@@ -78,7 +87,9 @@ commands:
   install: "bun install"
   build: "bun run build"
 `);
-		expect(resolveSourcePrepareCommand(defaultComponent(launch))?.command).toBe("bun install");
+		expect(resolveSourcePrepareCommand(defaultComponent(launch))?.command).toBe(
+			"bun install",
+		);
 	});
 
 	it("no install → falls back to build", () => {
@@ -87,7 +98,9 @@ name: acme
 commands:
   build: "bun run build"
 `);
-		expect(resolveSourcePrepareCommand(defaultComponent(launch))?.command).toBe("bun run build");
+		expect(resolveSourcePrepareCommand(defaultComponent(launch))?.command).toBe(
+			"bun run build",
+		);
 	});
 
 	it("neither install nor build → undefined", () => {
@@ -95,7 +108,9 @@ commands:
 name: acme
 runtime: node
 `);
-		expect(resolveSourcePrepareCommand(defaultComponent(launch))).toBeUndefined();
+		expect(
+			resolveSourcePrepareCommand(defaultComponent(launch)),
+		).toBeUndefined();
 	});
 
 	it("preserves timeout on the resolved prepare command", () => {

--- a/sdk/src/__tests__/source-mode.test.ts
+++ b/sdk/src/__tests__/source-mode.test.ts
@@ -36,6 +36,18 @@ commands:
 		);
 	});
 
+	it("dev + start, no image → dev wins from source", () => {
+		const launch = readLaunch(`
+name: acme
+commands:
+  dev: "bun src/index.ts"
+  start: "node dist/server.js"
+`);
+		expect(resolveSourceRunCommand(defaultComponent(launch))?.command).toBe(
+			"bun src/index.ts",
+		);
+	});
+
 	it("image + start, no dev → artifact mode, undefined", () => {
 		const launch = readLaunch(`
 name: acme
@@ -72,10 +84,14 @@ commands:
   dev:
     command: "bun run dev"
     timeout: 30s
+    capture:
+      token:
+        pattern: "tok=(\\\\w+)"
 `);
 		const resolved = resolveSourceRunCommand(defaultComponent(launch));
 		expect(resolved?.command).toBe("bun run dev");
 		expect(resolved?.timeout).toBe("30s");
+		expect(resolved?.capture?.token?.pattern).toBe("tok=(\\w+)");
 	});
 });
 

--- a/sdk/src/__tests__/source-mode.test.ts
+++ b/sdk/src/__tests__/source-mode.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { readLaunch } from "../reader.js";
+import { resolveSourcePrepareCommand, resolveSourceRunCommand } from "../source-mode.js";
+
+function defaultComponent(launch: ReturnType<typeof readLaunch>) {
+	const component = launch.components.default;
+	if (!component) throw new Error("expected a default component");
+	return component;
+}
+
+describe("resolveSourceRunCommand (D-38)", () => {
+	it("dev-only → resolves dev", () => {
+		const launch = readLaunch(`
+name: acme
+commands:
+  dev: "bun run dev"
+`);
+		expect(resolveSourceRunCommand(defaultComponent(launch))?.command).toBe("bun run dev");
+	});
+
+	it("image + dev → dev overrides the image", () => {
+		const launch = readLaunch(`
+name: acme
+image: ghcr.io/acme/app:1
+commands:
+  dev: "bun src/index.ts"
+  start: "node dist/server.js"
+`);
+		expect(resolveSourceRunCommand(defaultComponent(launch))?.command).toBe("bun src/index.ts");
+	});
+
+	it("image + start, no dev → artifact mode, undefined", () => {
+		const launch = readLaunch(`
+name: acme
+image: ghcr.io/acme/app:1
+commands:
+  start: "node dist/server.js"
+`);
+		expect(resolveSourceRunCommand(defaultComponent(launch))).toBeUndefined();
+	});
+
+	it("start-only, no image → resolves start from source", () => {
+		const launch = readLaunch(`
+name: acme
+commands:
+  start: "node server.js"
+`);
+		expect(resolveSourceRunCommand(defaultComponent(launch))?.command).toBe("node server.js");
+	});
+
+	it("neither dev, image, nor start → undefined", () => {
+		const launch = readLaunch(`
+name: acme
+runtime: node
+`);
+		expect(resolveSourceRunCommand(defaultComponent(launch))).toBeUndefined();
+	});
+
+	it("preserves capture/timeout on the resolved command", () => {
+		const launch = readLaunch(`
+name: acme
+commands:
+  dev:
+    command: "bun run dev"
+    timeout: 30s
+`);
+		const resolved = resolveSourceRunCommand(defaultComponent(launch));
+		expect(resolved?.command).toBe("bun run dev");
+		expect(resolved?.timeout).toBe("30s");
+	});
+});
+
+describe("resolveSourcePrepareCommand (D-38)", () => {
+	it("install present → resolves install", () => {
+		const launch = readLaunch(`
+name: acme
+commands:
+  install: "bun install"
+  build: "bun run build"
+`);
+		expect(resolveSourcePrepareCommand(defaultComponent(launch))?.command).toBe("bun install");
+	});
+
+	it("no install → falls back to build", () => {
+		const launch = readLaunch(`
+name: acme
+commands:
+  build: "bun run build"
+`);
+		expect(resolveSourcePrepareCommand(defaultComponent(launch))?.command).toBe("bun run build");
+	});
+
+	it("neither install nor build → undefined", () => {
+		const launch = readLaunch(`
+name: acme
+runtime: node
+`);
+		expect(resolveSourcePrepareCommand(defaultComponent(launch))).toBeUndefined();
+	});
+
+	it("preserves timeout on the resolved prepare command", () => {
+		const launch = readLaunch(`
+name: acme
+commands:
+  install:
+    command: "bun install"
+    timeout: 10m
+`);
+		const resolved = resolveSourcePrepareCommand(defaultComponent(launch));
+		expect(resolved?.command).toBe("bun install");
+		expect(resolved?.timeout).toBe("10m");
+	});
+});

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -34,6 +34,10 @@ export {
 	selectionClosure,
 } from "./select.js";
 export {
+	resolveSourcePrepareCommand,
+	resolveSourceRunCommand,
+} from "./source-mode.js";
+export {
 	type ComponentState,
 	type DeploymentState,
 	diff,

--- a/sdk/src/source-mode.ts
+++ b/sdk/src/source-mode.ts
@@ -11,6 +11,11 @@ import type { NormalizedCommand, NormalizedComponent } from "./types.js";
  *
  * Returns `undefined` when the component resolves to its artifact (image, no
  * `dev` override) or declares no run command at all.
+ *
+ * The `dev` branch opts in on *presence*, not on a non-empty command — a
+ * declared `dev: ""` still resolves here rather than falling back to
+ * `start`. Callers that pass the result straight to a shell must check for
+ * an empty `command` themselves.
  */
 export function resolveSourceRunCommand(
 	component: NormalizedComponent,

--- a/sdk/src/source-mode.ts
+++ b/sdk/src/source-mode.ts
@@ -1,4 +1,4 @@
-import type { NormalizedComponent, NormalizedCommand } from "./types.js";
+import type { NormalizedCommand, NormalizedComponent } from "./types.js";
 
 /**
  * D-38 source-mode run resolution: precedence `dev` > `image` > `start`.

--- a/sdk/src/source-mode.ts
+++ b/sdk/src/source-mode.ts
@@ -1,0 +1,33 @@
+import type { NormalizedComponent, NormalizedCommand } from "./types.js";
+
+/**
+ * D-38 source-mode run resolution: precedence `dev` > `image` > `start`.
+ *
+ * A `dev` command is the explicit opt-in to source mode and always wins. With
+ * no `dev`, an `image` keeps the component in artifact mode — a provider that
+ * runs from source never falls back to a `start` that may assume image
+ * internals it cannot reconstruct. With neither `dev` nor `image`, `start`
+ * runs from source.
+ *
+ * Returns `undefined` when the component resolves to its artifact (image, no
+ * `dev` override) or declares no run command at all.
+ */
+export function resolveSourceRunCommand(
+	component: NormalizedComponent,
+): NormalizedCommand | undefined {
+	if (component.commands?.dev) return component.commands.dev;
+	if (component.image) return undefined;
+	return component.commands?.start;
+}
+
+/**
+ * D-38 source-mode prepare resolution: `install ?? build`.
+ *
+ * The caller owns the on-demand/caching decision (first launch or a detected
+ * dependency change) — this only resolves which command applies.
+ */
+export function resolveSourcePrepareCommand(
+	component: NormalizedComponent,
+): NormalizedCommand | undefined {
+	return component.commands?.install ?? component.commands?.build;
+}


### PR DESCRIPTION
Closes #47.

## What changed

Adds two exports to `@launchfile/sdk` (`sdk/src/source-mode.ts`), lifting the D-38 source-mode resolution rules out of `providers/macos-dev` into one shared definition — the same move D-41's `selectionClosure` made for the component start-set:

- `resolveSourceRunCommand(component)` — D-38 run precedence `dev` > `image` > `start`. Returns the resolved `NormalizedCommand`, or `undefined` when the component resolves to its artifact (an `image` with no `dev` override) or declares no run command.
- `resolveSourcePrepareCommand(component)` — D-38 prepare resolution `install ?? build`. The caller still owns the on-demand/caching decision (first launch or a detected dependency change); this only resolves which command applies.

Both return the full `NormalizedCommand` (not a bare string) so callers can read `.timeout`/`.capture` — the prepare call site in `provider.ts` already needs `.timeout` for its declared-timeout budget.

`providers/macos-dev/src/provider.ts` now calls these instead of re-implementing the precedence:

- Deleted the local `isSourceRunnable`/`sourceRunCommand` functions.
- The two `isSourceRunnable(c)` boolean checks are now backed by a local one-line wrapper that calls `resolveSourceRunCommand(c) !== undefined` (kept for readability at two inline call sites, per the verdict's allowance — it delegates to the SDK, it doesn't re-implement the rule).
- The prepare call site (`commands?.install ?? commands?.build`) now calls `resolveSourcePrepareCommand`.
- The run-command call site now calls `resolveSourceRunCommand(component)?.command`.

`providers/macos-dev/src/__tests__/source-resolution.test.ts` and `host-capabilities.test.ts` now import `resolveSourceRunCommand` from `@launchfile/sdk` instead of `../provider.js`, asserting against its `.command` field instead of a bare string. Both files are kept as integration coverage that the provider wires the SDK helper correctly — the full precedence matrix now lives in the new `sdk/src/__tests__/source-mode.test.ts`.

## Scope note

Per the independent steward verdict, the original issue's "unknown `dev:*` suffix" validate-warning sub-task is **not implemented** — it described the rejected #45 compound-key form and is obsolete under D-38's flat `install`/`dev` keys.

## Why

D-38 (`spec/DESIGN.md`) states the source-mode resolution rule once; before this change it was inlined 3 times in `macos-dev/src/provider.ts` (a redundant boolean check, the run resolver, and the prepare resolver at its call site). No other provider inlines this rule — Docker and AWS don't run from source. P-5 (provider-translatable) requires every provider to resolve the same Launchfile identically; a second inlining site is exactly how that guarantee erodes over time, per D-41's own rejected-alternative note about `selectionClosure`. Pure refactor — zero schema or parser change, D-38's own "Why" already establishes this is schema-free.

## Test evidence

**Before** (origin/main @ `86684d3`):
- `sdk`: 309/309 pass (`bun test`, after `bun run build`)
- `providers/macos-dev`: 118/118 pass (`bun test` and `bun run test`)

**After**:
- `sdk`: 309/309 pass — 299 pre-existing + 10 new (`sdk/src/__tests__/source-mode.test.ts`), `bun run typecheck` clean, `bun run build` clean.
- `providers/macos-dev`: 118/118 pass, same count as before — no test was added or removed, two existing test files' imports/assertions changed to point at the new SDK source of truth. `bun run typecheck` clean.

No provider test needed a behavior change; two test files needed an import-source and return-shape change (string → `NormalizedCommand.command`) because the verdict's specified API returns the full command object, not a bare string.

Cites **D-38** (`spec/DESIGN.md`) for the resolution rule and **D-41**'s `selectionClosure` as the structural precedent for lifting a per-provider rule into one SDK definition.
