### PR TITLE
chore: CI runs the packages' own test runner, and `bun test` says so

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - run: cd sdk && bun install --frozen-lockfile
       - run: cd sdk && bun run typecheck
       - run: cd sdk && bun run build
-      - run: cd sdk && bun test
+      - run: cd sdk && bun run test
 
   providers:
     name: "Provider (${{ matrix.provider }})"
@@ -42,7 +42,7 @@ jobs:
         run: cd sdk && bun install --frozen-lockfile && bun run build
       - run: cd providers/${{ matrix.provider }} && bun install --frozen-lockfile
       - run: cd providers/${{ matrix.provider }} && bun run typecheck
-      - run: cd providers/${{ matrix.provider }} && bun test
+      - run: cd providers/${{ matrix.provider }} && bun run test
 
   # The AWS provider is translation-only: prove the emitted HCL is valid Terraform
   # against the real AWS provider schema (no credentials — init only fetches the
@@ -91,7 +91,7 @@ jobs:
       - run: cd packages/launchfile && bun install --frozen-lockfile
       - run: cd packages/launchfile && bun run typecheck
       - run: cd packages/launchfile && bun run build
-      - run: cd packages/launchfile && bun test
+      - run: cd packages/launchfile && bun run test
       - name: Verify dist/cli.js exists
         run: test -f packages/launchfile/dist/cli.js || (echo "dist/cli.js missing!" && exit 1)
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,4 @@
+# `bun test` would silently use Bun's runner instead of Vitest.
+# The preload stops it and points at `bun run test`.
+[test]
+preload = ["./scripts/test-guard.ts"]

--- a/catalog/test/bunfig.toml
+++ b/catalog/test/bunfig.toml
@@ -1,0 +1,4 @@
+# `bun test` would silently use Bun's runner instead of Vitest.
+# The preload stops it and points at `bun run test`.
+[test]
+preload = ["./scripts/test-guard.ts"]

--- a/catalog/test/scripts/test-guard.ts
+++ b/catalog/test/scripts/test-guard.ts
@@ -1,0 +1,26 @@
+/**
+ * bunfig.toml preloads this file for `bun test` only. `bun run test` never
+ * loads it, so reaching this code means Bun's built-in runner was used instead
+ * of Vitest.
+ *
+ * The two runners disagree: Bun's ignores vitest.config.ts, and it shares one
+ * module registry across every test file, so a `vi.mock()` in one file leaks
+ * into the files loaded after it. A suite can pass under one runner and fail
+ * under the other.
+ */
+
+process.stderr.write(
+	[
+		"",
+		"  bun test is not the test runner for catalog/test.",
+		"",
+		"    use:  bun run test        (vitest run)",
+		"",
+		"  Bun's built-in runner ignores vitest.config.ts and shares module",
+		"  mocks across files, so its results do not match CI.",
+		"",
+		"",
+	].join("\n"),
+);
+
+process.exit(1);

--- a/packages/launchfile/bunfig.toml
+++ b/packages/launchfile/bunfig.toml
@@ -1,0 +1,4 @@
+# `bun test` would silently use Bun's runner instead of Vitest.
+# The preload stops it and points at `bun run test`.
+[test]
+preload = ["./scripts/test-guard.ts"]

--- a/packages/launchfile/scripts/test-guard.ts
+++ b/packages/launchfile/scripts/test-guard.ts
@@ -1,0 +1,26 @@
+/**
+ * bunfig.toml preloads this file for `bun test` only. `bun run test` never
+ * loads it, so reaching this code means Bun's built-in runner was used instead
+ * of Vitest.
+ *
+ * The two runners disagree: Bun's ignores vitest.config.ts, and it shares one
+ * module registry across every test file, so a `vi.mock()` in one file leaks
+ * into the files loaded after it. A suite can pass under one runner and fail
+ * under the other.
+ */
+
+process.stderr.write(
+	[
+		"",
+		"  bun test is not the test runner for packages/launchfile.",
+		"",
+		"    use:  bun run test        (vitest run)",
+		"",
+		"  Bun's built-in runner ignores vitest.config.ts and shares module",
+		"  mocks across files, so its results do not match CI.",
+		"",
+		"",
+	].join("\n"),
+);
+
+process.exit(1);

--- a/providers/aws/bunfig.toml
+++ b/providers/aws/bunfig.toml
@@ -1,0 +1,4 @@
+# `bun test` would silently use Bun's runner instead of Vitest.
+# The preload stops it and points at `bun run test`.
+[test]
+preload = ["./scripts/test-guard.ts"]

--- a/providers/aws/scripts/test-guard.ts
+++ b/providers/aws/scripts/test-guard.ts
@@ -1,0 +1,26 @@
+/**
+ * bunfig.toml preloads this file for `bun test` only. `bun run test` never
+ * loads it, so reaching this code means Bun's built-in runner was used instead
+ * of Vitest.
+ *
+ * The two runners disagree: Bun's ignores vitest.config.ts, and it shares one
+ * module registry across every test file, so a `vi.mock()` in one file leaks
+ * into the files loaded after it. A suite can pass under one runner and fail
+ * under the other.
+ */
+
+process.stderr.write(
+	[
+		"",
+		"  bun test is not the test runner for providers/aws.",
+		"",
+		"    use:  bun run test        (vitest run)",
+		"",
+		"  Bun's built-in runner ignores vitest.config.ts and shares module",
+		"  mocks across files, so its results do not match CI.",
+		"",
+		"",
+	].join("\n"),
+);
+
+process.exit(1);

--- a/providers/docker/bunfig.toml
+++ b/providers/docker/bunfig.toml
@@ -1,0 +1,4 @@
+# `bun test` would silently use Bun's runner instead of Vitest.
+# The preload stops it and points at `bun run test`.
+[test]
+preload = ["./scripts/test-guard.ts"]

--- a/providers/docker/scripts/test-guard.ts
+++ b/providers/docker/scripts/test-guard.ts
@@ -1,0 +1,26 @@
+/**
+ * bunfig.toml preloads this file for `bun test` only. `bun run test` never
+ * loads it, so reaching this code means Bun's built-in runner was used instead
+ * of Vitest.
+ *
+ * The two runners disagree: Bun's ignores vitest.config.ts, and it shares one
+ * module registry across every test file, so a `vi.mock()` in one file leaks
+ * into the files loaded after it. A suite can pass under one runner and fail
+ * under the other.
+ */
+
+process.stderr.write(
+	[
+		"",
+		"  bun test is not the test runner for providers/docker.",
+		"",
+		"    use:  bun run test        (vitest run)",
+		"",
+		"  Bun's built-in runner ignores vitest.config.ts and shares module",
+		"  mocks across files, so its results do not match CI.",
+		"",
+		"",
+	].join("\n"),
+);
+
+process.exit(1);

--- a/providers/macos-dev/bunfig.toml
+++ b/providers/macos-dev/bunfig.toml
@@ -1,0 +1,4 @@
+# `bun test` would silently use Bun's runner instead of Vitest.
+# The preload stops it and points at `bun run test`.
+[test]
+preload = ["./scripts/test-guard.ts"]

--- a/providers/macos-dev/scripts/test-guard.ts
+++ b/providers/macos-dev/scripts/test-guard.ts
@@ -1,0 +1,26 @@
+/**
+ * bunfig.toml preloads this file for `bun test` only. `bun run test` never
+ * loads it, so reaching this code means Bun's built-in runner was used instead
+ * of Vitest.
+ *
+ * The two runners disagree: Bun's ignores vitest.config.ts, and it shares one
+ * module registry across every test file, so a `vi.mock()` in one file leaks
+ * into the files loaded after it. A suite can pass under one runner and fail
+ * under the other.
+ */
+
+process.stderr.write(
+	[
+		"",
+		"  bun test is not the test runner for providers/macos-dev.",
+		"",
+		"    use:  bun run test        (vitest run)",
+		"",
+		"  Bun's built-in runner ignores vitest.config.ts and shares module",
+		"  mocks across files, so its results do not match CI.",
+		"",
+		"",
+	].join("\n"),
+);
+
+process.exit(1);

--- a/scripts/test-guard.ts
+++ b/scripts/test-guard.ts
@@ -1,0 +1,26 @@
+/**
+ * bunfig.toml preloads this file for `bun test` only. `bun run test` never
+ * loads it, so reaching this code means Bun's built-in runner was used instead
+ * of Vitest.
+ *
+ * The two runners disagree: Bun's ignores vitest.config.ts, and it shares one
+ * module registry across every test file, so a `vi.mock()` in one file leaks
+ * into the files loaded after it. A suite can pass under one runner and fail
+ * under the other.
+ */
+
+process.stderr.write(
+	[
+		"",
+		"  bun test is not the test runner for this repo.",
+		"",
+		"    use:  cd <package> && bun run test    (vitest run)",
+		"",
+		"  Bun's built-in runner ignores vitest.config.ts and shares module",
+		"  mocks across files, so its results do not match CI.",
+		"",
+		"",
+	].join("\n"),
+);
+
+process.exit(1);

--- a/sdk/bunfig.toml
+++ b/sdk/bunfig.toml
@@ -1,0 +1,4 @@
+# `bun test` would silently use Bun's runner instead of Vitest.
+# The preload stops it and points at `bun run test`.
+[test]
+preload = ["./scripts/test-guard.ts"]

--- a/sdk/scripts/test-guard.ts
+++ b/sdk/scripts/test-guard.ts
@@ -1,0 +1,26 @@
+/**
+ * bunfig.toml preloads this file for `bun test` only. `bun run test` never
+ * loads it, so reaching this code means Bun's built-in runner was used instead
+ * of Vitest.
+ *
+ * The two runners disagree: Bun's ignores vitest.config.ts, and it shares one
+ * module registry across every test file, so a `vi.mock()` in one file leaks
+ * into the files loaded after it. A suite can pass under one runner and fail
+ * under the other.
+ */
+
+process.stderr.write(
+	[
+		"",
+		"  bun test is not the test runner for sdk.",
+		"",
+		"    use:  bun run test        (vitest run)",
+		"",
+		"  Bun's built-in runner ignores vitest.config.ts and shares module",
+		"  mocks across files, so its results do not match CI.",
+		"",
+		"",
+	].join("\n"),
+);
+
+process.exit(1);


### PR DESCRIPTION
Every package in this repo declares `"test": "vitest run"`. CI invoked `bun test`.

Those are different executors. `bun test` runs Bun's built-in test runner; `bun run test` runs the package script. So CI has been running a runner the packages never asked for, with `vitest.config.ts` ignored.

## Why it matters

Bun's runner shares one module registry across every test file in a run. Vitest isolates each file. A `vi.mock()` therefore behaves differently under the two.

Observed in `providers/macos-dev` (bun 1.4.0), with the module mock that `provider-required-env.test.ts` installs on `../shell.js`:

```
bun test src/__tests__/shell-injection.test.ts                          →  12 pass /  0 fail
bun test src/__tests__/provider-required-env.test.ts \
         src/__tests__/shell-injection.test.ts                          →   0 pass /  2 fail
```

The mock leaks forward into the second file and turns `shell()` into a no-op. Under `vitest run` the same files pass. The divergence is not theoretical or uniform: this same suite passed under the bun the CI runner shipped and failed under bun 1.4.0 locally, on identical sources.

## The change

- `.github/workflows/ci.yml`: the three test steps run `bun run test`.
- Each package with a Vitest suite gets a `bunfig.toml` whose `[test] preload` points at a `scripts/test-guard.ts`. Running `bun test` there now prints why it is the wrong command and exits 1.

`bunfig.toml` is read from the working directory only — a root one does not reach a run started in `sdk/`, confirmed by test — so each package carries its own. That also keeps every package self-contained for the `git subtree split` the repo is laid out for.

Guarded: `sdk`, `providers/docker`, `providers/macos-dev`, `providers/aws`, `packages/launchfile`, `catalog/test`, and the repo root.

The guard files sit outside every package's `files` allowlist, so they are not published. Confirmed with `npm pack --dry-run` on `sdk` (40 files, no `bunfig.toml`, no `scripts/`).

## Verification

`bun test` exits 1 with the guard message in all seven directories.

`bun run test`, following CI's build order (SDK, then providers, then CLI):

| Package | Tests |
|-----------------------|---------|
| `sdk` | 364/364 |
| `providers/docker` | 186/186 |
| `providers/macos-dev` | 164/164 |
| `providers/aws` | 55/55 |
| `packages/launchfile` | 64/64 |
| `catalog/test` | 26/26 |

`packages/launchfile` was additionally run with only `sdk` and `providers/docker` built — exactly what the CLI job builds — and is green there too.

No published behavior changes, so no changeset.
