### PR TITLE
Speed up the AWS terraform-validate CI job (93s → seconds)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,17 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    ignore:
+      # TypeScript 7 (the native port) exports no `ts.sys`, and
+      # @astrojs/language-server calls `ts.sys.fileExists` when it looks for a
+      # tsconfig — so `astro check` dies with "Cannot read properties of
+      # undefined (reading 'fileExists')". @astrojs/check 0.9.10 is the newest
+      # release and still pins language-server ^2.16.7, so there is no version
+      # to upgrade into. These two sites stay on TypeScript 6 until a
+      # language-server release supports the 7.x API; the workspace root is
+      # unaffected because it runs `tsc` directly. Drop this once that lands.
+      - dependency-name: typescript
+        update-types: ["version-update:semver-major"]
     groups:
       astro-ecosystem:
         patterns: ["astro", "@astrojs/*"]
@@ -43,6 +54,17 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    ignore:
+      # TypeScript 7 (the native port) exports no `ts.sys`, and
+      # @astrojs/language-server calls `ts.sys.fileExists` when it looks for a
+      # tsconfig — so `astro check` dies with "Cannot read properties of
+      # undefined (reading 'fileExists')". @astrojs/check 0.9.10 is the newest
+      # release and still pins language-server ^2.16.7, so there is no version
+      # to upgrade into. These two sites stay on TypeScript 6 until a
+      # language-server release supports the 7.x API; the workspace root is
+      # unaffected because it runs `tsc` directly. Drop this once that lands.
+      - dependency-name: typescript
+        update-types: ["version-update:semver-major"]
     groups:
       astro-ecosystem:
         patterns: ["astro", "@astrojs/*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,13 @@ jobs:
   # against the real AWS provider schema (no credentials — init only fetches the
   # schema). This is the conformance gate the unit tests can't give us: they
   # assert structure, terraform validate asserts the output actually parses.
+  #
+  # No `needs: sdk` — this job builds the SDK from source itself (~1s), so a
+  # broken SDK fails it here with the same error. Gating on the sdk job only
+  # added queue latency to the run's longest pole.
   aws-terraform-validate:
     name: "AWS provider — terraform validate"
     runs-on: ubuntu-latest
-    needs: sdk
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -63,8 +66,10 @@ jobs:
       - run: cd providers/aws && bun install --frozen-lockfile
       # Validate the emitted HCL for the stable spec examples. The community
       # catalog is validated locally (`bun run validate:tf`) — gating every
-      # catalog PR on 80+ terraform runs would be slow and brittle. The shared
-      # plugin cache means the AWS provider downloads once, not per example.
+      # catalog PR on the whole catalog would make every catalog PR wait on a
+      # third party's schema server. The plugin cache plus the script's shared
+      # `terraform init` mean the AWS provider is downloaded and initialized
+      # once per run, not once per example.
       - name: Validate emitted Terraform for spec examples
         env:
           TF_PLUGIN_CACHE_DIR: ${{ runner.temp }}/tf-plugin-cache

--- a/providers/aws/src/validate-tf.ts
+++ b/providers/aws/src/validate-tf.ts
@@ -12,17 +12,24 @@
  * Works with `terraform` (default) or OpenTofu (`tofu`). No AWS credentials
  * needed — `init -backend=false` only downloads the provider schema. Set
  * TF_PLUGIN_CACHE_DIR so the provider downloads once and every dir reuses it.
+ *
+ * `init` costs seconds per directory; `validate` costs ~1s. So sources that
+ * declare identical `required_providers` share a single initialized directory —
+ * one init, then a symlinked `.terraform` per source — and the validates run
+ * concurrently (`VALIDATE_TF_CONCURRENCY` to override the default).
  */
 
 import { execFile } from "node:child_process";
 import {
+	copyFileSync,
 	existsSync,
 	mkdtempSync,
 	readdirSync,
 	readFileSync,
+	symlinkSync,
 	writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
+import { availableParallelism, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
@@ -100,16 +107,47 @@ async function init(dir: string): Promise<void> {
 	}
 }
 
-async function validateOne(
-	src: Source,
-	workRoot: string,
-): Promise<{ ok: boolean; detail: string }> {
-	const launch = readLaunch(readFileSync(src.path, "utf8"));
-	const { hcl } = translate(launch);
-	const dir = mkdtempSync(join(workRoot, `${src.name}-`));
-	writeFileSync(join(dir, "main.tf"), hcl);
+/** The emitted `terraform { ... }` block, brace-matched. Two sources with the
+ * same block need the same plugins, so one `init` serves both. Sources whose
+ * block can't be found get their own init — correctness over speed. */
+function requiredProvidersKey(hcl: string, fallback: string): string {
+	const start = hcl.indexOf("terraform {");
+	if (start === -1) return fallback;
+	let depth = 0;
+	for (let i = hcl.indexOf("{", start); i < hcl.length; i += 1) {
+		if (hcl[i] === "{") depth += 1;
+		else if (hcl[i] === "}") {
+			depth -= 1;
+			if (depth === 0) return hcl.slice(start, i + 1);
+		}
+	}
+	return fallback;
+}
+
+interface Candidate {
+	src: Source;
+	dir: string;
+	key: string;
+}
+
+/** Point `dir` at an already-initialized `.terraform` instead of running init.
+ * Returns false when the platform refuses the symlink (Windows without
+ * developer mode), so the caller can fall back to a real init. */
+function borrowInit(dir: string, from: string): boolean {
 	try {
-		await init(dir);
+		symlinkSync(join(from, ".terraform"), join(dir, ".terraform"), "dir");
+		const lock = join(from, ".terraform.lock.hcl");
+		if (existsSync(lock)) copyFileSync(lock, join(dir, ".terraform.lock.hcl"));
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function validateOne(
+	dir: string,
+): Promise<{ ok: boolean; detail: string }> {
+	try {
 		// Array-based exec: arguments bypass the shell entirely (CWE-78 safe).
 		await run(BIN, ["validate", "-no-color"], { cwd: dir });
 		return { ok: true, detail: "" };
@@ -126,27 +164,93 @@ async function validateOne(
 	}
 }
 
+/** Each validate spawns a provider plugin holding the full AWS schema, so this
+ * is bounded by memory as much as by cores. */
+function concurrency(): number {
+	const override = Number(process.env.VALIDATE_TF_CONCURRENCY);
+	if (Number.isInteger(override) && override > 0) return override;
+	return Math.max(1, Math.min(availableParallelism(), 8));
+}
+
+async function mapLimit<T>(
+	items: T[],
+	limit: number,
+	fn: (item: T) => Promise<void>,
+): Promise<void> {
+	let next = 0;
+	const workers = Array.from({ length: Math.min(limit, items.length) }, () =>
+		(async () => {
+			for (let i = next++; i < items.length; i = next++) {
+				const item = items[i];
+				if (item !== undefined) await fn(item);
+			}
+		})(),
+	);
+	await Promise.all(workers);
+}
+
 async function main(): Promise<void> {
 	const examplesOnly = process.argv.includes("--examples");
 	const list = sources(examplesOnly);
 	const workRoot = mkdtempSync(join(tmpdir(), "lf-aws-validate-"));
-	let pass = 0;
-	const failures: string[] = [];
 
-	for (const src of list) {
-		const result = await validateOne(src, workRoot);
-		if (result.ok) {
-			pass += 1;
-			process.stdout.write(`ok    ${src.name}\n`);
-		} else {
-			failures.push(src.name);
-			process.stdout.write(`FAIL  ${src.name}\n${result.detail}\n`);
+	// Translation is pure and cheap — do it all up front so the provider
+	// requirements are known before any terraform process starts.
+	const candidates: Candidate[] = list.map((src) => {
+		const launch = readLaunch(readFileSync(src.path, "utf8"));
+		const { hcl } = translate(launch);
+		const dir = mkdtempSync(join(workRoot, `${src.name}-`));
+		writeFileSync(join(dir, "main.tf"), hcl);
+		return { src, dir, key: requiredProvidersKey(hcl, src.name) };
+	});
+
+	const groups = new Map<string, Candidate[]>();
+	for (const c of candidates) {
+		const group = groups.get(c.key);
+		if (group) group.push(c);
+		else groups.set(c.key, [c]);
+	}
+
+	const initFailures: string[] = [];
+	for (const group of groups.values()) {
+		const leader = group[0];
+		if (!leader) continue;
+		try {
+			await init(leader.dir);
+		} catch (err) {
+			for (const c of group) {
+				initFailures.push(c.src.name);
+				process.stdout.write(
+					`FAIL  ${c.src.name}\n${(err as Error).message.trim().split("\n").slice(0, 12).join("\n")}\n`,
+				);
+			}
+			continue;
+		}
+		for (const c of group.slice(1)) {
+			if (!borrowInit(c.dir, leader.dir)) await init(c.dir);
 		}
 	}
 
+	const initialized = candidates.filter(
+		(c) => !initFailures.includes(c.src.name),
+	);
+	const failures = [...initFailures];
+	let pass = 0;
+
+	await mapLimit(initialized, concurrency(), async (c) => {
+		const result = await validateOne(c.dir);
+		if (result.ok) {
+			pass += 1;
+			process.stdout.write(`ok    ${c.src.name}\n`);
+		} else {
+			failures.push(c.src.name);
+			process.stdout.write(`FAIL  ${c.src.name}\n${result.detail}\n`);
+		}
+	});
+
 	process.stdout.write(`\n${pass}/${list.length} valid (${BIN})\n`);
 	if (failures.length > 0) {
-		process.stderr.write(`Invalid HCL for: ${failures.join(", ")}\n`);
+		process.stderr.write(`Invalid HCL for: ${failures.sort().join(", ")}\n`);
 		process.exit(1);
 	}
 }


### PR DESCRIPTION
`AWS provider — terraform validate` is the longest job in CI: 101s in [run 32711412319](https://github.com/launchfile/launchfile/actions/runs/32711412319), 93s of it in one step.

**Cause.** `validate:tf` ran `terraform init` once per example directory. Measured with OpenTofu on a warm plugin cache: init ~17s, validate ~1.2s. So init was ~93% of the per-example cost, paid 13 times, sequentially. The job log shows this as a flat ~7.2s per example — flat is the tell, since a download would spike only the first.

**Change.** Group sources by their emitted `terraform { required_providers { … } }` block, run one `init` per group, symlink `.terraform` into the rest, and run the validates concurrently (`VALIDATE_TF_CONCURRENCY` to override). Also drop `needs: sdk` from the job — it builds the SDK itself in ~1s, so the dependency only added 15s of queue latency to the run's longest pole.

**Measured locally** (OpenTofu, warm cache): `--examples` 229.6s → 21.7s; full catalog (85 sources) 32.4s.

**The gate still gates.** With a `bad.tf` carrying an unsupported argument injected into every directory, the run reports `0/13 valid`, exits 1, and each failure cites the AWS provider schema. A borrowed `.terraform` resolves the real schema exactly as a per-directory init does.

The CI numbers in this PR are a projection from local timings — this PR's own run is the measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)