### PR TITLE
providers: docker honors requires.config for postgres extensions

### DIFF
--- a/providers/docker/src/__tests__/compose-generator.test.ts
+++ b/providers/docker/src/__tests__/compose-generator.test.ts
@@ -694,3 +694,185 @@ secrets:
 		expect(ports.size).toBeGreaterThan(1500);
 	});
 });
+
+describe("requires.config — postgres extensions (PROVIDERS.md §10.8)", () => {
+	const pgLaunch = (config: string) =>
+		readLaunch(`
+name: vectorapp
+image: myapp:1
+requires:
+  - type: postgres
+${config}
+provides:
+  - protocol: http
+    port: 3000
+    exposed: true
+`);
+
+	it("selects the pgvector image and emits an init script for extensions: [vector]", () => {
+		const launch = pgLaunch(`    config:
+      extensions: [vector]`);
+		const result = launchToCompose(launch);
+
+		expect(result.yaml).toContain("pgvector/pgvector:pg16");
+		expect(result.yaml).not.toContain("postgres:16-alpine");
+		expect(result.yaml).toContain('CREATE EXTENSION IF NOT EXISTS "vector";');
+		expect(result.yaml).toContain("/docker-entrypoint-initdb.d/90-launchfile-extensions.sql");
+		expect(result.images).toContain("pgvector/pgvector:pg16");
+		expect(result.warnings).toHaveLength(0);
+	});
+
+	it("normalizes the package name pgvector to the SQL name vector", () => {
+		const launch = pgLaunch(`    config:
+      extensions: [pgvector]`);
+		const result = launchToCompose(launch);
+
+		expect(result.yaml).toContain("pgvector/pgvector:pg16");
+		expect(result.yaml).toContain('CREATE EXTENSION IF NOT EXISTS "vector";');
+		expect(result.yaml).not.toContain('"pgvector"');
+		expect(result.warnings).toHaveLength(0);
+	});
+
+	it("selects the postgis image for extensions: [postgis]", () => {
+		const launch = pgLaunch(`    config:
+      extensions: [postgis]`);
+		const result = launchToCompose(launch);
+
+		expect(result.yaml).toContain("postgis/postgis:16-3.4");
+		expect(result.yaml).toContain('CREATE EXTENSION IF NOT EXISTS "postgis";');
+		expect(result.warnings).toHaveLength(0);
+	});
+
+	it("keeps the stock image and emits no init script without config", () => {
+		const launch = pgLaunch("");
+		const result = launchToCompose(launch);
+
+		expect(result.yaml).toContain("postgres:16-alpine");
+		expect(result.yaml).not.toContain("configs:");
+		expect(result.yaml).not.toContain("CREATE EXTENSION");
+	});
+
+	it("rejects an extension name that is not a safe identifier", () => {
+		const launch = pgLaunch(`    config:
+      extensions: ["vector; DROP TABLE users"]`);
+		const result = launchToCompose(launch);
+
+		expect(result.yaml).not.toContain("DROP TABLE");
+		expect(result.yaml).not.toContain("CREATE EXTENSION");
+		expect(result.warnings.some((w) => w.includes("not a valid identifier"))).toBe(true);
+	});
+
+	it("passes an unmapped extension through validated, with a warning", () => {
+		const launch = pgLaunch(`    config:
+      extensions: [pg_trgm]`);
+		const result = launchToCompose(launch);
+
+		expect(result.yaml).toContain("postgres:16-alpine");
+		expect(result.yaml).toContain('CREATE EXTENSION IF NOT EXISTS "pg_trgm";');
+		expect(result.warnings.some((w) => w.includes("no known dedicated image"))).toBe(true);
+	});
+
+	it("warns when two declared extensions need different images", () => {
+		const launch = pgLaunch(`    config:
+      extensions: [vector, postgis]`);
+		const result = launchToCompose(launch);
+
+		expect(result.yaml).toContain("pgvector/pgvector:pg16");
+		expect(result.yaml).toContain('CREATE EXTENSION IF NOT EXISTS "vector";');
+		expect(result.yaml).toContain('CREATE EXTENSION IF NOT EXISTS "postgis";');
+		expect(result.warnings.some((w) => w.includes("need different images"))).toBe(true);
+	});
+
+	it("warns for a postgres config key it cannot honor", () => {
+		const launch = pgLaunch(`    config:
+      shared_buffers: 256MB`);
+		const result = launchToCompose(launch);
+
+		expect(result.yaml).toContain("postgres:16-alpine");
+		expect(
+			result.warnings.some(
+				(w) => w.includes('"shared_buffers"') && w.includes("not supported"),
+			),
+		).toBe(true);
+	});
+
+	it("warns for config on a backing service type with no config support", () => {
+		const launch = readLaunch(`
+name: cacheapp
+image: myapp:1
+requires:
+  - type: redis
+    config:
+      maxmemory: 256mb
+`);
+		const result = launchToCompose(launch);
+
+		expect(
+			result.warnings.some((w) => w.includes('"maxmemory"') && w.includes("not supported")),
+		).toBe(true);
+	});
+});
+
+describe("requires.config — shared backing service across components", () => {
+	const twoComponentLaunch = (apiReq: string, workerReq: string) =>
+		readLaunch(`
+name: multi-pg
+components:
+  api:
+    image: nginx
+    requires:
+      - type: postgres
+${apiReq}
+    provides:
+      - port: 4000
+        protocol: http
+        exposed: true
+  worker:
+    image: nginx
+    requires:
+      - type: postgres
+${workerReq}
+`);
+
+	it("warns when a later requirement's config differs from the shared service's", () => {
+		const launch = twoComponentLaunch(
+			"",
+			`        config:
+          extensions: [vector]`,
+		);
+		const result = launchToCompose(launch);
+
+		// First requirement (no config) created the service — stock image, no init script
+		expect(result.yaml).toContain("postgres:16-alpine");
+		expect(result.yaml).not.toContain("CREATE EXTENSION");
+		expect(
+			result.warnings.some(
+				(w) => w.includes("differs") && w.includes("multi-pg-postgres"),
+			),
+		).toBe(true);
+	});
+
+	it("stays silent when both components declare identical config", () => {
+		const config = `        config:
+          extensions: [vector]`;
+		const launch = twoComponentLaunch(config, config);
+		const result = launchToCompose(launch);
+
+		expect(result.yaml).toContain("pgvector/pgvector:pg16");
+		expect(result.yaml).toContain('CREATE EXTENSION IF NOT EXISTS "vector";');
+		expect(result.warnings).toHaveLength(0);
+	});
+
+	it("honors the first requirement's config and warns on the config-less duplicate", () => {
+		const launch = twoComponentLaunch(
+			`        config:
+          extensions: [vector]`,
+			"",
+		);
+		const result = launchToCompose(launch);
+
+		expect(result.yaml).toContain("pgvector/pgvector:pg16");
+		expect(result.yaml).toContain('CREATE EXTENSION IF NOT EXISTS "vector";');
+		expect(result.warnings.some((w) => w.includes("differs"))).toBe(true);
+	});
+});

--- a/providers/docker/src/compose-generator.ts
+++ b/providers/docker/src/compose-generator.ts
@@ -78,6 +78,98 @@ function generatePort(): string {
 	return String(10_000 + (buf[0]! % range));
 }
 
+// --- requires.config handling ---
+
+// Security: extension names come from Launchfile config (untrusted input).
+// Validate each against SAFE_IDENTIFIER before interpolating into SQL —
+// the same regex providers/macos-dev/src/resources/postgres.ts uses.
+const SAFE_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+// SPEC.md's `config.extensions` example lists package names (`pgvector`)
+// while CREATE EXTENSION needs the SQL extension name (`vector`). Accept
+// both spellings and normalize to the SQL name; names not listed here pass
+// through unchanged.
+const POSTGRES_EXTENSION_SQL_NAMES: Record<string, string> = {
+	pgvector: "vector",
+};
+
+// SQL extension name → smallest stock image that ships its binaries. The
+// default postgres image carries the contrib extensions (pg_trgm, hstore,
+// citext, …) but not these; declaring one swaps the service image.
+const POSTGRES_EXTENSION_IMAGES: Record<string, string> = {
+	vector: "pgvector/pgvector:pg16",
+	postgis: "postgis/postgis:16-3.4",
+};
+
+/**
+ * Honor `requires.config` for postgres (PROVIDERS.md §10.8: report gaps,
+ * not silent drops). Declared extensions select a satisfying image and are
+ * created via an init script the caller mounts into
+ * /docker-entrypoint-initdb.d/ (runs when the database directory is
+ * initialized). An extension no known image provides passes through
+ * validated — if the image lacks it, initialization fails loudly at boot
+ * instead of the app failing later on its first CREATE EXTENSION. Every
+ * config key or extension the provider cannot honor is surfaced as a
+ * warning, never dropped.
+ *
+ * Returns the init SQL, or undefined when no extensions are declared.
+ * Mutates `backing.image` when an extension requires a different image.
+ */
+function applyPostgresConfig(
+	config: Record<string, unknown>,
+	backing: BackingService,
+	warnings: string[],
+): string | undefined {
+	const sqlNames: string[] = [];
+	for (const [key, value] of Object.entries(config)) {
+		if (key !== "extensions") {
+			warnings.push(
+				`postgres config key ${JSON.stringify(key)} is not supported by the docker provider — ignored`,
+			);
+			continue;
+		}
+		if (!Array.isArray(value)) {
+			warnings.push("postgres config.extensions must be a list — ignored");
+			continue;
+		}
+		for (const entry of value) {
+			if (typeof entry !== "string" || !SAFE_IDENTIFIER.test(entry)) {
+				warnings.push(
+					`postgres extension name ${JSON.stringify(entry)} is not a valid identifier — skipped`,
+				);
+				continue;
+			}
+			const sqlName = POSTGRES_EXTENSION_SQL_NAMES[entry] ?? entry;
+			if (!sqlNames.includes(sqlName)) sqlNames.push(sqlName);
+		}
+	}
+
+	if (sqlNames.length === 0) return undefined;
+
+	// First declared extension with a dedicated image picks the image;
+	// contrib extensions keep the default image.
+	const imageExts = sqlNames.filter((n) => POSTGRES_EXTENSION_IMAGES[n]);
+	const first = imageExts[0];
+	if (first) {
+		backing.image = POSTGRES_EXTENSION_IMAGES[first]!;
+		for (const other of imageExts.slice(1)) {
+			warnings.push(
+				`postgres extensions ${first} and ${other} need different images — selected ` +
+					`${backing.image}; CREATE EXTENSION ${other} will fail at boot unless that image provides it`,
+			);
+		}
+	}
+	for (const ext of sqlNames) {
+		if (POSTGRES_EXTENSION_IMAGES[ext]) continue;
+		warnings.push(
+			`postgres extension "${ext}" has no known dedicated image — passing it through; ` +
+				`initialization fails at boot if ${backing.image} does not provide it`,
+		);
+	}
+
+	return `${sqlNames.map((n) => `CREATE EXTENSION IF NOT EXISTS "${n}";`).join("\n")}\n`;
+}
+
 /**
  * Create a backing service factory with pre-generated or cached passwords.
  * Passwords are per-app to ensure consistency across restarts.
@@ -503,6 +595,9 @@ export function launchToCompose(
 	const builds: string[] = [];
 	const services: Record<string, Record<string, unknown>> = {};
 	const volumes: Record<string, Record<string, unknown>> = {};
+	const configs: Record<string, Record<string, unknown>> = {};
+	// serviceName → serialized req.config it was created with (shared-service dedup)
+	const appliedConfigs = new Map<string, string>();
 	const secrets = opts.secrets ?? {};
 	const generatedEnv = opts.generatedEnv ?? {};
 	const ports: Record<string, number> = {};
@@ -691,6 +786,8 @@ export function launchToCompose(
 					req,
 					services,
 					volumes,
+					configs,
+					appliedConfigs,
 					images,
 					warnings,
 					backingServices,
@@ -798,6 +895,9 @@ export function launchToCompose(
 	if (Object.keys(volumes).length > 0) {
 		compose.volumes = volumes;
 	}
+	if (Object.keys(configs).length > 0) {
+		compose.configs = configs;
+	}
 
 	return {
 		yaml: stringify(compose, { lineWidth: 120 }),
@@ -861,6 +961,8 @@ function addBackingService(
 	req: NormalizedRequirement,
 	services: Record<string, Record<string, unknown>>,
 	volumes: Record<string, Record<string, unknown>>,
+	configs: Record<string, Record<string, unknown>>,
+	appliedConfigs: Map<string, string>,
 	images: string[],
 	warnings: string[],
 	backingServices: Record<string, (name: string) => BackingService>,
@@ -875,13 +977,56 @@ function addBackingService(
 
 	const serviceName = `${appName}-${type}`;
 
-	if (!services[serviceName]) {
+	if (services[serviceName]) {
+		// The backing service is shared across components; only the requirement
+		// that created it configured it. A later requirement whose config
+		// matches is already satisfied; a differing one cannot be honored and
+		// must be surfaced (§10.8) — never silently dropped. The comparison is
+		// on serialized form, so key order matters; a false mismatch costs a
+		// warning, never a behavior change.
+		const incoming = JSON.stringify(req.config ?? null);
+		if (incoming !== appliedConfigs.get(serviceName)) {
+			warnings.push(
+				`${type} config on a later requirement differs from what the shared service ` +
+					`${serviceName} was created with — ignored (the first requirement wins)`,
+			);
+		}
+	} else {
 		const backing = factory(appName);
+		appliedConfigs.set(serviceName, JSON.stringify(req.config ?? null));
+
+		// requires.config — honor what we can, surface what we can't (§10.8).
+		let initSql: string | undefined;
+		if (req.config) {
+			if (type === "postgres") {
+				initSql = applyPostgresConfig(req.config, backing, warnings);
+			} else {
+				for (const key of Object.keys(req.config)) {
+					warnings.push(
+						`${type} config key ${JSON.stringify(key)} is not supported by the docker provider — ignored`,
+					);
+				}
+			}
+		}
+
 		images.push(backing.image);
 
 		const service: Record<string, unknown> = {
 			image: backing.image,
 		};
+
+		if (initSql) {
+			// Inline compose config (Compose v2.23.0+) — keeps the init script
+			// inside the generated file, no sidecar to write or clean up.
+			const configName = `${serviceName}-init`;
+			configs[configName] = { content: initSql };
+			service.configs = [
+				{
+					source: configName,
+					target: "/docker-entrypoint-initdb.d/90-launchfile-extensions.sql",
+				},
+			];
+		}
 
 		if (Object.keys(backing.environment).length > 0) {
 			service.environment = backing.environment;


### PR DESCRIPTION
Closes #267

## What

The docker provider now honors `requires.config` for postgres — at minimum `config.extensions` — instead of silently dropping it. A Launchfile declaring

```yaml
requires:
  - type: postgres
    config:
      extensions: [vector]
```

gets a postgres image that ships the extension's binaries and an init script that creates the extension before the app's first connection.

## How

Design choices are the provider's call (P-11 — the declaration is intent; image and init strategy are execution):

- **Name normalization.** `spec/SPEC.md:239`'s example uses *package* names (`pgvector`) while `CREATE EXTENSION` needs the *SQL* name (`vector`). The provider accepts both and normalizes via an explicit map (`pgvector` → `vector`); unmapped names pass through unchanged. The spec-level defect (the example vs. the reference implementation) is tracked separately — see the sibling issue.
- **Image selection.** Extensions whose binaries the stock `postgres:16-alpine` lacks select a satisfying image: `pgvector/pgvector:pg16` for `vector`, `postgis/postgis:16-3.4` for `postgis`. First declared image-requiring extension wins; a second one that needs a different image is surfaced as a warning.
- **Init script.** All validated extensions are created via `CREATE EXTENSION IF NOT EXISTS "<ext>";` in a script mounted at `/docker-entrypoint-initdb.d/90-launchfile-extensions.sql`, delivered as an inline compose `configs` entry (Compose v2.23.0+) so the generator still emits a single self-contained file.
- **Report gaps, not silent drops (`spec/PROVIDERS.md:231`, §10 item 8).** Everything the provider cannot honor is pushed onto the existing warnings channel: invalid identifiers (rejected), unmapped extensions (passed through validated, warned — a missing binary fails loudly at boot instead of silently later), conflicting image requirements, unsupported postgres `config` keys (e.g. `shared_buffers`), and `config` on backing-service types with no config support (e.g. redis).
- **Shared backing services stay honest.** Components share one service per type (`${app}-${type}`), and only the requirement that creates the service configures it. A later requirement with an identical `config` is already satisfied and stays silent; one whose `config` differs is surfaced with a warning naming the shared service — declaration order can no longer silently decide whether extensions apply.
- **Security.** Extension names come from Launchfile config (untrusted input) and are validated against the same `SAFE_IDENTIFIER` regex macos-dev uses (`providers/macos-dev/src/resources/identifiers.ts:18`), before any SQL interpolation (CWE-78/SQL-injection guard).

## Precedent

`providers/macos-dev/src/resources/postgres.ts:129-143` already honors `req.config?.extensions` with identifier validation and per-entry `CREATE EXTENSION IF NOT EXISTS`. This PR closes the P-5 leak where the same Launchfile behaved differently between the two shipped providers.

## Tests

Twelve new cases in `providers/docker/src/__tests__/compose-generator.test.ts` (`requires.config — postgres extensions` + `shared backing service across components`): image selection for `vector`/`postgis`, package-name normalization, no-config stock behavior, unsafe-identifier rejection, unmapped-extension pass-through with warning, conflicting-image warning, unsupported-key warnings (postgres and redis), and the multi-component shared-postgres cases (differing config warns; identical config merges silently; first requirement wins). Full docker provider suite at the rebased HEAD (2026-08-25): 198/198 passing; `tsc --noEmit` clean.

**Verified live at the rebased HEAD** (2026-08-25, through the real CLI): a fixture Launchfile with `config: { extensions: [vector] }` launched via `launchfile up --docker`, booted healthy on `pgvector/pgvector:pg16`, and `SELECT extname FROM pg_extension` inside the container returned `vector`. Torn down after; zero containers left.
