### PR TITLE
providers: reconcile resource properties with the ratified vocabulary (#182)

### DIFF
--- a/providers/aws/src/__tests__/resource-conformance.test.ts
+++ b/providers/aws/src/__tests__/resource-conformance.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Conformance of this provider's resource properties against the standard
+ * vocabulary (SPEC.md § Resource Property Vocabulary, D-46).
+ *
+ * Both directions are checked:
+ *
+ * - MUST — for every listed type the provider supports, it exposes at least the
+ *   registry's keys. A missing key is a conformance bug (the D-30 / #173 shape).
+ * - MAY — every key beyond the registry is named in EXTENSIONS below. The
+ *   vocabulary for a known type is open, so an extra key is legal; what is not
+ *   legal is an extra key nobody decided on. Without this direction only half
+ *   the surface is guarded, and the extension side drifts silently.
+ *
+ * The registry is read from `spec/schema/resource-properties.json` so the check
+ * tracks the ratified table rather than a copy of it.
+ */
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { readLaunch } from "@launchfile/sdk";
+import { beforeAll, describe, expect, it } from "vitest";
+import { resourcePropertyKeys, translate } from "../translate.js";
+
+const REGISTRY_PATH = join(
+	import.meta.dirname,
+	"../../../../spec/schema/resource-properties.json",
+);
+
+/** Keys this provider exposes beyond the standard vocabulary, per type. */
+const EXTENSIONS: Record<string, string[]> = {};
+
+async function readRegistry(): Promise<Record<string, string[]>> {
+	const raw = await readFile(REGISTRY_PATH, "utf8");
+	const parsed = JSON.parse(raw) as {
+		types: Record<string, Record<string, string>>;
+	};
+	const out: Record<string, string[]> = {};
+	for (const [type, props] of Object.entries(parsed.types)) {
+		out[type] = Object.keys(props);
+	}
+	return out;
+}
+
+describe("aws provider — resource property conformance", () => {
+	let registry: Record<string, string[]>;
+	const provider = resourcePropertyKeys();
+
+	beforeAll(async () => {
+		registry = await readRegistry();
+	});
+
+	it("exposes at least the standard vocabulary for every listed type it supports", () => {
+		const missing: string[] = [];
+		for (const [type, keys] of Object.entries(provider)) {
+			const promised = registry[type];
+			// The trigger is "supports a listed type". A type this provider
+			// stands up that the registry does not list (mariadb) has no
+			// vocabulary and stays fully open (L-4).
+			if (!promised) continue;
+			for (const key of promised) {
+				if (!keys.includes(key)) missing.push(`${type}.${key}`);
+			}
+		}
+
+		expect(missing).toEqual([]);
+	});
+
+	it("exposes no extension property outside the declared allowlist", () => {
+		const undeclared: string[] = [];
+		for (const [type, keys] of Object.entries(provider)) {
+			const promised = registry[type];
+			if (!promised) continue;
+			const allowed = new Set([...promised, ...(EXTENSIONS[type] ?? [])]);
+			for (const key of keys) {
+				if (!allowed.has(key)) undeclared.push(`${type}.${key}`);
+			}
+		}
+
+		expect(undeclared).toEqual([]);
+	});
+
+	it("covers mariadb without grading it — the registry does not list the type", () => {
+		expect(provider).toHaveProperty("mariadb");
+		expect(registry).not.toHaveProperty("mariadb");
+	});
+});
+
+describe("aws elasticache", () => {
+	it("exposes the promised redis password", () => {
+		// emitElastiCache()'s return is the property map a $redis.* expression
+		// resolves against. The cluster carries no AUTH token, so the value is
+		// empty — but the key is what the MUST is about.
+		expect(resourcePropertyKeys().redis).toContain("password");
+	});
+
+	it("still emits a working cluster and url for a redis requirement", () => {
+		const { hcl, conformance } = translate(
+			readLaunch(`
+version: launch/v1
+name: my-app
+runtime: node
+commands:
+  start: "node server.js"
+requires:
+  - type: redis
+    set_env:
+      REDIS_URL: $url
+`),
+		);
+
+		expect(hcl).toContain('resource "aws_elasticache_cluster"');
+		expect(
+			conformance.mapped.some((m) => m.target === "aws_elasticache_cluster"),
+		).toBe(true);
+	});
+});

--- a/providers/aws/src/translate.ts
+++ b/providers/aws/src/translate.ts
@@ -64,6 +64,35 @@ const MANAGED_RESOURCES: Record<
 	redis: { engine: "redis", port: 6379, kind: "elasticache" },
 };
 
+/**
+ * The property keys each managed resource type exposes, keyed by type.
+ *
+ * Derived by running the emitters against a throwaway block list, not
+ * hand-listed: the conformance test (`__tests__/resource-conformance.test.ts`)
+ * compares these against `spec/schema/resource-properties.json`, and a
+ * hand-maintained copy would drift from the emitters, which is the drift the
+ * check exists to catch.
+ */
+export function resourcePropertyKeys(): Record<string, string[]> {
+	const keys: Record<string, string[]> = {};
+	for (const [type, spec] of Object.entries(MANAGED_RESOURCES)) {
+		const discarded: string[] = [];
+		const properties =
+			spec.kind === "rds"
+				? emitRds(
+						discarded,
+						"probe",
+						type,
+						{ type } as NormalizedRequirement,
+						spec.engine,
+						spec.port,
+					)
+				: emitElastiCache(discarded, "probe", type);
+		keys[type] = Object.keys(properties);
+	}
+	return keys;
+}
+
 /** Lowercase, DNS-safe identifier for AWS resource names (RDS identifiers, cache cluster ids). */
 function dnsName(name: string): string {
 	// Linear-time trim (no anchored `-+` ReDoS on untrusted names) — same shape as tfName.
@@ -655,7 +684,10 @@ function emitElastiCache(
 		),
 	);
 	const host = `\${aws_elasticache_cluster.${tf}.cache_nodes[0].address}`;
-	return { host, port: 6379, url: `redis://${host}:6379` };
+	// The cluster runs with no AUTH token, so the honest password is empty. The
+	// property is still exposed: SPEC.md § Resource Property Vocabulary makes it
+	// a MUST for every provider that supports redis.
+	return { host, port: 6379, password: "", url: `redis://${host}:6379` };
 }
 
 function emitComponent(

--- a/providers/docker/src/__tests__/resource-conformance.test.ts
+++ b/providers/docker/src/__tests__/resource-conformance.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Conformance of this provider's resource properties against the standard
+ * vocabulary (SPEC.md § Resource Property Vocabulary, D-46).
+ *
+ * Both directions are checked:
+ *
+ * - MUST — for every listed type the provider supports, it exposes at least the
+ *   registry's keys. A missing key is a conformance bug (the D-30 / #173 shape).
+ * - MAY — every key beyond the registry is named in EXTENSIONS below. The
+ *   vocabulary for a known type is open, so an extra key is legal; what is not
+ *   legal is an extra key nobody decided on. Without this direction only half
+ *   the surface is guarded, and the extension side drifts silently.
+ *
+ * The registry is read from `spec/schema/resource-properties.json` so the check
+ * tracks the ratified table rather than a copy of it.
+ */
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { readLaunch } from "@launchfile/sdk";
+import { describe, expect, it } from "vitest";
+import { launchToCompose, resourcePropertyKeys } from "../compose-generator.js";
+
+const REGISTRY_PATH = join(
+	import.meta.dirname,
+	"../../../../spec/schema/resource-properties.json",
+);
+
+/**
+ * Keys this provider exposes beyond the standard vocabulary, per type.
+ *
+ * `elasticsearch` `user`/`password`: the factory runs x-pack security on, so
+ * credentials exist and are reported. Adopting them into the table is a
+ * separate spec decision (issue #182, Part B).
+ *
+ * `minio` `region`: every S3 client SDK requires a region string, so the
+ * factory hardcodes one. Also a Part B adoption candidate.
+ *
+ * `s3` `host`/`port`: this provider backs `s3` with a local MinIO, which is
+ * addressable by host and port. Real S3 is a regional HTTPS endpoint with
+ * neither, which is why the table keeps `s3` narrow.
+ */
+const EXTENSIONS: Record<string, string[]> = {
+	elasticsearch: ["user", "password"],
+	minio: ["region"],
+	s3: ["host", "port"],
+};
+
+async function readRegistry(): Promise<Record<string, string[]>> {
+	const raw = await readFile(REGISTRY_PATH, "utf8");
+	const parsed = JSON.parse(raw) as {
+		types: Record<string, Record<string, string>>;
+	};
+	const out: Record<string, string[]> = {};
+	for (const [type, props] of Object.entries(parsed.types)) {
+		out[type] = Object.keys(props);
+	}
+	return out;
+}
+
+describe("docker provider — resource property conformance", () => {
+	it("exposes at least the standard vocabulary for every listed type it supports", async () => {
+		const registry = await readRegistry();
+		const provider = resourcePropertyKeys();
+
+		const missing: string[] = [];
+		for (const [type, keys] of Object.entries(provider)) {
+			const promised = registry[type];
+			// The trigger is "supports a listed type". A type this provider
+			// stands up that the registry does not list (mariadb) has no
+			// vocabulary and stays fully open (L-4).
+			if (!promised) continue;
+			for (const key of promised) {
+				if (!keys.includes(key)) missing.push(`${type}.${key}`);
+			}
+		}
+
+		expect(missing).toEqual([]);
+	});
+
+	it("exposes no extension property outside the declared allowlist", async () => {
+		const registry = await readRegistry();
+		const provider = resourcePropertyKeys();
+
+		const undeclared: string[] = [];
+		for (const [type, keys] of Object.entries(provider)) {
+			const promised = registry[type];
+			if (!promised) continue;
+			const allowed = new Set([...promised, ...(EXTENSIONS[type] ?? [])]);
+			for (const key of keys) {
+				if (!allowed.has(key)) undeclared.push(`${type}.${key}`);
+			}
+		}
+
+		expect(undeclared).toEqual([]);
+	});
+
+	it("declares no extension for a type it does not support", async () => {
+		// Guards the allowlist itself: a stale entry would silently widen the
+		// check above for a type that no longer exists here.
+		const provider = resourcePropertyKeys();
+		for (const type of Object.keys(EXTENSIONS)) {
+			expect(Object.keys(provider)).toContain(type);
+		}
+	});
+
+	it("skips the types it does not stand up", () => {
+		const provider = resourcePropertyKeys();
+		// Both are in the registry; neither has a factory here. addBackingService
+		// warns and skips, so there is nothing to conform.
+		expect(provider).not.toHaveProperty("sqlite");
+		expect(provider).not.toHaveProperty("kafka");
+	});
+});
+
+describe("docker clickhouse", () => {
+	it("exposes the promised user and password", () => {
+		const keys = resourcePropertyKeys();
+		expect(keys.clickhouse).toContain("user");
+		expect(keys.clickhouse).toContain("password");
+	});
+
+	it("resolves $user through set_env to the image's default user", () => {
+		const launch = readLaunch(`
+name: analytics
+image: app:1
+requires:
+  - type: clickhouse
+    set_env:
+      CLICKHOUSE_USER: $user
+      CLICKHOUSE_PASSWORD: $password
+`);
+		const result = launchToCompose(launch);
+
+		expect(result.yaml).toContain("CLICKHOUSE_USER: default");
+		// Empty password is the image's shipped default, reported honestly.
+		expect(result.yaml).toContain('CLICKHOUSE_PASSWORD: ""');
+	});
+});
+
+describe("docker redis", () => {
+	it("exposes the promised password", () => {
+		expect(resourcePropertyKeys().redis).toContain("password");
+	});
+});
+
+describe("docker elasticsearch", () => {
+	it("does not expose name — elasticsearch provisions no named database", () => {
+		expect(resourcePropertyKeys().elasticsearch).not.toContain("name");
+	});
+
+	it("still exposes the credentials the factory generates", () => {
+		const keys = resourcePropertyKeys().elasticsearch;
+		expect(keys).toContain("user");
+		expect(keys).toContain("password");
+	});
+});

--- a/providers/docker/src/compose-generator.ts
+++ b/providers/docker/src/compose-generator.ts
@@ -69,6 +69,9 @@ function generatePort(): string {
 /**
  * Create a backing service factory with pre-generated or cached passwords.
  * Passwords are per-app to ensure consistency across restarts.
+ *
+ * Each factory's `properties` map is this provider's answer to SPEC.md
+ * § Resource Property Vocabulary; `resourcePropertyKeys()` reads it back.
  */
 function createBackingServices(
 	savedSecrets: Record<string, string>,
@@ -168,6 +171,10 @@ function createBackingServices(
 			properties: {
 				host: `${_name}-redis`,
 				port: "6379",
+				// The image ships with no `requirepass`, so the honest value is empty.
+				// The property is still exposed: SPEC.md § Resource Property Vocabulary
+				// makes it a MUST for every provider that supports redis.
+				password: "",
 				url: `redis://${_name}-redis:6379`,
 			},
 			healthcheck: {
@@ -207,6 +214,10 @@ function createBackingServices(
 			image: "clickhouse/clickhouse-server:latest",
 			environment: {},
 			properties: {
+				// The image's shipped defaults: the `default` user with an empty
+				// password. Reported as-is so the values match the deployment.
+				user: "default",
+				password: "",
 				host: `${name}-clickhouse`,
 				port: "8123",
 				url: `http://${name}-clickhouse:8123`,
@@ -237,7 +248,6 @@ function createBackingServices(
 					user: "elastic",
 					password: pw,
 					url: `http://elastic:${encodeURIComponent(pw)}@${name}-elasticsearch:9200`,
-					name: name,
 				},
 				healthcheck: {
 					test: ["CMD-SHELL", `curl -sf -u elastic:$ELASTIC_PASSWORD http://localhost:9200/_cluster/health || exit 1`],
@@ -352,6 +362,26 @@ function createBackingServices(
 			};
 		},
 	};
+}
+
+/**
+ * The property keys each supported backing-service type exposes, keyed by type.
+ *
+ * Derived by running the factories, not hand-listed: the conformance test
+ * (`__tests__/resource-conformance.test.ts`) compares these against
+ * `spec/schema/resource-properties.json`, and a hand-maintained copy would
+ * drift from the factories, which is the drift the check exists to catch.
+ *
+ * Calling this generates throwaway passwords into a local secrets map. They are
+ * never returned and never reach a compose file.
+ */
+export function resourcePropertyKeys(): Record<string, string[]> {
+	const factories = createBackingServices({});
+	const keys: Record<string, string[]> = {};
+	for (const [type, factory] of Object.entries(factories)) {
+		keys[type] = Object.keys(factory("probe").properties);
+	}
+	return keys;
 }
 
 /**

--- a/providers/macos-dev/src/__tests__/resource-conformance.test.ts
+++ b/providers/macos-dev/src/__tests__/resource-conformance.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Conformance of this provider's resource properties against the standard
+ * vocabulary (SPEC.md § Resource Property Vocabulary, D-46).
+ *
+ * Both directions are checked:
+ *
+ * - MUST — for every listed type the provider supports, it exposes at least the
+ *   registry's keys. A missing key is a conformance bug (the D-30 / #173 shape).
+ * - MAY — every key beyond the registry is named in EXTENSIONS below. The
+ *   vocabulary for a known type is open, so an extra key is legal; what is not
+ *   legal is an extra key nobody decided on. Without this direction only half
+ *   the surface is guarded, and the extension side drifts silently.
+ *
+ * The registry is read from `spec/schema/resource-properties.json` so the check
+ * tracks the ratified table rather than a copy of it.
+ */
+
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { NormalizedRequirement } from "@launchfile/sdk";
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+	getProvisioner,
+	type ShellRunner,
+	supportedResourceTypes,
+} from "../resources/index.js";
+
+const REGISTRY_PATH = join(
+	import.meta.dirname,
+	"../../../../spec/schema/resource-properties.json",
+);
+
+/** Keys this provider exposes beyond the standard vocabulary, per type. */
+const EXTENSIONS: Record<string, string[]> = {};
+
+/** A shell that runs nothing and reports success, so no brew or server is touched. */
+const NO_OP_SHELL: Partial<ShellRunner> = {
+	shell: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+	shellOk: async () => true,
+};
+
+async function readRegistry(): Promise<Record<string, string[]>> {
+	const raw = await readFile(REGISTRY_PATH, "utf8");
+	const parsed = JSON.parse(raw) as {
+		types: Record<string, Record<string, string>>;
+	};
+	const out: Record<string, string[]> = {};
+	for (const [type, props] of Object.entries(parsed.types)) {
+		out[type] = Object.keys(props);
+	}
+	return out;
+}
+
+/** Provision every supported type against the no-op shell and collect its keys. */
+async function providerKeys(
+	projectDir: string,
+): Promise<Record<string, string[]>> {
+	const out: Record<string, string[]> = {};
+	for (const type of supportedResourceTypes()) {
+		const provisioner = getProvisioner(type, NO_OP_SHELL);
+		if (!provisioner) throw new Error(`no provisioner for ${type}`);
+		const { properties } = await provisioner.provision(
+			{ type } as NormalizedRequirement,
+			{ appName: "my-app", projectDir },
+		);
+		out[type] = Object.keys(properties);
+	}
+	return out;
+}
+
+describe("macos-dev provider — resource property conformance", () => {
+	let registry: Record<string, string[]>;
+	let provider: Record<string, string[]>;
+
+	beforeAll(async () => {
+		registry = await readRegistry();
+		provider = await providerKeys(await mkdtemp(join(tmpdir(), "lf-conf-")));
+	});
+
+	it("exposes at least the standard vocabulary for every listed type it supports", () => {
+		const missing: string[] = [];
+		for (const [type, keys] of Object.entries(provider)) {
+			const promised = registry[type];
+			// The trigger is "supports a listed type". A type this provider
+			// stands up that the registry does not list (mariadb) has no
+			// vocabulary and stays fully open (L-4).
+			if (!promised) continue;
+			for (const key of promised) {
+				if (!keys.includes(key)) missing.push(`${type}.${key}`);
+			}
+		}
+
+		expect(missing).toEqual([]);
+	});
+
+	it("exposes no extension property outside the declared allowlist", () => {
+		const undeclared: string[] = [];
+		for (const [type, keys] of Object.entries(provider)) {
+			const promised = registry[type];
+			if (!promised) continue;
+			const allowed = new Set([...promised, ...(EXTENSIONS[type] ?? [])]);
+			for (const key of keys) {
+				if (!allowed.has(key)) undeclared.push(`${type}.${key}`);
+			}
+		}
+
+		expect(undeclared).toEqual([]);
+	});
+
+	it("covers mariadb without grading it — the registry does not list the type", () => {
+		expect(provider).toHaveProperty("mariadb");
+		expect(registry).not.toHaveProperty("mariadb");
+	});
+});
+
+describe("macos-dev sqlite", () => {
+	let properties: Record<string, string | number | undefined>;
+
+	beforeAll(async () => {
+		const projectDir = await mkdtemp(join(tmpdir(), "lf-sqlite-"));
+		const provisioner = getProvisioner("sqlite");
+		if (!provisioner) throw new Error("no sqlite provisioner");
+		({ properties } = await provisioner.provision(
+			{ type: "sqlite" } as NormalizedRequirement,
+			{ appName: "my-app", projectDir },
+		));
+	});
+
+	it("exposes neither host nor port — a file has neither", () => {
+		// `port: 0` was a value an app could act on (connect(host, 0)). Absent,
+		// $sqlite.port resolves to "" through the unknown-property rule instead.
+		expect(properties).not.toHaveProperty("host");
+		expect(properties).not.toHaveProperty("port");
+	});
+
+	it("exposes the url and path the table promises", () => {
+		expect(properties.url).toMatch(/^sqlite:\/\//);
+		expect(String(properties.path)).toContain("my_app.db");
+	});
+});
+
+describe("macos-dev network resources still carry host and port", () => {
+	// Regression guard for loosening ResourceProperties: making host/port
+	// optional must not let a networked type quietly drop them.
+	for (const type of ["postgres", "mysql", "redis"]) {
+		it(`${type} exposes host and port`, async () => {
+			const provisioner = getProvisioner(type, NO_OP_SHELL);
+			if (!provisioner) throw new Error(`no ${type} provisioner`);
+			const { properties } = await provisioner.provision(
+				{ type } as NormalizedRequirement,
+				{ appName: "my-app", projectDir: tmpdir() },
+			);
+
+			expect(properties.host).toBe("localhost");
+			expect(typeof properties.port).toBe("number");
+			expect(properties.port).toBeGreaterThan(0);
+		});
+	}
+});

--- a/providers/macos-dev/src/resources/index.ts
+++ b/providers/macos-dev/src/resources/index.ts
@@ -4,26 +4,48 @@
  * Maps resource type names to their provisioner implementations.
  */
 
-import type { ResourceProvisioner } from "./types.js";
+import type { ResourceProvisioner, ShellRunner } from "./types.js";
 import { PostgresProvisioner } from "./postgres.js";
 import { RedisProvisioner } from "./redis.js";
 import { SqliteProvisioner } from "./sqlite.js";
 import { MysqlProvisioner } from "./mysql.js";
 
-const provisioners: Record<string, ResourceProvisioner> = {
-	postgres: new PostgresProvisioner(),
-	redis: new RedisProvisioner(),
-	sqlite: new SqliteProvisioner(),
-	mysql: new MysqlProvisioner(),
-	mariadb: new MysqlProvisioner(), // MariaDB is MySQL-compatible
-};
+/**
+ * One factory per supported type, rather than one instance, so a caller can
+ * supply the shell a provisioner runs against. The conformance test
+ * (`__tests__/resource-conformance.test.ts`) is the caller that needs it: it
+ * walks this registry so the check covers every supported type, and no type can
+ * fall out of the check by being listed in only one of two places.
+ *
+ * The map has a null prototype, so a lookup keyed by a resource type read out
+ * of a Launchfile resolves to `undefined` for `constructor`, `__proto__` and
+ * every other `Object.prototype` key rather than an inherited value.
+ */
+const factories: Record<
+	string,
+	(deps?: Partial<ShellRunner>) => ResourceProvisioner
+> = Object.assign(Object.create(null), {
+	postgres: (deps?: Partial<ShellRunner>) => new PostgresProvisioner(deps),
+	redis: (deps?: Partial<ShellRunner>) => new RedisProvisioner(deps),
+	sqlite: () => new SqliteProvisioner(),
+	mysql: (deps?: Partial<ShellRunner>) => new MysqlProvisioner(deps),
+	mariadb: (deps?: Partial<ShellRunner>) => new MysqlProvisioner(deps), // MariaDB is MySQL-compatible
+});
 
-export function getProvisioner(type: string): ResourceProvisioner | undefined {
-	return provisioners[type];
+export function getProvisioner(
+	type: string,
+	deps?: Partial<ShellRunner>,
+): ResourceProvisioner | undefined {
+	return factories[type]?.(deps);
 }
 
 export function supportedResourceTypes(): string[] {
-	return Object.keys(provisioners);
+	return Object.keys(factories);
 }
 
-export type { ResourceProvisioner, ResourceProperties, ProvisionOpts } from "./types.js";
+export type {
+	ResourceProvisioner,
+	ResourceProperties,
+	ProvisionOpts,
+	ShellRunner,
+} from "./types.js";

--- a/providers/macos-dev/src/resources/mysql.ts
+++ b/providers/macos-dev/src/resources/mysql.ts
@@ -6,7 +6,12 @@ import type { NormalizedRequirement } from "@launchfile/sdk";
 import { shell, shellOk } from "../shell.js";
 import { generatePassword } from "../secret-generator.js";
 import type { ResourceState } from "../state.js";
-import type { ProvisionOpts, ResourceProperties, ResourceProvisioner } from "./types.js";
+import type {
+	ProvisionOpts,
+	ResourceProperties,
+	ResourceProvisioner,
+	ShellRunner,
+} from "./types.js";
 
 const DEFAULT_PORT = 3306;
 const DEFAULT_HOST = "localhost";
@@ -16,9 +21,16 @@ const SAFE_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
 export class MysqlProvisioner implements ResourceProvisioner {
 	readonly type = "mysql";
+	readonly #shell: ShellRunner["shell"];
+	readonly #shellOk: ShellRunner["shellOk"];
+
+	constructor(deps: Partial<ShellRunner> = {}) {
+		this.#shell = deps.shell ?? shell;
+		this.#shellOk = deps.shellOk ?? shellOk;
+	}
 
 	async isRunning(): Promise<boolean> {
-		return shellOk("mysqladmin ping -h localhost --silent");
+		return this.#shellOk("mysqladmin ping -h localhost --silent");
 	}
 
 	async provision(
@@ -28,10 +40,10 @@ export class MysqlProvisioner implements ResourceProvisioner {
 	): Promise<{ properties: ResourceProperties; state: ResourceState }> {
 		if (!(await this.isRunning())) {
 			console.log("  Starting MySQL via brew...");
-			const started = await shellOk("brew services start mysql");
+			const started = await this.#shellOk("brew services start mysql");
 			if (!started) {
-				await shell("brew install mysql");
-				await shell("brew services start mysql");
+				await this.#shell("brew install mysql");
+				await this.#shell("brew services start mysql");
 			}
 		}
 
@@ -43,16 +55,16 @@ export class MysqlProvisioner implements ResourceProvisioner {
 		const port = DEFAULT_PORT;
 
 		// Create database and user (idempotent)
-		await shell(
+		await this.#shell(
 			`mysql -h ${DEFAULT_HOST} -u root -e "CREATE DATABASE IF NOT EXISTS \\\`${dbName}\\\`;"`,
 			{ allowFailure: true },
 		);
-		await shell(
+		await this.#shell(
 			`mysql -h ${DEFAULT_HOST} -u root -e "CREATE USER IF NOT EXISTS '${user}'@'${DEFAULT_HOST}' IDENTIFIED BY '${password}';"`,
 			// silent: this command embeds the generated DB password; don't echo it (CWE-532).
 			{ allowFailure: true, silent: true },
 		);
-		await shell(
+		await this.#shell(
 			`mysql -h ${DEFAULT_HOST} -u root -e "GRANT ALL PRIVILEGES ON \\\`${dbName}\\\`.* TO '${user}'@'${DEFAULT_HOST}';"`,
 			{ allowFailure: true },
 		);
@@ -84,13 +96,13 @@ export class MysqlProvisioner implements ResourceProvisioner {
 	async destroy(state: ResourceState): Promise<void> {
 		// Security: state values come from disk (state.json) — validate before SQL interpolation
 		if (state.dbName && SAFE_IDENTIFIER.test(state.dbName)) {
-			await shell(
+			await this.#shell(
 				`mysql -h ${DEFAULT_HOST} -u root -e "DROP DATABASE IF EXISTS \\\`${state.dbName}\\\`;"`,
 				{ allowFailure: true },
 			);
 		}
 		if (state.user && SAFE_IDENTIFIER.test(state.user)) {
-			await shell(
+			await this.#shell(
 				`mysql -h ${DEFAULT_HOST} -u root -e "DROP USER IF EXISTS '${state.user}'@'${DEFAULT_HOST}';"`,
 				{ allowFailure: true },
 			);

--- a/providers/macos-dev/src/resources/postgres.ts
+++ b/providers/macos-dev/src/resources/postgres.ts
@@ -12,7 +12,14 @@ import type { NormalizedRequirement } from "@launchfile/sdk";
 import { shell, shellOk } from "../shell.js";
 import { generatePassword } from "../secret-generator.js";
 import type { ResourceState } from "../state.js";
-import type { ProvisionOpts, ResourceProperties, ResourceProvisioner } from "./types.js";
+import type {
+	ProvisionOpts,
+	ResourceProperties,
+	ResourceProvisioner,
+	ShellRunner,
+} from "./types.js";
+
+export type { ShellRunner };
 
 const DEFAULT_PORT = 5432;
 const DEFAULT_HOST = "localhost";
@@ -21,15 +28,6 @@ const READY_TIMEOUT_SECONDS = 10;
 // Security: validate identifiers before interpolating into shell/SQL commands.
 // Only alphanumeric + underscore — safe for SQL identifiers and shell args.
 const SAFE_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
-
-/**
- * The shell surface this provisioner runs against. Injecting it lets tests
- * drive the provisioning sequence without a live Postgres or Homebrew.
- */
-export interface ShellRunner {
-	shell: typeof shell;
-	shellOk: typeof shellOk;
-}
 
 export class PostgresProvisioner implements ResourceProvisioner {
 	readonly type = "postgres";

--- a/providers/macos-dev/src/resources/redis.ts
+++ b/providers/macos-dev/src/resources/redis.ts
@@ -5,16 +5,28 @@
 import type { NormalizedRequirement } from "@launchfile/sdk";
 import { shell, shellOk } from "../shell.js";
 import type { ResourceState } from "../state.js";
-import type { ProvisionOpts, ResourceProperties, ResourceProvisioner } from "./types.js";
+import type {
+	ProvisionOpts,
+	ResourceProperties,
+	ResourceProvisioner,
+	ShellRunner,
+} from "./types.js";
 
 const DEFAULT_PORT = 6379;
 const DEFAULT_HOST = "localhost";
 
 export class RedisProvisioner implements ResourceProvisioner {
 	readonly type = "redis";
+	readonly #shell: ShellRunner["shell"];
+	readonly #shellOk: ShellRunner["shellOk"];
+
+	constructor(deps: Partial<ShellRunner> = {}) {
+		this.#shell = deps.shell ?? shell;
+		this.#shellOk = deps.shellOk ?? shellOk;
+	}
 
 	async isRunning(): Promise<boolean> {
-		return shellOk("redis-cli ping");
+		return this.#shellOk("redis-cli ping");
 	}
 
 	async provision(
@@ -24,10 +36,10 @@ export class RedisProvisioner implements ResourceProvisioner {
 	): Promise<{ properties: ResourceProperties; state: ResourceState }> {
 		if (!(await this.isRunning())) {
 			console.log("  Starting Redis via brew...");
-			const started = await shellOk("brew services start redis");
+			const started = await this.#shellOk("brew services start redis");
 			if (!started) {
-				await shell("brew install redis");
-				await shell("brew services start redis");
+				await this.#shell("brew install redis");
+				await this.#shell("brew services start redis");
 			}
 		}
 

--- a/providers/macos-dev/src/resources/sqlite.ts
+++ b/providers/macos-dev/src/resources/sqlite.ts
@@ -26,10 +26,10 @@ export class SqliteProvisioner implements ResourceProvisioner {
 
 		const dbPath = join(dataDir, `${safeName}.db`);
 
+		// SPEC.md § Resource Property Vocabulary gives sqlite `url` and `path`
+		// only. A file has no host and no port, so neither is exposed.
 		const properties: ResourceProperties = {
 			url: `sqlite://${dbPath}`,
-			host: "",
-			port: 0,
 			path: dbPath,
 		};
 

--- a/providers/macos-dev/src/resources/types.ts
+++ b/providers/macos-dev/src/resources/types.ts
@@ -6,13 +6,23 @@
  */
 
 import type { NormalizedRequirement } from "@launchfile/sdk";
+import type { shell, shellOk } from "../shell.js";
 import type { ResourceState } from "../state.js";
 
-/** Properties that a provisioned resource exposes for expression resolution */
+/**
+ * Properties that a provisioned resource exposes for expression resolution.
+ *
+ * Only `url` is required. A resource type addressed by something other than a
+ * network endpoint — sqlite is a file — has no host and no port, and fabricating
+ * `host: ""` / `port: 0` to satisfy the type would report a value an app could
+ * act on (PROVIDERS.md §10.8, D-52). Omitted properties resolve to the empty
+ * string through the standard unknown-property rule, so leaving them out costs
+ * the caller nothing.
+ */
 export interface ResourceProperties {
 	url: string;
-	host: string;
-	port: number;
+	host?: string;
+	port?: number;
 	user?: string;
 	password?: string;
 	name?: string;
@@ -22,6 +32,15 @@ export interface ResourceProperties {
 	bucket?: string;
 	region?: string;
 	[key: string]: string | number | undefined;
+}
+
+/**
+ * The shell surface a provisioner runs against. Injecting it lets tests drive
+ * the provisioning sequence without Homebrew or a live server.
+ */
+export interface ShellRunner {
+	shell: typeof shell;
+	shellOk: typeof shellOk;
 }
 
 export interface ProvisionOpts {


### PR DESCRIPTION
---

Part A of the [#182 verdict](https://github.com/launchfile/launchfile/issues/182)'s DEFER-with-split: the four rows that are pure provider conformance against MUSTs and semantics **already ratified** in D-46 and SPEC.md. No spec, schema, or SDK file is touched, and nothing here changes the portable contract.

The three rows that would widen it — `elasticsearch` `user`/`password`, `minio` `region`, `s3` `host`/`port` — need an Author decision and are **not** in this PR. #182 stays open for them.

## What changed

### MUST gaps closed

A provider that supports a listed type must expose the properties SPEC.md § Resource Property Vocabulary promises for it. Three providers were short:

| Provider | Type | Was | Now |
|---|---|---|---|
| docker | `redis` | `host`, `port`, `url` | `+ password: ""` |
| aws | `redis` (ElastiCache) | `host`, `port`, `url` | `+ password: ""` |
| docker | `clickhouse` | `host`, `port`, `url`, `name` | `+ user: "default"`, `+ password: ""` |

`redis` `password` was **missed by the issue as filed**. Two of three reference providers omitted it, on the type with the highest catalog usage (14 of 113 files). `providers/macos-dev` was already conformant and is the shape the other two now follow.

The clickhouse values are the image's shipped defaults, reported as they are. Whether the docker clickhouse should be authenticated at all is a security change with a different blast radius — filed separately, deliberately not bundled here.

### Fabricated properties removed

**docker `elasticsearch` `name`** — the factory echoed the app name back under a key the registry defines as *"Name of the provisioned database"* for postgres/mysql/mongodb/clickhouse. Elasticsearch provisions no named database, so the key had no referent and gave one word two meanings (**P-9**). It was a copied line, not a feature.

**macos-dev `sqlite` `host`/`port`** — not an extension. `ResourceProperties` declared `url`/`host`/`port` **required**, so the provisioner had to fill something in and wrote `host: ""`, `port: 0`. `port: 0` is a value an app can act on (`connect(host, 0)`) — the fabrication family **PROVIDERS.md §10.8 / D-52** forbid elsewhere (**P-1**: a port number for a file is infra shape that does not exist). `host` and `port` are now optional on the interface and absent from the sqlite map; `$sqlite.host` resolves to the same empty string through the standard unknown-property rule, so the observable value is unchanged.

### The conformance check the issue asked for

One test file per provider, guarding **both** directions:

- **MUST** — for every listed type the provider supports, its property keys are a superset of the registry's. Skips types the provider does not stand up (docker: `sqlite`, `kafka`) and types the registry does not list (`mariadb`, which stays open under **L-4**). The trigger is *"supports a listed type,"* not *"the type is listed."*
- **MAY** — every key beyond the registry is named in a per-provider allowlist. Without this only half the surface is guarded and the extension side drifts silently, which is how the divergence arose in the first place. **This is the direction that catches the `elasticsearch` `name` row.**

Both read `spec/schema/resource-properties.json` directly, so the check tracks the registry rather than a copy of it. Each provider derives its keys by running its own factories, so the check cannot pass against a stale hand-written list.

Enabling that for macos-dev turned the resource registry from singletons into factories and gave `RedisProvisioner` and `MysqlProvisioner` the injectable shell `PostgresProvisioner` already had — otherwise the test would shell out to Homebrew.

## Verification

**Tests pass (655/655).** All green, none skipped:

| Suite | Before | After |
|---|---|---|
| `providers/docker` | 124 | **133** (+9) |
| `providers/macos-dev` | 118 | **126** (+8) |
| `providers/aws` | 50 | **55** (+5) |
| `sdk` (untouched) | 299 | **299** |
| `packages/launchfile` (untouched) | 42 | **42** |

`typecheck` clean in all four workspaces. Both runners exercised — `bun test` (what CI runs) and `bun run test` (vitest) — because the new files are the first in `providers/macos-dev` to construct provisioners with injected dependencies.

**The three-form consistency test is untouched and still passes.** `sdk/src/__tests__/resource-properties.test.ts` parses the SPEC.md table as ground truth and asserts the registry and `sdk/src/resource-properties.ts` match it exactly, so any table edit is a three-file edit. Part A makes **no** table edit, which is why it is a provider-only change; 299/299 confirms it.

**Mutation-checked, not just green.** Removing `user: "default"` from the clickhouse factory fails 3 of the new tests, including the superset check. The check has teeth.

**Verified live**, docker provider, compose project `gov23-resprops`, torn down after (no other project touched):

```
$ docker compose -p gov23-resprops exec app env | grep REDIS
REDIS_PASSWORD=
REDIS_HOST=gov23-resprops-redis
REDIS_URL=redis://gov23-resprops-redis:6379

$ docker compose -p gov23-resprops exec redis redis-cli PING
PONG          # unauthenticated — so the empty password is honest, not a placeholder
```

```
$ docker compose -p gov23-resprops exec app env | grep CLICKHOUSE
CLICKHOUSE_NAME=gov23-resprops
CLICKHOUSE_USER=default
CLICKHOUSE_PASSWORD=
CLICKHOUSE_URL=http://gov23-resprops-clickhouse:8123

$ docker compose -p gov23-resprops exec clickhouse \
    clickhouse-client --user default --password "" --query "SELECT currentUser(), version()"
default   26.7.5.10   # the reported credentials are the ones that actually work
```

## Blast radius

No shipped file consumes any property this PR changes. Grepped across `catalog/`, `spec/`, `packages/`, `www-dev/`, `www-org/` for `$redis.password`, `$clickhouse.user`, `$clickhouse.password`, `$elasticsearch.name`, `$sqlite.host`, `$sqlite.port` — **zero hits**. No catalog file declares `elasticsearch` at all. Emitted compose and Terraform for every catalog app and spec example are byte-identical to before, except for the two added env keys where a file asks for them.

## Documentation-site gate

**No `www-dev` or `www-org` source change is required**, assessed per the gate:

- `www-org` auto-renders `spec/SPEC.md` H2 sections and `D-*` entries. This PR edits neither.
- `www-dev` teaches resource properties generically — `learn/adding-a-database.astro` enumerates `$url`/`$host`/`$port`/`$user`/`$password` as a database-wide list, not per type. No new `$`-expression, reserved namespace, command key, or `spec/examples/` entry is added, so no example-array registration and no `learn/` prose change is owed.

## Principles and decisions

| Ref | Bearing |
|---|---|
| **P-1** | `port: 0` for a file is infra shape that does not exist. |
| **P-9** | `name` cannot mean "provisioned database" for four types and "the app name" for a fifth. |
| **D-30 / #173** | Precedent: a provider omitting a promised property is a conformance bug, not a spec question. |
| **D-46** | Rule 1 (open vocabulary, warn-only) bounds the MAY allowlist; rule 3 (three-form consistency) is why Part A touches no spec file. |
| **D-52 / PROVIDERS.md §10.8** | `port: 0` is a fabricated value in the family the spec forbids elsewhere. |
| **L-4** | `mariadb` and unknown types stay open and unwarned; the check must not misfire on them. |

## Not in this PR — deliberately

- **Part B, the vocabulary widenings** (`elasticsearch` `user`/`password`, `minio` `region`) and the `s3` narrowness rationale. Each widening adds a MUST binding every third-party provider, which is a change to the published portable contract and needs Author sign-off plus a new `D-*`. Part B should also carry the per-type MUST into `spec/PROVIDERS.md` §10 — rule 6 today says only *"Resolve the reserved expression namespaces it supports … unknown reserved keys resolve to `\"\"`,"* which is materially weaker and does not carry the per-type obligation where provider authors read it.
- **Making the docker clickhouse authenticated.** A hardening, not a conformance fix, and it changes the resolved `url`. Filed separately.
- **Whether a type named `s3` may be satisfied by a local MinIO.** Surfaced by the `s3` `host`/`port` row; a separate provider-semantics question. Filed separately.

Refs #182 — does **not** close it; Part B remains open.
