### PR TITLE
chore: run CI on merges to main, not only on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,13 @@ on:
   # Nothing holds the filter up on the other side — CI reads no secret and
   # carries a read-only token, so a run costs minutes and nothing else.
   pull_request:
+  # And every merge into main. A `pull_request` run tests `refs/pull/N/merge` —
+  # the PR merged into main as main stood when that run started — so once main
+  # moves, the result describes a tree that no longer exists. Two PRs green
+  # against different bases can produce a broken main between them. This is the
+  # only run that looks at the merged result.
+  push:
+    branches: [main]
 
 # Least privilege: every job here only reads the checked-out code (build/test/
 # validate). No job writes to the repo, comments, or deploys, so the workflow


### PR DESCRIPTION
Closes #263.

`.github/workflows/ci.yml` triggered on `pull_request:` and nothing else, so the SDK, provider, website and workflow-lint jobs have never run on a commit that is on `main`.

```
$ gh api repos/launchfile/launchfile/commits/1d23763/check-runs --jq '.check_runs[].name' | sort -u
Analyze (actions)
Analyze (javascript-typescript)
Browser (Playwright)
Smoke (Node 18)
Smoke (Node 20)
Smoke (Node 22)
Version or Publish
Websites
deploy
```

`main` reads as green because the workflows that *do* run on push are green. The test suite is simply not in that picture.

This is not a recent regression — `ci.yml` has never carried a `push:` trigger:

```
$ git log -p --follow -- .github/workflows/ci.yml | grep -E '^[+-].*push:'
(no output)
```

## The change

```yaml
on:
  pull_request:
  push:
    branches: [main]
```

Seven added lines, six of them the comment explaining why the trigger is there.

## Why it is needed

A `pull_request` run tests `refs/pull/N/merge` — the PR merged into `main` **as `main` stood when that run started**. Once `main` moves, that result describes a tree that no longer exists. Two PRs can each be green against different bases and produce a broken `main` between them.

PR #258 is a live example of the mechanism, caught only because it is still open: green at its head, red once `main` moved to `1d23763`, because `main` had added a test whose shell double predates a rename in the PR. Between two PRs that have already merged, nothing looks at the result at all.

`main` is also the branch `release.yml` publishes to npm from (`push: branches: [main]`), so it is currently the one branch with no test signal and the only one with a path to a downstream `node_modules`.

## Scope

This is **detection, not prevention** — it reports a broken `main` within one run of it being created. Prevention is "require branches to be up to date before merging", a branch-protection setting; `main` is recorded as unprotected with both rulesets disabled in #187. Detection first is the right order: those settings are worth more once there is a check on `main` for a ruleset to require.

## Cost

No job in `ci.yml` reads a secret or writes anything (`permissions: contents: read`), so the added runs cost minutes and nothing else. PR branches are unaffected — they keep their existing `pull_request` run, and `push: branches: [main]` does not match them.

## Verification

Ran the same strict parse that the `Workflow Lint` job runs, against all six workflow files:

```
ci.yml triggers -> {'pull_request': None, 'push': {'branches': ['main']}}
6 parsed cleanly, 0 failed
```
