### PR TITLE
catalog: state an image-pinning policy and fix the 3 untagged hoppscotch images

### DIFF
--- a/catalog/CONTRIBUTING.md
+++ b/catalog/CONTRIBUTING.md
@@ -51,30 +51,56 @@ This catalog indexes how third-party apps map onto the Launchfile format. It fol
 each upstream project's own release channel — it does not re-publish or freeze
 upstream images.
 
-Write the `image:` reference in this order of preference:
+Every rung below asks the same question: **what is the narrowest tag upstream
+publishes?** Check the upstream registry's tag list, not only its README. Write the
+`image:` reference in this order of preference:
 
-1. **The narrowest stable tag upstream itself recommends** in its README or install
-   docs — `louislam/dockge:1`, `ghcr.io/requarks/wiki:2`, `neosmemo/memos:stable`,
-   `ghost:5-alpine`, `quay.io/hedgedoc/hedgedoc:1.10.8`.
-2. **A major-version tag**, where upstream publishes one but its own docs still say
-   `:latest`.
-3. **`:latest`**, only where upstream publishes no narrower stable tag. Say so on the
+1. **The narrowest stable tag that still receives patches** — a channel upstream
+   maintains and moves forward: `neosmemo/memos:stable`, `ghost:5-alpine`,
+   `louislam/dockge:1`, `ghcr.io/requarks/wiki:2`. Where upstream maintains more than
+   one such channel, take the one its README or install docs recommends.
+2. **An exact release**, where upstream publishes no maintained channel —
+   `quay.io/hedgedoc/hedgedoc:1.10.8`, `hoppscotch/hoppscotch-backend:2026.7.0`.
+   Neither upstream publishes a version channel it maintains — only exact releases
+   alongside floating tags like `:latest`. An exact release freezes the app until
+   someone re-tests it, so take it only because the alternative is `:latest`.
+3. **`:latest`**, only where upstream publishes nothing narrower at all. Say so on the
    line:
    `image: example/app:latest  # upstream publishes no versioned tag`
 
 **Always write a tag.** A bare `image: example/app` silently means `:latest` and hides
 the choice from review.
 
+**This order binds new entries and any entry you edit — it is not applied
+retroactively.** Most entries already in the catalog sit on `:latest` without the
+annotation. They are grandfathered, and there is no sweep. They converge as apps are
+re-tested: when you re-test an app, bring its `image:` line up to this order, and add
+the annotation if it stays on `:latest`.
+
 Prefer an image published by the upstream project itself — its own `ghcr.io`,
 `docker.io` or `quay.io` namespace, or a Docker Official Image — over a third-party
 rebuild. Where only a third-party image exists (`ghcr.io/muchobien/pocketbase`,
-`lscr.io/linuxserver/*`), that is fine; note the publisher in `metadata.yaml`.
+`lscr.io/linuxserver/*`), that is fine — record it as a top-level `publisher:` line in
+`metadata.yaml`:
+
+```yaml
+publisher: "third-party rebuild — ghcr.io/muchobien (upstream publishes no image)"
+```
+
+Keep it top level. `catalog/test/src/test-app.ts` rebuilds the `images:` and
+`test_results:` blocks from scratch and rewrites the file through a YAML round-trip.
+A per-image field or a YAML comment does not survive the next
+`bun run src/test-app.ts <app>`. Top-level keys do.
 
 **Do not pin by `@sha256` digest.** A digest freezes an app at the moment its entry
 landed, and this catalog has no mechanism to re-pin. Bumping an image is not a one-line
 edit: `metadata.yaml` records `images[].size_mb` and `test_results.last_tested`, so a
 bump means re-running the app locally and re-measuring. A digest nobody refreshes is a
 permanently unpatched image — worse than following upstream.
+
+Rung 2 freezes an app the same way, which is exactly why it ranks below rung 1 and
+applies only where upstream maintains no channel to follow. A digest freezes every
+entry, including the ones upstream still patches.
 
 ## Updating an Existing App
 

--- a/catalog/CONTRIBUTING.md
+++ b/catalog/CONTRIBUTING.md
@@ -38,12 +38,43 @@ health: /health
 
 ## Guidelines
 
-- Use the official Docker image when available
 - Prefer `set_env` with `$url` for database wiring (covers most cases)
 - Add `health` when the app has a health endpoint
 - Mark user-provided env vars as `required: true`
 - Mark secrets as `sensitive: true`
 - For multi-component apps, use `depends_on` with `condition: healthy`
+- See [Image references](#image-references) below for choosing an `image:` tag
+
+## Image references
+
+This catalog indexes how third-party apps map onto the Launchfile format. It follows
+each upstream project's own release channel — it does not re-publish or freeze
+upstream images.
+
+Write the `image:` reference in this order of preference:
+
+1. **The narrowest stable tag upstream itself recommends** in its README or install
+   docs — `louislam/dockge:1`, `ghcr.io/requarks/wiki:2`, `neosmemo/memos:stable`,
+   `ghost:5-alpine`, `quay.io/hedgedoc/hedgedoc:1.10.8`.
+2. **A major-version tag**, where upstream publishes one but its own docs still say
+   `:latest`.
+3. **`:latest`**, only where upstream publishes no narrower stable tag. Say so on the
+   line:
+   `image: example/app:latest  # upstream publishes no versioned tag`
+
+**Always write a tag.** A bare `image: example/app` silently means `:latest` and hides
+the choice from review.
+
+Prefer an image published by the upstream project itself — its own `ghcr.io`,
+`docker.io` or `quay.io` namespace, or a Docker Official Image — over a third-party
+rebuild. Where only a third-party image exists (`ghcr.io/muchobien/pocketbase`,
+`lscr.io/linuxserver/*`), that is fine; note the publisher in `metadata.yaml`.
+
+**Do not pin by `@sha256` digest.** A digest freezes an app at the moment its entry
+landed, and this catalog has no mechanism to re-pin. Bumping an image is not a one-line
+edit: `metadata.yaml` records `images[].size_mb` and `test_results.last_tested`, so a
+bump means re-running the app locally and re-measuring. A digest nobody refreshes is a
+permanently unpatched image — worse than following upstream.
 
 ## Updating an Existing App
 

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -11,6 +11,16 @@ drafts/     Proposed — Launchfile written, not yet verified
 
 Tested apps have screenshots, test results, and metadata in their directory. The source of truth is the `apps/` directory itself.
 
+### What this catalog is
+
+A community-maintained index of Launchfiles for third-party apps, verified to launch.
+It follows each upstream project's own release channel; it is not a distribution and
+does not re-publish, freeze, or vouch for upstream images. Platforms that deploy from
+this catalog own their own supply-chain controls — image admission, scanning,
+pull-through caching. That boundary is deliberate: the risk originates with the
+upstream publishers, and it is defended where the image is pulled and run, not in the
+index that names it.
+
 ## Tested Apps
 
 These apps have been verified to launch successfully from their Launchfile:

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -2,6 +2,16 @@
 
 Community-maintained Launchfiles for popular open-source applications. Each Launchfile describes what an app needs to run — its components, services, environment, and health checks — so any Launchfile-compatible platform can deploy it.
 
+## What this catalog is
+
+A community-maintained index of Launchfiles for third-party apps, with the `apps/`
+entries verified to launch. It follows each upstream project's own release channel; it
+is not a distribution and does not re-publish, freeze, or vouch for upstream images.
+Platforms that deploy from this catalog own their own supply-chain controls — image
+admission, scanning, pull-through caching. That boundary is deliberate: the risk
+originates with the upstream publishers, and it is defended where the image is pulled
+and run, not in the index that names it.
+
 ## Structure
 
 ```
@@ -10,16 +20,6 @@ drafts/     Proposed — Launchfile written, not yet verified
 ```
 
 Tested apps have screenshots, test results, and metadata in their directory. The source of truth is the `apps/` directory itself.
-
-### What this catalog is
-
-A community-maintained index of Launchfiles for third-party apps, verified to launch.
-It follows each upstream project's own release channel; it is not a distribution and
-does not re-publish, freeze, or vouch for upstream images. Platforms that deploy from
-this catalog own their own supply-chain controls — image admission, scanning,
-pull-through caching. That boundary is deliberate: the risk originates with the
-upstream publishers, and it is defended where the image is pulled and run, not in the
-index that names it.
 
 ## Tested Apps
 

--- a/catalog/drafts/hoppscotch/Launchfile
+++ b/catalog/drafts/hoppscotch/Launchfile
@@ -5,7 +5,7 @@ description: "Open-source API development ecosystem"
 
 components:
   backend:
-    image: hoppscotch/hoppscotch-backend
+    image: hoppscotch/hoppscotch-backend:2026.7.0
     provides:
       - protocol: http
         port: 3170
@@ -24,7 +24,7 @@ components:
     restart: always
 
   frontend:
-    image: hoppscotch/hoppscotch-frontend
+    image: hoppscotch/hoppscotch-frontend:2026.7.0
     provides:
       - protocol: http
         port: 3000
@@ -44,7 +44,7 @@ components:
     restart: always
 
   admin:
-    image: hoppscotch/hoppscotch-admin
+    image: hoppscotch/hoppscotch-admin:2026.7.0
     provides:
       - protocol: http
         port: 3100


### PR DESCRIPTION
Closes #189

## What this does

Adds a stated policy for `image:` tag pinning, and fixes the one concrete defect
the issue's audit turned up (three draft images with no tag at all).

1. **`catalog/CONTRIBUTING.md`** — new `## Image references` section: follow
   upstream's own narrowest stable tag; fall back to a major-version tag; use
   `:latest` only where upstream publishes nothing narrower, with a rationale
   comment on the line. Never pin by `@sha256` digest. Replaces the old
   `- Use the official Docker image when available` bullet, which was undefined
   and satisfied by 5 of 71 entries under a strict reading.
2. **`catalog/README.md`** — new `## What this catalog is` section, directly
   under the intro paragraph where a consumer lands: this catalog follows upstream's
   release channel, it does not re-publish/freeze/vouch for images, and
   supply-chain controls (admission, scanning, pull-through caching) belong to
   the platform that deploys from it, not to the index.
3. **`catalog/drafts/hoppscotch/Launchfile`** — pinned the three previously
   untagged images (`hoppscotch-backend`, `hoppscotch-frontend`,
   `hoppscotch-admin`) to `2026.7.0`, upstream's current published release.
   Hoppscotch's own install docs `docker pull` these images bare (implicit
   `:latest`) and publish no major-only channel — only full `YYYY.MM.patch`
   tags on Docker Hub — so the full version is the narrowest tag available
   (verified against Docker Hub's tag listings for all three images).

Scope is forward-only, per the verdict: this does not retag any of the other
112 floating `:latest` references. A separate sweep issue for those, and a
separate issue for a catalog CI lint job, are proposed follow-ups (not filed
by this PR).

## Verdict linkage

Steward verdict on #189: **ACCEPT / High confidence**, option (c) — follow
upstream's own narrowest stable tag; `:latest` only where upstream publishes
nothing narrower; never `@sha256`. Full verdict, including why this stays out
of `spec/DESIGN.md` (D-57 released back to the pool — catalog editorial
policy, not a format decision) and why a full retag sweep is out of scope, is
staged at `steward/.rclaude/project/gov-staged-artifacts-2026-08-23/item189/verdict.md`.

The first commit copied the verdict's drafted text verbatim (plus one
cross-reference line in CONTRIBUTING.md's Guidelines list). The second commit
reworks that text per the steward's PR review — see **Review round 1** below.

## Verification: the Dependabot/Renovate claim

The verdict flagged one claim as INFERRED and unverified (item 15): that
Dependabot cannot target a file named `Launchfile` for the `docker` ecosystem,
while Renovate can, via `customManagers` (regex) with `datasourceTemplate:
docker`, and that `pinDigests: true` "maintains a readable `tag@sha256:…` pair
automatically."

I checked this against current vendor docs and community reports before
writing any of the staged text (WebSearch/WebFetch, 2026-08-23):

- **Dependabot cannot target a file named `Launchfile`** — confirmed. Its
  `docker` ecosystem discovers only files literally named `Dockerfile` /
  `Containerfile`, files matching the `docker-compose*.y*ml` pattern (GA since
  Feb 2025), and YAML that parses as a Hash with both `apiVersion` and `kind`
  keys (Kubernetes/Helm manifests). A bare `image:`-only file named
  `Launchfile` matches none of these.
- **Renovate `customManagers` can target an arbitrary filename with
  `datasourceTemplate: docker`** — confirmed against the official docs
  (the documented example targets `Chart.yaml`, not a Dockerfile).
- **`pinDigests: true` "maintains a readable pair automatically" for a
  `customManagers`/regex match — NOT verified, and I'm treating it as false
  for this claim's purposes.** Multiple Renovate maintainer/community threads
  (2021 through 2025) report that a regex manager cannot pin an *absent*
  digest unless the match includes an explicit `currentDigest` capture group;
  without one, digest-pinning either silently no-ops or breaks the pin-digest
  branch for the whole repo. This is materially weaker than "automatic."

Per the verdict's instruction, this sub-claim is **cut**, not softened. It
does not appear in either staged file (`CONTRIBUTING.md` / `README.md`) — the
verdict's drafted policy text never referenced Dependabot or Renovate to begin
with, so nothing needed removing there. It also does not appear in this PR
body beyond this verification note, and is not carried into the follow-up
issue draft. It remains relevant only to the verdict's own "reopening
condition" for revisiting digest-pinning (§ The one genuinely Author-owned
question), which is not part of this change and is not something this PR
resolves.

## Deviations from the verdict

None in the policy text. One addition: a one-line cross-reference
(`- See [Image references](#image-references) below for choosing an `image:`
tag`) added to CONTRIBUTING.md's existing Guidelines list, pointing at the new
section — not in the verdict's draft, added for discoverability since the old
inline bullet was removed from that list.

## Review round 1

Steward review: **REQUEST_CHANGES**, 3 blockers + 2 suggestions. Addressed in
`d39d91b` (`catalog: rework the image-reference ladder per steward review`).
`b4e182d` is untouched, and the three hoppscotch pins are unchanged.

**B1 — the ladder could not classify this PR's own case.** Fixed by keying
every rung on what upstream *publishes* and splitting the maintained channel
from the frozen release:

1. The narrowest stable tag that still receives patches — a channel upstream
   maintains and moves forward (`neosmemo/memos:stable`, `ghost:5-alpine`,
   `louislam/dockge:1`, `ghcr.io/requarks/wiki:2`). Upstream's own
   recommendation is now the tiebreaker *inside* this rung, when upstream
   maintains more than one channel — not a separate axis.
2. An exact release, where upstream publishes no maintained channel
   (`quay.io/hedgedoc/hedgedoc:1.10.8`,
   `hoppscotch/hoppscotch-backend:2026.7.0`).
3. `:latest`, only where upstream publishes nothing narrower, annotated on the
   line.

The old rung 2 ("a major-version tag, where upstream publishes one but its own
docs still say `:latest`") is gone — it existed only to bridge the
recommends/publishes split, and a maintained major tag is now rung 1 by
definition. Both worked examples in rung 2 come from the review's own
verification: HedgeDoc publishes only exact releases plus
`latest`/`alpine`/`debian`, and hoppscotch's 84 tags carry no channel other
than `latest`/`ci-test`. The rung-2 text now says that explicitly, so the pins
are correct *by the written rule* rather than by the commit message.

The review also noted rung 2 sits in tension with the `@sha256` ban, since an
exact release freezes an app too. Added a closing paragraph stating the actual
distinction: rung 2 freezes one app that has no channel to follow, and ranks
below rung 1 for that reason; a digest freezes every entry, including the ones
upstream still patches.

**B2 — silence about the 112 non-conforming entries.** Added an explicit
forward-only paragraph after "Always write a tag": the order binds new entries
and any entry you edit, it is not applied retroactively, existing `:latest`
entries are grandfathered, there is no sweep, and they converge as apps are
re-tested. The sweep issue remains a proposed follow-up, unfiled by this PR.

**B3 — "note the publisher in `metadata.yaml`" named no key.** Confirmed the
review's reading of `catalog/test/src/test-app.ts`: it rebuilds
`metadata.test_results` and `metadata.images` from scratch (`name`, `size_mb`,
`platform` only) and rewrites the file via `parse()` → `stringify()`, so
per-image fields and YAML comments are destroyed on the next re-test, while
other top-level keys survive the merge intact. Named a top-level `publisher:`
key, showed it in a YAML block, and stated why it has to be top level.

**S1** applied — `README.md` now reads "with the `apps/` entries verified to
launch," which no longer contradicts the `drafts/` line four lines above.

**S2** applied — `What this catalog is` promoted from `###` under
`## Structure` to a top-level `##` directly beneath the intro paragraph.

Re-verified after the rework: exactly 3 files changed against the merge base,
the three hoppscotch `image:` lines byte-identical to `b4e182d`, no trailing
whitespace, no markdown table touched in either file, and the hoppscotch
Launchfile still validates.

## Test plan

- [x] `bun test` in `sdk/` — 299/299 pass (no SDK/spec files touched; run to
      confirm no regression).
- [x] `bun run <sdk>/src/reader.ts` (`readLaunch` + `lintLaunch`, ad hoc) on
      the edited `catalog/drafts/hoppscotch/Launchfile` — schema-valid, zero
      lint warnings.
- [x] `bun run sdk/src/cli.ts validate catalog/drafts/hoppscotch/Launchfile`
      re-run after the round-1 rework — `✓ hoppscotch is valid`.
- [x] Manual read of both markdown files for repo style and rendering; no
      tables were touched.
- [ ] No catalog CI job exists to run automatically (verdict fact 1) — this is
      exactly the gap the proposed follow-up issue tracks.
