### PR TITLE
chore: correct the #258 severity note — pre-fix postgres was command execution

### DIFF
--- a/.changeset/macos-dev-argv-execution.md
+++ b/.changeset/macos-dev-argv-execution.md
@@ -10,4 +10,6 @@ The runtime installers were the live case: `detectVersion()` returns the verbati
 
 Values reused from `.launchfile/state.json` are now validated before they reach SQL. `MysqlProvisioner.provision()` interpolated the stored database name, user and password into `mysql -e`, which runs `;`-separated statements as root; `loadState()` parses that file with no validation and it sits inside the cloned repo. Postgres guarded its two identifiers but not the password. Both provisioners now check all three against `resources/identifiers.ts` before issuing any statement.
 
+Measured, not assumed: the pre-fix postgres password was OS command execution, not a contained role change. Driven against a live server, a hostile `.launchfile/state.json` password inside the `DO $$ … $$` body runs `COPY … TO PROGRAM` (a host command) and escalates the app role to a cluster superuser; only non-transactional DDL such as `DROP DATABASE` is refused inside the block. The base64url password allowlist is what closes this — argv execution alone would still pass a quote through to the SQL parser.
+
 Also fixes an unrelated bug in the same code: the rbenv/pyenv installed-version check matched with `grep`, treating the version as a regex, so every `.` matched any character and an unrelated installed version could satisfy the request and skip the install.


### PR DESCRIPTION
PR #258 fixed the macos-dev postgres/mysql injection, but its still-unreleased changeset described the postgres hole as the stored password "reaching SQL." The reasoning that the `DO $$ … $$` body contained the payload — `DROP DATABASE` out, `ALTER ROLE … SUPERUSER` in — was drafted for the #258 description and cut before merge, never run against a server.

I measured it: drove the real pre-#258 `provision()` against a live postgres:16 with a hostile `.launchfile/state.json` password. All observed:

- `COPY … TO PROGRAM` inside the DO body executes — OS command execution, no break-out needed. Same via dynamic `EXECUTE`.
- `ALTER ROLE … SUPERUSER` inside the body executes — the app role becomes a cluster superuser.
- `DROP DATABASE` inside the body is refused (can't run in a function); the block's only real limit is non-transactional DDL.
- The shell transport was a second RCE surface: `$(…)` runs a host command before psql parses anything (CWE-78).

So the pre-#258 bug was **command execution**, not a contained role change. The fix still holds and needs both halves it has: argv (closes the shell layer) and the base64url `SAFE_PASSWORD` allowlist (closes the SQL layer — argv alone would pass a quote through to the SQL parser).

This PR only corrects the severity paragraph in the unreleased #258 changeset so the shipped changelog records the real blast radius. The measurement harness and transcript are retained out-of-tree by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)