### PR TITLE
Speed up the website CI jobs (26s of browser setup per job)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,17 @@ jobs:
       - run: cd ${{ matrix.site }} && bun install --frozen-lockfile
       - run: cd ${{ matrix.site }} && bun run typecheck
       - run: cd ${{ matrix.site }} && bun run build
+      # Chrome for Testing + the headless shell are ~9s of download per job, and
+      # both matrix legs pay it. smoke-tests/bun.lock pins the Playwright
+      # version, so it is the correct cache key: a version bump changes the
+      # hash, misses, and re-downloads the matching browser build. Both legs
+      # start together and miss together on a bump — one wins the save, the
+      # other logs "cache already exists" and moves on.
+      - name: Cache Playwright browsers
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('smoke-tests/bun.lock') }}
       # Functional search test against the freshly-built site, BEFORE deploy.
       # Site search broke for ~6 days after the Astro 6→7 bump because nothing
       # exercised it pre-merge — only the post-deploy smoke caught it, live.
@@ -142,7 +153,15 @@ jobs:
           MERMAID_BASE_URL: http://127.0.0.1:8080
         run: |
           bun install --frozen-lockfile
-          bunx playwright install --with-deps chromium
+          # No --with-deps: it spent ~16s per job on apt for nothing. On
+          # ubuntu-latest every library Playwright asks for (libnss3, libcairo2,
+          # libatk*, libasound2t64, …) is already the newest version; the only
+          # packages it added were 21MB of CJK/Cyrillic/Thai fonts. Nothing here
+          # asserts pixels — no toHaveScreenshot, no snapshots — and the one
+          # geometry check is boundingBox().width > 0 on an English mermaid SVG.
+          # If a future runner image drops a library, this fails loudly at
+          # browser launch and the fix is to put the flag back.
+          bunx playwright install chromium
           node serve-build.mjs "../$SEARCH_SITE/dist/client" 8080 &
           for i in $(seq 1 30); do curl -sf "$SEARCH_BASE_URL/" >/dev/null && break; sleep 0.5; done
           bunx playwright test browser/

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ Existing tools describe **how** to build infrastructure. A Launchfile describes 
 
 This is a monorepo containing the specification, reference SDK, catalog, and websites. Components will be split into separate repositories as they develop independent contributor bases or release cadences. The `launchfile/launchfile` repo will remain the canonical home of the specification itself.
 
+## Core architecture
+
+- [SPEC.md](spec/SPEC.md) defines the YAML format.
+- [DESIGN.md](spec/DESIGN.md) records principles and binding decisions.
+- The SDK parses, normalizes, validates, and resolves expressions.
+- Docker, macOS, and AWS providers translate that model into execution.
+- The unified CLI orchestrates providers.
+- The catalog supplies real-app evidence.
+- Steward applies the public rules through the process in [GOVERNANCE.md](governance/GOVERNANCE.md).
+
 ## License
 
 [MIT](LICENSE)

--- a/smoke-tests/bun.lock
+++ b/smoke-tests/bun.lock
@@ -1,0 +1,21 @@
+{
+  "lockfileVersion": 2,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "smoke-tests",
+      "devDependencies": {
+        "@playwright/test": "^1.52.0",
+      },
+    },
+  },
+  "packages": {
+    "@playwright/test": ["@playwright/test@1.62.1", "", { "dependencies": { "playwright": "1.62.1" }, "bin": { "playwright": "cli.js" } }, "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ=="],
+
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "playwright": ["playwright@1.62.1", "", { "dependencies": { "playwright-core": "1.62.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg=="],
+
+    "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
+  }
+}


### PR DESCRIPTION
Follow-up to #249. With the terraform job fixed, `Website (www-dev)` at 62s became the run's longest pole.

The `Search + mermaid render` step was 39s (www-dev) / 34s (www-org) in [run 32715606739](https://github.com/launchfile/launchfile/actions/runs/32715606739). Breakdown from the www-dev log:

| segment | time |
|---|---|
| `bun install` | 0.7s |
| `playwright install` — apt phase | **16.5s** |
| `playwright install` — browser downloads | **9.5s** |
| serve + readiness poll | 1.6s |
| the tests themselves (6, passing) | 5.0s |

**`--with-deps` was buying fonts, not libraries.** The apt log reports every library Playwright asks for — `libnss3`, `libcairo2`, `libatk*`, `libasound2t64` — as `already the newest version` on `ubuntu-latest`. The 9 packages it actually installed were 21.1 MB of CJK/Cyrillic/Thai font coverage. Nothing here asserts pixels (no `toHaveScreenshot`, no snapshots); the one geometry check is `boundingBox().width > 0` on an English mermaid SVG. If a future runner image drops a library, browser launch fails loudly and the fix is re-adding one flag.

**Nothing in `.github/workflows` was cached.** `actions/cache` on `~/.cache/ms-playwright`, keyed on `smoke-tests/bun.lock`.

**`smoke-tests/bun.lock` was not committed — a live bug.** `.gitignore` states "Bun lockfiles are committed", and www-dev/www-org/www-shared all track theirs. `smoke-tests` is not a workspace member, so bun reads its own lockfile — which wasn't in git, so `--frozen-lockfile` pinned nothing and silently resolved `^1.52.0` to 1.62.1. The lockfile records 1.62.1, pinning current behaviour rather than changing it.

Expect the first run here to still miss the cache (GitHub scopes branch caches to the branch), so it should show the 16.5s apt win only. The cache win lands on the second run and after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)