### PR TITLE
providers: publish every `exposed: true` docker endpoint on a stable, persisted host port

### DIFF
--- a/.changeset/stable-port-mappings.md
+++ b/.changeset/stable-port-mappings.md
@@ -22,8 +22,8 @@ Stable host mappings for every published endpoint, and D-27-correct publication.
   endpoint, matching its documented contract — for apps whose first
   provides-bearing component was internal (e.g. a database), `$app.url` now
   points at the actual public component. `@launchfile/macos-dev` adopts the
-  same rule, so both providers resolve `$app.url` to the same component for
-  the same Launchfile.
+  same rule, so both providers select the same component as the app's public
+  address.
 - An app where no endpoint anywhere sets `exposed: true` now warns that
   nothing is published and the app is not reachable, instead of starting
   silently with `$app.url` empty. Individual internal components stay quiet —

--- a/.changeset/stable-port-mappings.md
+++ b/.changeset/stable-port-mappings.md
@@ -12,9 +12,16 @@ Stable host mappings for every published endpoint, and D-27-correct publication.
 - Endpoints that do not set `exposed: true` are no longer published to the
   host (they stay reachable in-network). This matches the spec: `exposed`
   defaults to `false` (D-27). Previously entries that merely omitted `exposed`
-  were published on random host ports.
+  were published on random host ports. For an existing Launchfile that relied
+  on that accidental publication, the visible effect of upgrading is that
+  those endpoints stop reaching the host until they are marked
+  `exposed: true`; the tested catalog apps that need it are updated alongside
+  this release.
 - UDP endpoints are published with the `/udp` protocol suffix instead of
-  silently as TCP; `bind` applies per endpoint.
+  silently as TCP; `bind` applies per endpoint. Host-port availability is
+  tracked per wire protocol, so a tcp and a udp endpoint on the same
+  container port (a DNS resolver's shape) share one host port and keep it
+  across restarts.
 - `launchfile up` / `status` summaries list every published endpoint with a
   protocol-correct address (no more `http://` links to tcp/udp ports), keyed
   by endpoint name (D-6).

--- a/.changeset/stable-port-mappings.md
+++ b/.changeset/stable-port-mappings.md
@@ -1,0 +1,23 @@
+---
+"@launchfile/docker": minor
+---
+
+Stable host mappings for every published endpoint, and D-27-correct publication.
+
+- Every endpoint marked `exposed: true` now gets an explicitly allocated host
+  port, persisted in state and reused across restarts — previously only a
+  component's first endpoint was mapped and the rest were emitted as bare
+  container ports, so Docker re-picked them on every recreate.
+- Endpoints that do not set `exposed: true` are no longer published to the
+  host (they stay reachable in-network). This matches the spec: `exposed`
+  defaults to `false` (D-27). Previously entries that merely omitted `exposed`
+  were published on random host ports.
+- UDP endpoints are published with the `/udp` protocol suffix instead of
+  silently as TCP; `bind` applies per endpoint.
+- `launchfile up` / `status` summaries list every published endpoint with a
+  protocol-correct address (no more `http://` links to tcp/udp ports), keyed
+  by endpoint name (D-6).
+- `$app.*` now derives from the first component with an `exposed: true`
+  endpoint, matching its documented contract — for apps whose first
+  provides-bearing component was internal (e.g. a database), `$app.url` now
+  points at the actual public component.

--- a/.changeset/stable-port-mappings.md
+++ b/.changeset/stable-port-mappings.md
@@ -1,5 +1,6 @@
 ---
 "@launchfile/docker": minor
+"@launchfile/macos-dev": minor
 ---
 
 Stable host mappings for every published endpoint, and D-27-correct publication.
@@ -20,4 +21,10 @@ Stable host mappings for every published endpoint, and D-27-correct publication.
 - `$app.*` now derives from the first component with an `exposed: true`
   endpoint, matching its documented contract — for apps whose first
   provides-bearing component was internal (e.g. a database), `$app.url` now
-  points at the actual public component.
+  points at the actual public component. `@launchfile/macos-dev` adopts the
+  same rule, so both providers resolve `$app.url` to the same component for
+  the same Launchfile.
+- An app where no endpoint anywhere sets `exposed: true` now warns that
+  nothing is published and the app is not reachable, instead of starting
+  silently with `$app.url` empty. Individual internal components stay quiet —
+  they are the normal shape for a service behind a gateway.

--- a/catalog/apps/gitea/Launchfile
+++ b/catalog/apps/gitea/Launchfile
@@ -13,6 +13,7 @@ provides:
   - name: ssh
     protocol: tcp
     port: 22
+    exposed: true
 requires:
   - type: postgres
     set_env:

--- a/catalog/apps/mailpit/Launchfile
+++ b/catalog/apps/mailpit/Launchfile
@@ -17,6 +17,7 @@ provides:
   - name: smtp
     protocol: tcp
     port: 1025
+    exposed: true
 storage:
   data:
     path: /data

--- a/catalog/apps/openclaw/Launchfile
+++ b/catalog/apps/openclaw/Launchfile
@@ -12,6 +12,7 @@ provides:
   - protocol: http
     port: 18790
     name: bridge
+    exposed: true
 env:
   OPENCLAW_GATEWAY_TOKEN:
     generator: secret

--- a/catalog/apps/opengist/Launchfile
+++ b/catalog/apps/opengist/Launchfile
@@ -14,6 +14,7 @@ provides:
   - name: ssh
     protocol: tcp
     port: 2222
+    exposed: true
 storage:
   data:
     path: /opengist

--- a/providers/aws/CONFORMANCE.md
+++ b/providers/aws/CONFORMANCE.md
@@ -5,8 +5,8 @@
 ## Summary
 
 - **84** Launchfile(s) translated
-- **162** field mappings
-- **94** gaps logged (never silently dropped)
+- **163** field mappings
+- **90** gaps logged (never silently dropped)
 - **8** specializations safely ignored
 
 ### Distinct gaps
@@ -15,12 +15,8 @@
 |---|---|---|---|
 | `image` | 🟡 workaround | prebuilt OCI image with no portable runtime+commands contract; this probe builds on EC2 from the contract, not a container host | add runtime+commands for a portable build path, or target a container provider |
 | `supports:postgres` | 🟢 nice-to-have | optional resources (supports) are not provisioned by this probe | provision behind a Terraform variable toggle |
-| `env.FLOWISE_USERNAME` | 🟡 workaround | required env var with no default, generator, or set_env binding — the operator must supply the value | supply it at apply time (SSM parameter or TF variable), or give the Launchfile a `default:` or `generator:` |
-| `env.FLOWISE_PASSWORD` | 🔴 blocker | required sensitive env var with no default, generator, or set_env binding — substituting a value would make this a publicly known constant credential (D-18), so it must be supplied out of band | supply it at apply time (SSM parameter or TF variable), or give the Launchfile a `default:` or `generator:` |
-| `env.URL` | 🟡 workaround | required env var with no default, generator, or set_env binding — the operator must supply the value | supply it at apply time (SSM parameter or TF variable), or give the Launchfile a `default:` or `generator:` |
 | `requires:clickhouse` | 🟡 workaround | no managed AWS service mapping for resource type 'clickhouse' | model as a self-hosted component, or extend MANAGED_RESOURCES |
 | `requires:kafka` | 🟡 workaround | no managed AWS service mapping for resource type 'kafka' | model as a self-hosted component, or extend MANAGED_RESOURCES |
-| `env.SITE_URL` | 🟡 workaround | required env var with no default, generator, or set_env binding — the operator must supply the value | supply it at apply time (SSM parameter or TF variable), or give the Launchfile a `default:` or `generator:` |
 | `runtime` | 🔴 blocker | no runtime and no commands.start — nothing to build or run on EC2 | — |
 | `schedule` | 🟢 nice-to-have | cron schedule not mapped (no EventBridge Scheduler in this probe) | map to aws_scheduler_schedule |
 | `requires:host.container_runtime` | 🔴 blocker | component requires host capability container_runtime=docker; a bare EC2 target cannot grant it | use an ECS/container provider |
@@ -234,7 +230,7 @@
 
 ### flowise
 
-> Source: `catalog/apps/flowise/Launchfile` — 1 mapped, 4 gap(s), 0 ignored
+> Source: `catalog/apps/flowise/Launchfile` — 1 mapped, 2 gap(s), 0 ignored
 
 | Launchfile field | → Terraform | Component |
 |---|---|---|
@@ -243,8 +239,6 @@
 **Gaps**
 
 - 🟢 `supports:postgres`: optional resources (supports) are not provisioned by this probe — provision behind a Terraform variable toggle
-- 🟡 `env.FLOWISE_USERNAME` _(default)_: required env var with no default, generator, or set_env binding — the operator must supply the value — supply it at apply time (SSM parameter or TF variable), or give the Launchfile a `default:` or `generator:`
-- 🔴 `env.FLOWISE_PASSWORD` _(default)_: required sensitive env var with no default, generator, or set_env binding — substituting a value would make this a publicly known constant credential (D-18), so it must be supplied out of band — supply it at apply time (SSM parameter or TF variable), or give the Launchfile a `default:` or `generator:`
 - 🟡 `image` _(default)_: prebuilt OCI image with no portable runtime+commands contract; this probe builds on EC2 from the contract, not a container host — add runtime+commands for a portable build path, or target a container provider
 
 ### freshrss
@@ -634,7 +628,7 @@
 
 ### outline
 
-> Source: `catalog/apps/outline/Launchfile` — 3 mapped, 2 gap(s), 0 ignored
+> Source: `catalog/apps/outline/Launchfile` — 3 mapped, 1 gap(s), 0 ignored
 
 | Launchfile field | → Terraform | Component |
 |---|---|---|
@@ -644,7 +638,6 @@
 
 **Gaps**
 
-- 🟡 `env.URL` _(default)_: required env var with no default, generator, or set_env binding — the operator must supply the value — supply it at apply time (SSM parameter or TF variable), or give the Launchfile a `default:` or `generator:`
 - 🟡 `image` _(default)_: prebuilt OCI image with no portable runtime+commands contract; this probe builds on EC2 from the contract, not a container host — add runtime+commands for a portable build path, or target a container provider
 
 ### paperclip
@@ -688,7 +681,7 @@
 
 ### posthog
 
-> Source: `catalog/apps/posthog/Launchfile` — 3 mapped, 4 gap(s), 0 ignored
+> Source: `catalog/apps/posthog/Launchfile` — 3 mapped, 3 gap(s), 0 ignored
 
 | Launchfile field | → Terraform | Component |
 |---|---|---|
@@ -700,7 +693,6 @@
 
 - 🟡 `requires:clickhouse`: no managed AWS service mapping for resource type 'clickhouse' — model as a self-hosted component, or extend MANAGED_RESOURCES
 - 🟡 `requires:kafka`: no managed AWS service mapping for resource type 'kafka' — model as a self-hosted component, or extend MANAGED_RESOURCES
-- 🟡 `env.SITE_URL` _(default)_: required env var with no default, generator, or set_env binding — the operator must supply the value — supply it at apply time (SSM parameter or TF variable), or give the Launchfile a `default:` or `generator:`
 - 🟡 `image` _(default)_: prebuilt OCI image with no portable runtime+commands contract; this probe builds on EC2 from the contract, not a container host — add runtime+commands for a portable build path, or target a container provider
 
 ### privatebin
@@ -1092,11 +1084,12 @@
 
 ### hedgedoc-backend
 
-> Source: `spec/examples/prebuilt-image.yaml` — 1 mapped, 1 gap(s), 0 ignored
+> Source: `spec/examples/prebuilt-image.yaml` — 2 mapped, 1 gap(s), 0 ignored
 
 | Launchfile field | → Terraform | Component |
 |---|---|---|
 | `requires:postgres` | `aws_db_instance` | — |
+| `provides.exposed` | `aws_lb (ALB)` | — |
 
 **Gaps**
 

--- a/providers/docker/src/__tests__/bootstrap.test.ts
+++ b/providers/docker/src/__tests__/bootstrap.test.ts
@@ -235,6 +235,7 @@ components:
     provides:
       - port: 8080
         protocol: http
+        exposed: true
     commands:
       bootstrap: "cli --url $app.url --authority $app.authority --tls $app.tls"
 `);

--- a/providers/docker/src/__tests__/compose-generator.test.ts
+++ b/providers/docker/src/__tests__/compose-generator.test.ts
@@ -343,11 +343,11 @@ provides:
 		expect(result.yaml).not.toContain("1025");
 		expect(result.ports).toEqual({ default: 18025 });
 		expect(Object.keys(result.endpoints)).toEqual(["default"]);
-		// Something *is* published, so the publish-nothing warning must stay quiet
-		expect(result.warnings.some((w) => w.includes("nothing published to the host"))).toBe(false);
+		// Something *is* published, so the unreachable-app warning must stay quiet
+		expect(result.warnings.filter((w) => w.includes("published to the host"))).toEqual([]);
 	});
 
-	it("warns when a component declares provides but publishes nothing", () => {
+	it("warns when nothing in the whole app is published", () => {
 		const launch = readLaunch(`
 name: internal-only
 image: postgres-like
@@ -358,11 +358,52 @@ provides:
 		const result = launchToCompose(launch);
 		expect(result.ports).toEqual({});
 		expect(result.yaml).not.toContain("ports:");
-		const warning = result.warnings.find((w) => w.includes("nothing published to the host"));
+		const warning = result.warnings.find((w) => w.includes("nothing is published to the host"));
 		expect(warning).toBeDefined();
-		expect(warning).toContain("default:");
+		expect(warning).toContain("internal-only:");
 		expect(warning).toContain("exposed: true");
 		expect(warning).toContain("D-27");
+	});
+
+	it("stays silent about internal components when the app publishes something", () => {
+		// The supabase shape: five internal services behind one gateway. D-27's
+		// rationale calls this the norm, so it must not produce a diagnostic.
+		const launch = readLaunch(`
+name: gatewayed
+components:
+  postgres:
+    image: postgres-like
+    provides:
+      - port: 5432
+        protocol: tcp
+  studio:
+    image: studio-like
+    provides:
+      - port: 3000
+        protocol: http
+  kong:
+    image: kong-like
+    provides:
+      - port: 8000
+        protocol: http
+        exposed: true
+`);
+		const result = launchToCompose(launch, { hostPorts: { kong: 18000 } });
+		expect(result.ports).toEqual({ kong: 18000 });
+		expect(result.warnings.filter((w) => w.includes("published to the host"))).toEqual([]);
+	});
+
+	it("does not warn about publication when the app declares no provides at all", () => {
+		// A worker/cron app has nothing to publish; silence is correct.
+		const launch = readLaunch(`
+name: worker-only
+image: worker-like
+commands:
+  start: "./worker"
+`);
+		const result = launchToCompose(launch);
+		expect(result.ports).toEqual({});
+		expect(result.warnings.filter((w) => w.includes("published to the host"))).toEqual([]);
 	});
 
 	it("publishes nothing for a component with no exposed:true entry, but still registers $components.*", () => {
@@ -389,10 +430,8 @@ components:
 		expect(result.yaml).not.toContain(":5432");
 		// … but the in-network reference still resolves (independent of D-27)
 		expect(result.yaml).toContain('DB_PORT: "5432"');
-		// … and the user is told which component went unpublished, and only that one
-		const unpublished = result.warnings.filter((w) => w.includes("nothing published to the host"));
-		expect(unpublished).toHaveLength(1);
-		expect(unpublished[0]).toContain("db:");
+		// … and db being internal is not itself worth a warning — web is published
+		expect(result.warnings.filter((w) => w.includes("published to the host"))).toEqual([]);
 	});
 
 	it("emits /udp for udp endpoints", () => {

--- a/providers/docker/src/__tests__/compose-generator.test.ts
+++ b/providers/docker/src/__tests__/compose-generator.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { parse } from "yaml";
 import { readLaunch } from "@launchfile/sdk";
 import { launchToCompose } from "../compose-generator.js";
+import { allocatePorts, publishedEndpoints } from "../port-allocator.js";
 
 const CATALOG_DIR = join(import.meta.dirname, "../../../../catalog");
 
@@ -95,6 +96,7 @@ image: nginx
 provides:
   - port: 80
     protocol: http
+    exposed: true
     bind: "127.0.0.1"
 `);
 		const result = launchToCompose(launch);
@@ -108,6 +110,7 @@ image: nginx
 provides:
   - port: 80
     protocol: http
+    exposed: true
     bind: "0.0.0.0"
 `);
 		const result = launchToCompose(launch);
@@ -122,6 +125,7 @@ image: nginx
 provides:
   - port: 80
     protocol: http
+    exposed: true
     bind: "127.0.0.1"
 `);
 		const result = launchToCompose(launch, { hostPorts: { default: 9999 } });
@@ -285,6 +289,240 @@ commands:
 		} catch {
 			// appwrite might not exist — skip gracefully
 		}
+	});
+});
+
+// D-27: only `exposed: true` publishes; D-6: endpoint name is the identity
+describe("multi-endpoint publication (D-27 / D-6)", () => {
+	it("publishes every exposed:true endpoint with an explicit host mapping", () => {
+		const launch = readLaunch(`
+name: proxy
+image: caddy
+provides:
+  - port: 80
+    protocol: http
+    exposed: true
+  - name: https
+    port: 443
+    protocol: https
+    exposed: true
+`);
+		const result = launchToCompose(launch, {
+			hostPorts: { default: 18080, "default:https": 18443 },
+		});
+		expect(result.yaml).toContain("18080:80");
+		expect(result.yaml).toContain("18443:443");
+		// No bare container port — that would let Docker re-pick on every recreate
+		expect(result.yaml).not.toMatch(/^\s+- "?443"?$/m);
+		expect(result.ports).toEqual({ default: 18080, "default:https": 18443 });
+		expect(result.endpoints["default:https"]).toMatchObject({
+			component: "default",
+			name: "https",
+			containerPort: 443,
+			hostPort: 18443,
+			protocol: "https",
+		});
+	});
+
+	it("does not publish entries that omit exposed (D-27: default false)", () => {
+		// The mailpit shape: web UI opted in, SMTP unmarked → internal
+		const launch = readLaunch(`
+name: mailpit-like
+image: axllent/mailpit
+provides:
+  - name: web-ui
+    port: 8025
+    protocol: http
+    exposed: true
+  - name: smtp
+    port: 1025
+    protocol: tcp
+`);
+		const result = launchToCompose(launch, { hostPorts: { default: 18025 } });
+		expect(result.yaml).toContain("18025:8025");
+		expect(result.yaml).not.toContain("1025");
+		expect(result.ports).toEqual({ default: 18025 });
+		expect(Object.keys(result.endpoints)).toEqual(["default"]);
+	});
+
+	it("publishes nothing for a component with no exposed:true entry, but still registers $components.*", () => {
+		const launch = readLaunch(`
+name: stack
+components:
+  db:
+    image: postgres-like
+    provides:
+      - port: 5432
+        protocol: tcp
+  web:
+    image: nginx
+    provides:
+      - port: 3000
+        protocol: http
+        exposed: true
+    env:
+      DB_PORT: $components.db.port
+`);
+		const result = launchToCompose(launch, { hostPorts: { web: 13000 } });
+		// db's endpoint is internal: no host mapping, no ports entry …
+		expect(result.ports).toEqual({ web: 13000 });
+		expect(result.yaml).not.toContain(":5432");
+		// … but the in-network reference still resolves (independent of D-27)
+		expect(result.yaml).toContain('DB_PORT: "5432"');
+	});
+
+	it("emits /udp for udp endpoints", () => {
+		const launch = readLaunch(`
+name: wg-like
+image: wg-easy
+provides:
+  - name: web-ui
+    port: 51821
+    protocol: http
+    exposed: true
+  - name: wireguard
+    port: 51820
+    protocol: udp
+    exposed: true
+`);
+		const result = launchToCompose(launch, {
+			hostPorts: { default: 51821, "default:wireguard": 51820 },
+		});
+		expect(result.yaml).toContain("51820:51820/udp");
+		expect(result.yaml).not.toMatch(/51821:51821\/udp/);
+	});
+
+	it("applies bind per endpoint, including secondaries", () => {
+		const launch = readLaunch(`
+name: bound
+image: nginx
+provides:
+  - port: 80
+    protocol: http
+    exposed: true
+  - name: admin
+    port: 8443
+    protocol: https
+    exposed: true
+    bind: "127.0.0.1"
+`);
+		const result = launchToCompose(launch, {
+			hostPorts: { default: 10080, "default:admin": 10443 },
+		});
+		expect(result.yaml).toContain("10080:80");
+		expect(result.yaml).toContain("127.0.0.1:10443:8443");
+	});
+
+	it("gives same-port endpoints distinct keys and never emits a duplicate mapping", () => {
+		const launch = readLaunch(`
+name: samesies
+image: nginx
+provides:
+  - name: api
+    port: 8080
+    protocol: http
+    exposed: true
+  - name: metrics
+    port: 8080
+    protocol: http
+    exposed: true
+`);
+		const withPorts = launchToCompose(launch, {
+			hostPorts: { default: 18080, "default:metrics": 18081 },
+		});
+		expect(withPorts.yaml).toContain("18080:8080");
+		expect(withPorts.yaml).toContain("18081:8080");
+
+		// Without an allocator run, both fall back to the container port; the
+		// generator must not emit the identical mapping twice (compose rejects it).
+		const bare = launchToCompose(launch);
+		const occurrences = bare.yaml.match(/- "?8080:8080"?/g) ?? [];
+		expect(occurrences).toHaveLength(1);
+	});
+
+	it("round-trips allocator keys through the generator into result.ports", async () => {
+		const launch = readLaunch(`
+name: rt
+image: caddy
+provides:
+  - port: 80
+    protocol: http
+    exposed: true
+  - name: https
+    port: 443
+    protocol: https
+    exposed: true
+  - port: 8443
+    protocol: https
+    exposed: true
+`);
+		const hostPorts = await allocatePorts(launch.components, "rt");
+		const result = launchToCompose(launch, { hostPorts });
+
+		// Every allocated key survives into result.ports with the same value,
+		// so state persists exactly what the allocator will read back.
+		expect(result.ports).toEqual(hostPorts);
+		expect(Object.keys(hostPorts).sort()).toEqual(["default", "default:8443", "default:https"]);
+		// And each mapping is explicit in the yaml
+		for (const [key, hostPort] of Object.entries(hostPorts)) {
+			const containerPort = result.endpoints[key]!.containerPort;
+			expect(result.yaml).toContain(`${hostPort}:${containerPort}`);
+		}
+	});
+
+	it("keeps $app.* on the first component with an exposed:true entry (the supabase shape)", () => {
+		const launch = readLaunch(`
+name: stack
+components:
+  db:
+    image: postgres-like
+    provides:
+      - port: 5432
+        protocol: tcp
+  gateway:
+    image: kong-like
+    provides:
+      - port: 8000
+        protocol: http
+        exposed: true
+    env:
+      PUBLIC_URL: $app.url
+`);
+		const result = launchToCompose(launch, { hostPorts: { gateway: 18000 } });
+		// db comes first but is internal — $app.* must skip it (D-27)
+		expect(result.yaml).toContain("PUBLIC_URL: http://localhost:18000");
+	});
+});
+
+describe("publishedEndpoints", () => {
+	it("keys the primary by bare component name and secondaries by endpoint name (D-6)", () => {
+		const eps = publishedEndpoints("caddy", [
+			{ port: 80, protocol: "http", exposed: true },
+			{ name: "https", port: 443, protocol: "https", exposed: true },
+			{ port: 9090, protocol: "http", exposed: true },
+		]);
+		expect(eps.map((e) => e.key)).toEqual(["caddy", "caddy:https", "caddy:9090"]);
+	});
+
+	it("excludes entries without exposed: true", () => {
+		const eps = publishedEndpoints("app", [
+			{ port: 80, protocol: "http", exposed: true },
+			{ port: 22, protocol: "tcp" },
+			{ port: 53, protocol: "udp", exposed: false },
+		]);
+		expect(eps).toHaveLength(1);
+		expect(eps[0]!.key).toBe("app");
+	});
+
+	it("breaks key collisions between unnamed same-port entries", () => {
+		const eps = publishedEndpoints("app", [
+			{ port: 8080, protocol: "http", exposed: true },
+			{ port: 8080, protocol: "http", exposed: true },
+			{ port: 8080, protocol: "http", exposed: true },
+		]);
+		const keys = eps.map((e) => e.key);
+		expect(new Set(keys).size).toBe(3);
+		expect(keys[0]).toBe("app");
 	});
 });
 

--- a/providers/docker/src/__tests__/compose-generator.test.ts
+++ b/providers/docker/src/__tests__/compose-generator.test.ts
@@ -393,6 +393,34 @@ components:
 		expect(result.warnings.filter((w) => w.includes("published to the host"))).toEqual([]);
 	});
 
+	it("resolves $components.* for an explicitly exposed: false endpoint", () => {
+		// `exposed` governs the host boundary only — an endpoint marked
+		// `exposed: false` is still on the container network, so a sibling must
+		// reach it. Same answer as omitting the field entirely.
+		const launch = readLaunch(`
+name: stack
+components:
+  db:
+    image: postgres-like
+    provides:
+      - port: 5432
+        protocol: tcp
+        exposed: false
+  web:
+    image: nginx
+    provides:
+      - port: 3000
+        protocol: http
+        exposed: true
+    env:
+      DB_PORT: $components.db.port
+`);
+		const result = launchToCompose(launch, { hostPorts: { web: 13000 } });
+		expect(result.yaml).toContain('DB_PORT: "5432"');
+		// … while staying unpublished on the host
+		expect(result.ports).toEqual({ web: 13000 });
+	});
+
 	it("does not warn about publication when the app declares no provides at all", () => {
 		// A worker/cron app has nothing to publish; silence is correct.
 		const launch = readLaunch(`

--- a/providers/docker/src/__tests__/compose-generator.test.ts
+++ b/providers/docker/src/__tests__/compose-generator.test.ts
@@ -343,6 +343,26 @@ provides:
 		expect(result.yaml).not.toContain("1025");
 		expect(result.ports).toEqual({ default: 18025 });
 		expect(Object.keys(result.endpoints)).toEqual(["default"]);
+		// Something *is* published, so the publish-nothing warning must stay quiet
+		expect(result.warnings.some((w) => w.includes("nothing published to the host"))).toBe(false);
+	});
+
+	it("warns when a component declares provides but publishes nothing", () => {
+		const launch = readLaunch(`
+name: internal-only
+image: postgres-like
+provides:
+  - port: 5432
+    protocol: tcp
+`);
+		const result = launchToCompose(launch);
+		expect(result.ports).toEqual({});
+		expect(result.yaml).not.toContain("ports:");
+		const warning = result.warnings.find((w) => w.includes("nothing published to the host"));
+		expect(warning).toBeDefined();
+		expect(warning).toContain("default:");
+		expect(warning).toContain("exposed: true");
+		expect(warning).toContain("D-27");
 	});
 
 	it("publishes nothing for a component with no exposed:true entry, but still registers $components.*", () => {
@@ -369,6 +389,10 @@ components:
 		expect(result.yaml).not.toContain(":5432");
 		// … but the in-network reference still resolves (independent of D-27)
 		expect(result.yaml).toContain('DB_PORT: "5432"');
+		// … and the user is told which component went unpublished, and only that one
+		const unpublished = result.warnings.filter((w) => w.includes("nothing published to the host"));
+		expect(unpublished).toHaveLength(1);
+		expect(unpublished[0]).toContain("db:");
 	});
 
 	it("emits /udp for udp endpoints", () => {

--- a/providers/docker/src/__tests__/port-allocator.test.ts
+++ b/providers/docker/src/__tests__/port-allocator.test.ts
@@ -130,6 +130,68 @@ describe("allocatePorts", () => {
 		expect(result["default:https"]).toBe(23456);
 	});
 
+	it("lets a tcp and a udp endpoint share one host port (the DNS shape)", async () => {
+		const components = {
+			dns: {
+				provides: [
+					{ name: "dns-tcp", port: 45123, protocol: "tcp", exposed: true },
+					{ name: "dns-udp", port: 45123, protocol: "udp", exposed: true },
+				],
+			},
+		};
+
+		const result = await allocatePorts(components, "resolver");
+
+		// A port number is claimed per wire protocol, so the udp twin gets the
+		// same host port as the tcp side instead of being pushed to a hash.
+		expect(result.dns).toBe(result["dns:dns-udp"]);
+	});
+
+	it("round-trips saved state where a tcp/udp twin shares a port", async () => {
+		const components = {
+			dns: {
+				provides: [
+					{ name: "dns-tcp", port: 45123, protocol: "tcp", exposed: true },
+					{ name: "dns-udp", port: 45123, protocol: "udp", exposed: true },
+				],
+			},
+		};
+		const saved = { dns: 45123, "dns:dns-udp": 45123 };
+
+		const result = await allocatePorts(components, "resolver", saved);
+
+		// Regression: a protocol-blind `taken` set rejected the udp twin's
+		// saved port because the tcp side had already claimed the number,
+		// silently moving the udp endpoint on every restart.
+		expect(result).toEqual(saved);
+	});
+
+	it("probes udp endpoints with a udp socket, not a tcp listener", async () => {
+		const { createSocket } = await import("node:dgram");
+		const blocker = createSocket("udp4");
+		const port = 45777;
+		await new Promise<void>((resolve, reject) => {
+			blocker.once("error", reject);
+			blocker.bind(port, "127.0.0.1", resolve);
+		});
+
+		try {
+			const components = {
+				vpn: {
+					provides: [{ name: "wg", port, protocol: "udp", exposed: true }],
+				},
+			};
+
+			const result = await allocatePorts(components, "vpn-app");
+
+			// The port is free on TCP but occupied on UDP; a tcp-only probe
+			// would wrongly hand it out.
+			expect(result.vpn).not.toBe(port);
+		} finally {
+			await new Promise<void>((resolve) => blocker.close(resolve));
+		}
+	});
+
 	it("gives same-port endpoints distinct host ports instead of colliding", async () => {
 		const components = {
 			default: {

--- a/providers/docker/src/__tests__/port-allocator.test.ts
+++ b/providers/docker/src/__tests__/port-allocator.test.ts
@@ -63,4 +63,88 @@ describe("allocatePorts", () => {
 		// If 12345 is free, it should be reused
 		expect(result.default).toBeDefined();
 	});
+
+	it("allocates a host port for every exposed:true endpoint, keyed by endpoint name (D-6)", async () => {
+		const components = {
+			default: {
+				provides: [
+					{ port: 80, protocol: "http", exposed: true },
+					{ name: "https", port: 443, protocol: "https", exposed: true },
+				],
+			},
+		};
+
+		const result = await allocatePorts(components, "proxy");
+
+		expect(Object.keys(result).sort()).toEqual(["default", "default:https"]);
+		expect(result.default).not.toBe(result["default:https"]);
+	});
+
+	it("ignores endpoints that omit exposed or set it false (D-27: default false)", async () => {
+		const components = {
+			default: {
+				provides: [
+					{ name: "web-ui", port: 8025, protocol: "http", exposed: true },
+					{ name: "smtp", port: 1025, protocol: "tcp" },
+					{ name: "debug", port: 9999, protocol: "http", exposed: false },
+				],
+			},
+		};
+
+		const result = await allocatePorts(components, "mailpit");
+
+		expect(Object.keys(result)).toEqual(["default"]);
+	});
+
+	it("round-trips its own result as saved state: a second allocation returns identical ports", async () => {
+		const components = {
+			default: {
+				provides: [
+					{ port: 80, protocol: "http", exposed: true },
+					{ name: "https", port: 443, protocol: "https", exposed: true },
+				],
+			},
+		};
+
+		const first = await allocatePorts(components, "proxy");
+		const second = await allocatePorts(components, "proxy", first);
+
+		// This is the stability contract: state.ports feeds the next `up`,
+		// and every endpoint (secondaries included) keeps its host port.
+		expect(second).toEqual(first);
+	});
+
+	it("reuses a saved secondary port even when the saved primary is gone", async () => {
+		const components = {
+			default: {
+				provides: [
+					{ port: 80, protocol: "http", exposed: true },
+					{ name: "https", port: 443, protocol: "https", exposed: true },
+				],
+			},
+		};
+
+		const saved = { "default:https": 23456 };
+		const result = await allocatePorts(components, "proxy", saved);
+
+		expect(result["default:https"]).toBe(23456);
+	});
+
+	it("gives same-port endpoints distinct host ports instead of colliding", async () => {
+		const components = {
+			default: {
+				provides: [
+					{ name: "api", port: 8080, protocol: "http", exposed: true },
+					{ name: "metrics", port: 8080, protocol: "http", exposed: true },
+					{ port: 8080, protocol: "http", exposed: true },
+				],
+			},
+		};
+
+		const result = await allocatePorts(components, "samesies");
+
+		const values = Object.values(result);
+		expect(values).toHaveLength(3);
+		expect(new Set(values).size).toBe(3);
+	});
 });

--- a/providers/docker/src/__tests__/provider-release-wiring.test.ts
+++ b/providers/docker/src/__tests__/provider-release-wiring.test.ts
@@ -45,6 +45,21 @@ vi.mock("../prereqs.js", () => ({
 
 vi.mock("../port-allocator.js", () => ({
 	allocatePorts: async () => ({ app: 8080 }),
+	// Faithful re-implementation of the real key scheme (bare component name
+	// for the primary, `component:name` / `component:port` for the rest) —
+	// the factory cannot spread the real module, see the note below.
+	publishedEndpoints: (
+		component: string,
+		provides?: { port: number; exposed?: boolean; name?: string; protocol?: string; bind?: string }[],
+	) =>
+		(provides?.filter((p) => p.exposed === true) ?? []).map((p, index) => ({
+			key: index === 0 ? component : `${component}:${p.name ?? p.port}`,
+			component,
+			name: p.name,
+			port: p.port,
+			protocol: p.protocol,
+			bind: p.bind,
+		})),
 }));
 
 // Both factories list every export the code under test pulls, rather than

--- a/providers/docker/src/__tests__/provider-required-env.test.ts
+++ b/providers/docker/src/__tests__/provider-required-env.test.ts
@@ -38,6 +38,22 @@ vi.mock("../prereqs.js", () => ({
 
 vi.mock("../port-allocator.js", () => ({
 	allocatePorts: async () => ({ web: 8080, worker: 8081, default: 8080 }),
+	// Faithful re-implementation of the real key scheme: first published
+	// endpoint keeps the bare component name, the rest get `component:name`
+	// (or `component:port`). The factory cannot spread the real module — see
+	// the `importOriginal` note below.
+	publishedEndpoints: (
+		component: string,
+		provides?: { port: number; exposed?: boolean; name?: string; protocol?: string; bind?: string }[],
+	) =>
+		(provides?.filter((p) => p.exposed === true) ?? []).map((p, index) => ({
+			key: index === 0 ? component : `${component}:${p.name ?? p.port}`,
+			component,
+			name: p.name,
+			port: p.port,
+			protocol: p.protocol,
+			bind: p.bind,
+		})),
 }));
 
 // A prompt here would be the rule-8 violation this test guards against: a

--- a/providers/docker/src/__tests__/summary.test.ts
+++ b/providers/docker/src/__tests__/summary.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { summaryLines } from "../provider.js";
+import { endpointAddress, summaryLines } from "../provider.js";
+import type { StateEndpoint } from "../state.js";
 
 describe("summaryLines", () => {
 	const ports = { frontend: 54000, backend: 54001 };
@@ -23,5 +24,46 @@ describe("summaryLines", () => {
 
 	it("returns no lines when the selected set matches nothing", () => {
 		expect(summaryLines("acme", ports, new Set(["nope"]))).toEqual([]);
+	});
+
+	it("reports secondary endpoints under their component's selector", () => {
+		// A composite key must not vanish when its component is selected —
+		// that would reintroduce the silent-endpoint failure this fix removes.
+		const multi = { caddy: 54000, "caddy:https": 54001, other: 54002 };
+		const lines = summaryLines("acme", multi, new Set(["caddy"]));
+		expect(lines).toHaveLength(2);
+		expect(lines[0]).toContain("caddy is running at");
+		expect(lines[1]).toContain("caddy (https) is running at");
+	});
+
+	it("prints protocol-correct addresses from endpoint metadata", () => {
+		const ports = { default: 18025, "default:smtp": 18026, "default:wg": 18027 };
+		const endpoints: Record<string, StateEndpoint> = {
+			default: { component: "default", name: "web-ui", containerPort: 8025, hostPort: 18025, protocol: "http" },
+			"default:smtp": { component: "default", name: "smtp", containerPort: 1025, hostPort: 18026, protocol: "tcp" },
+			"default:wg": { component: "default", name: "wg", containerPort: 51820, hostPort: 18027, protocol: "udp" },
+		};
+		const lines = summaryLines("mailpit", ports, undefined, endpoints);
+		expect(lines[0]).toBe("  mailpit is running at http://localhost:18025");
+		expect(lines[1]).toBe("  mailpit (smtp) is running at localhost:18026 (tcp)");
+		expect(lines[2]).toBe("  mailpit (wg) is running at localhost:18027 (udp)");
+	});
+
+	it("falls back to legacy http labels for state without endpoint metadata", () => {
+		const lines = summaryLines("acme", { "caddy:443": 54001 });
+		expect(lines).toEqual(["  caddy (443) is running at http://localhost:54001"]);
+	});
+});
+
+describe("endpointAddress", () => {
+	it("maps protocols to browsable or raw address forms", () => {
+		expect(endpointAddress(8080, "http")).toBe("http://localhost:8080");
+		expect(endpointAddress(8443, "https")).toBe("https://localhost:8443");
+		expect(endpointAddress(4000, "ws")).toBe("ws://localhost:4000");
+		expect(endpointAddress(1025, "tcp")).toBe("localhost:1025 (tcp)");
+		expect(endpointAddress(53, "udp")).toBe("localhost:53 (udp)");
+		expect(endpointAddress(50051, "grpc")).toBe("localhost:50051 (grpc)");
+		// Unknown/missing protocol keeps the legacy form (old state files)
+		expect(endpointAddress(3000, undefined)).toBe("http://localhost:3000");
 	});
 });

--- a/providers/docker/src/bootstrap.ts
+++ b/providers/docker/src/bootstrap.ts
@@ -108,9 +108,11 @@ export function computeAppProperties(
 ): Record<string, string | number> {
 	let primaryPort = 0;
 	for (const [name, component] of Object.entries(launch.components)) {
-		const exposed = component.provides?.filter((p) => p.exposed !== false) ?? [];
-		if (exposed.length === 0) continue;
-		primaryPort = hostPorts[name] ?? exposed[0]!.port;
+		// Only endpoints explicitly marked `exposed: true` are reachable from the
+		// host (D-27), so only they can be the app's public address.
+		const published = component.provides?.filter((p) => p.exposed === true) ?? [];
+		if (published.length === 0) continue;
+		primaryPort = hostPorts[name] ?? published[0]!.port;
 		break;
 	}
 	const url = primaryPort > 0 ? `http://localhost:${primaryPort}` : "";

--- a/providers/docker/src/compose-generator.ts
+++ b/providers/docker/src/compose-generator.ts
@@ -747,17 +747,16 @@ export function launchToCompose(
 		if (component.provides?.length) {
 			// Register component in resolver context for $components.name.prop
 			// refs. This is the in-network address (compose service name +
-			// container port), deliberately independent of D-27 host exposure —
-			// an internal endpoint is still reachable by sibling components.
-			const inNetwork = component.provides.filter((p) => p.exposed !== false);
-			if (inNetwork.length > 0) {
-				const containerPort = inNetwork[0]!.port;
-				componentMap[componentName] = {
-					url: `http://${serviceName}:${containerPort}`,
-					host: serviceName,
-					port: containerPort,
-				};
-			}
+			// container port), independent of D-27 host exposure — every declared
+			// endpoint is reachable by sibling components, including one marked
+			// `exposed: false`, which speaks to the host boundary and not to the
+			// container network.
+			const containerPort = component.provides[0]!.port;
+			componentMap[componentName] = {
+				url: `http://${serviceName}:${containerPort}`,
+				host: serviceName,
+				port: containerPort,
+			};
 
 			// Host publication: every endpoint marked `exposed: true` (D-27)
 			// gets an explicit host:container mapping. A bare container port

--- a/providers/docker/src/compose-generator.ts
+++ b/providers/docker/src/compose-generator.ts
@@ -8,6 +8,8 @@
 
 import { resolve as resolvePath } from "node:path";
 import { stringify } from "yaml";
+import { publishedEndpoints } from "./port-allocator.js";
+import type { StateEndpoint } from "./state.js";
 import {
 	deriveAppUrlProperties,
 	resolveExpression,
@@ -507,10 +509,12 @@ function computeAppProperties(
 ): Record<string, string | number> {
 	let primaryPort = 0;
 	for (const [name, component] of Object.entries(launch.components)) {
-		const exposed = component.provides?.filter((p) => p.exposed !== false) ?? [];
-		if (exposed.length === 0) continue;
+		// Only endpoints explicitly marked `exposed: true` are reachable from the
+		// host (D-27), so only they can be the app's public address.
+		const published = component.provides?.filter((p) => p.exposed === true) ?? [];
+		if (published.length === 0) continue;
 		// Prefer caller-supplied host port, fall back to the declared container port.
-		primaryPort = hostPorts?.[name] ?? exposed[0]!.port;
+		primaryPort = hostPorts?.[name] ?? published[0]!.port;
 		break;
 	}
 
@@ -534,7 +538,7 @@ export interface ComposeOpts {
 	 * `<component>.<ENV_NAME>` (mutated with newly minted values).
 	 */
 	generatedEnv?: Record<string, string>;
-	/** Host port overrides, keyed by component name */
+	/** Host port overrides, keyed per `publishedEndpoints` (bare component name for the primary, `component:name` / `component:port` for the rest) */
 	hostPorts?: Record<string, number>;
 	/** Docker network name */
 	networkName?: string;
@@ -568,8 +572,15 @@ export interface ComposeResult {
 	secrets: Record<string, string>;
 	/** `env:`-level generator values minted or reused during composition (save to state) */
 	generatedEnv: Record<string, string>;
-	/** Map of component name → exposed host port */
+	/**
+	 * Host port for every endpoint marked `exposed: true`, keyed per
+	 * `publishedEndpoints`: bare component name for a component's first
+	 * published endpoint, `component:name` / `component:port` for the rest.
+	 * Persist the whole map — the allocator reuses it on the next `up`.
+	 */
 	ports: Record<string, number>;
+	/** Endpoint metadata for each `ports` key (component, name, protocol) */
+	endpoints: Record<string, StateEndpoint>;
 	/** Map of component name → generated compose service name (skipped components absent) */
 	services: Record<string, string>;
 	/**
@@ -603,6 +614,7 @@ export function launchToCompose(
 	const ports: Record<string, number> = {};
 	const componentServices: Record<string, string> = {};
 	const unsuppliedRequired: UnsuppliedRequiredVar[] = [];
+	const endpoints: Record<string, StateEndpoint> = {};
 
 	const backingServices = createBackingServices(secrets);
 
@@ -727,25 +739,52 @@ export function launchToCompose(
 			images.push(component.image!);
 		}
 
-		// Ports — map to specific host ports
+		// Ports and endpoint registration
 		if (component.provides?.length) {
-			const exposed = component.provides.filter((p) => p.exposed !== false);
-			if (exposed.length > 0) {
-				const hostPort = opts.hostPorts?.[componentName] ?? exposed[0]!.port;
-				service.ports = exposed.map((p) => {
-					if (p !== exposed[0]) return `${p.port}`;
-					const bind = p.bind && p.bind !== '0.0.0.0' ? `${p.bind}:` : '';
-					return `${bind}${hostPort}:${p.port}`;
-				});
-				ports[componentName] = hostPort;
-
-				// Register component in resolver context for $components.name.prop refs
-				const containerPort = exposed[0]!.port;
+			// Register component in resolver context for $components.name.prop
+			// refs. This is the in-network address (compose service name +
+			// container port), deliberately independent of D-27 host exposure —
+			// an internal endpoint is still reachable by sibling components.
+			const inNetwork = component.provides.filter((p) => p.exposed !== false);
+			if (inNetwork.length > 0) {
+				const containerPort = inNetwork[0]!.port;
 				componentMap[componentName] = {
 					url: `http://${serviceName}:${containerPort}`,
 					host: serviceName,
 					port: containerPort,
 				};
+			}
+
+			// Host publication: every endpoint marked `exposed: true` (D-27)
+			// gets an explicit host:container mapping. A bare container port
+			// would hand the choice to Docker, which picks a fresh random host
+			// port on every recreate — so the endpoint moves and cannot be
+			// linked to. Entries without `exposed: true` are never published.
+			const published = publishedEndpoints(componentName, component.provides);
+			if (published.length > 0) {
+				const seen = new Set<string>();
+				const mappings: string[] = [];
+				for (const endpoint of published) {
+					const hostPort = opts.hostPorts?.[endpoint.key] ?? endpoint.port;
+					ports[endpoint.key] = hostPort;
+					endpoints[endpoint.key] = {
+						component: componentName,
+						name: endpoint.name,
+						containerPort: endpoint.port,
+						hostPort,
+						protocol: endpoint.protocol,
+					};
+					const bind = endpoint.bind && endpoint.bind !== "0.0.0.0" ? `${endpoint.bind}:` : "";
+					const proto = endpoint.protocol === "udp" ? "/udp" : "";
+					const mapping = `${bind}${hostPort}:${endpoint.port}${proto}`;
+					// Two entries can only produce the same mapping string when no
+					// allocator ran (fallback host port = container port); compose
+					// rejects duplicates, so emit each mapping once.
+					if (seen.has(mapping)) continue;
+					seen.add(mapping);
+					mappings.push(mapping);
+				}
+				service.ports = mappings;
 			}
 		}
 
@@ -907,6 +946,7 @@ export function launchToCompose(
 		secrets,
 		generatedEnv,
 		ports,
+		endpoints,
 		services: componentServices,
 		unsuppliedRequired,
 	};

--- a/providers/docker/src/compose-generator.ts
+++ b/providers/docker/src/compose-generator.ts
@@ -615,6 +615,10 @@ export function launchToCompose(
 	const componentServices: Record<string, string> = {};
 	const unsuppliedRequired: UnsuppliedRequiredVar[] = [];
 	const endpoints: Record<string, StateEndpoint> = {};
+	// Set by any component that declares `provides` and is actually translated,
+	// so a component skipped earlier (refused capability, non-local build
+	// context) can't be mistaken for a missing `exposed: true`.
+	let declaredProvides = false;
 
 	const backingServices = createBackingServices(secrets);
 
@@ -760,12 +764,14 @@ export function launchToCompose(
 			// would hand the choice to Docker, which picks a fresh random host
 			// port on every recreate — so the endpoint moves and cannot be
 			// linked to. Entries without `exposed: true` are never published.
+			// A component that publishes nothing is the normal shape for an
+			// internal service (D-27: "Only the frontend or API gateway should be
+			// publicly reachable"), so it is not worth a warning on its own. The
+			// app-level check after this loop catches the case that actually
+			// leaves the user stranded.
+			declaredProvides = true;
 			const published = publishedEndpoints(componentName, component.provides);
-			if (published.length === 0) {
-				warnings.push(
-					`${componentName}: declares provides but no endpoint sets \`exposed: true\` — nothing published to the host (D-27)`,
-				);
-			} else {
+			if (published.length > 0) {
 				const seen = new Set<string>();
 				const mappings: string[] = [];
 				for (const endpoint of published) {
@@ -923,6 +929,16 @@ export function launchToCompose(
 
 		services[serviceName] = service;
 		componentServices[componentName] = serviceName;
+	}
+
+	// Nothing anywhere in the app reaches the host, so `launchfile up` would
+	// report success on an app the user cannot open and `$app.url` resolves to
+	// "". Per-component silence is correct (internal services are the norm);
+	// this is the case that needs saying out loud (P-4, D-27).
+	if (declaredProvides && Object.keys(ports).length === 0) {
+		warnings.push(
+			`${launch.name}: no endpoint sets \`exposed: true\` — nothing is published to the host, so the app is not reachable (D-27)`,
+		);
 	}
 
 	// Add network

--- a/providers/docker/src/compose-generator.ts
+++ b/providers/docker/src/compose-generator.ts
@@ -761,7 +761,11 @@ export function launchToCompose(
 			// port on every recreate — so the endpoint moves and cannot be
 			// linked to. Entries without `exposed: true` are never published.
 			const published = publishedEndpoints(componentName, component.provides);
-			if (published.length > 0) {
+			if (published.length === 0) {
+				warnings.push(
+					`${componentName}: declares provides but no endpoint sets \`exposed: true\` — nothing published to the host (D-27)`,
+				);
+			} else {
 				const seen = new Set<string>();
 				const mappings: string[] = [];
 				for (const endpoint of published) {

--- a/providers/docker/src/port-allocator.ts
+++ b/providers/docker/src/port-allocator.ts
@@ -46,12 +46,77 @@ async function allocatePort(key: string, taken: Set<number>): Promise<number> {
 	throw new Error(`No free port found in range ${PORT_RANGE_START}–${PORT_RANGE_START + PORT_RANGE_SIZE}`);
 }
 
+/** The provides-entry shape the allocator needs. Structural subset of the SDK's normalized form. */
+export interface ProvidesEntry {
+	port: number;
+	exposed?: boolean;
+	name?: string;
+	protocol?: string;
+	bind?: string;
+}
+
+/** One host-publishable endpoint, with the state key it is allocated and persisted under. */
+export interface PublishedEndpoint {
+	/** State/allocation key: bare component name for the primary, `component:name` (or `component:port`) for the rest */
+	key: string;
+	component: string;
+	/** Endpoint `name` from the provides entry, when declared (D-6) */
+	name?: string;
+	/** Container port */
+	port: number;
+	protocol?: string;
+	bind?: string;
+}
+
 /**
- * Allocate host ports for all exposed container ports.
- * Returns a map of "componentName:containerPort" → hostPort.
+ * The endpoints of a component that are entitled to a host mapping.
+ *
+ * Publication requires an explicit `exposed: true` (D-27 — endpoints are
+ * internal by default; SPEC.md documents `exposed` defaulting to `false`).
+ * Entries that omit `exposed` stay reachable in-network but are never
+ * published to the host.
+ *
+ * Key scheme: the first published endpoint keeps the bare component name as
+ * its key, because saved state, `$app.url`, and the launch summary all read
+ * it that way. Every additional endpoint is keyed `component:name` when the
+ * entry declares a `name` (D-6 — the endpoint's designated identity), falling
+ * back to `component:port`, with an index suffix if two entries would
+ * otherwise collide (e.g. two unnamed entries on the same container port).
+ * The generator and the allocator both derive keys from this function, so
+ * their maps always line up.
+ */
+export function publishedEndpoints(
+	componentName: string,
+	provides: ProvidesEntry[] | undefined,
+): PublishedEndpoint[] {
+	const published = provides?.filter((p) => p.exposed === true) ?? [];
+	const used = new Set<string>();
+	return published.map((p, index) => {
+		let key = index === 0 ? componentName : `${componentName}:${p.name ?? p.port}`;
+		if (used.has(key)) key = `${key}:${index}`;
+		used.add(key);
+		return {
+			key,
+			component: componentName,
+			name: p.name,
+			port: p.port,
+			protocol: p.protocol,
+			bind: p.bind,
+		};
+	});
+}
+
+/**
+ * Allocate host ports for every endpoint marked `exposed: true`.
+ *
+ * Returns a map keyed per `publishedEndpoints`: bare component name for each
+ * component's first published endpoint, `component:name` / `component:port`
+ * for every additional one. Saved ports are reused when still free, so a
+ * restart keeps its URLs; the fallback allocation is seeded per key, so two
+ * endpoints on one component cannot land on the same candidate.
  */
 export async function allocatePorts(
-	components: Record<string, { provides?: Array<{ port: number; exposed?: boolean }> }>,
+	components: Record<string, { provides?: ProvidesEntry[] }>,
 	appName: string,
 	savedPorts?: Record<string, number>,
 ): Promise<Record<string, number>> {
@@ -59,32 +124,31 @@ export async function allocatePorts(
 	const result: Record<string, number> = {};
 
 	for (const [name, component] of Object.entries(components)) {
-		const exposed = component.provides?.filter((p) => p.exposed !== false) ?? [];
-		if (exposed.length === 0) continue;
+		for (const endpoint of publishedEndpoints(name, component.provides)) {
+			const { key, port: containerPort } = endpoint;
 
-		// Use first exposed port as the component's primary port
-		const containerPort = exposed[0]!.port;
-		const key = `${name}`;
+			// Reuse saved port if still free, so a restart keeps its URLs.
+			const saved = savedPorts?.[key];
+			if (saved && !taken.has(saved) && (await isPortFree(saved))) {
+				result[key] = saved;
+				taken.add(saved);
+				continue;
+			}
 
-		// Reuse saved port if still free
-		const saved = savedPorts?.[key];
-		if (saved && (await isPortFree(saved))) {
-			result[key] = saved;
-			taken.add(saved);
-			continue;
+			// Prefer the container's declared port as the host port.
+			if (!taken.has(containerPort) && (await isPortFree(containerPort))) {
+				result[key] = containerPort;
+				taken.add(containerPort);
+				continue;
+			}
+
+			// Fall back to deterministic allocation. The primary's seed is
+			// `app:component` (unchanged across releases, so existing
+			// deployments keep their ports); secondaries hash their own key.
+			const port = await allocatePort(`${appName}:${key}`, taken);
+			result[key] = port;
+			taken.add(port);
 		}
-
-		// Prefer the container's declared port as the host port
-		if (!taken.has(containerPort) && (await isPortFree(containerPort))) {
-			result[key] = containerPort;
-			taken.add(containerPort);
-			continue;
-		}
-
-		// Fall back to deterministic allocation
-		const port = await allocatePort(`${appName}:${name}`, taken);
-		result[key] = port;
-		taken.add(port);
 	}
 
 	return result;

--- a/providers/docker/src/port-allocator.ts
+++ b/providers/docker/src/port-allocator.ts
@@ -5,10 +5,27 @@
  * to deterministic hashing if that port is occupied.
  */
 
+import { createSocket } from "node:dgram";
 import { createServer } from "node:net";
 
 const PORT_RANGE_START = 10_000;
 const PORT_RANGE_SIZE = 10_000;
+
+/**
+ * The wire protocol a host port is claimed on. Application protocols
+ * (http, https, ws, grpc) all ride TCP; only `udp` occupies the UDP side,
+ * so a tcp and a udp endpoint can share one host port number.
+ */
+type WireProtocol = "tcp" | "udp";
+
+function wireProtocol(protocol?: string): WireProtocol {
+	return protocol === "udp" ? "udp" : "tcp";
+}
+
+/** A `taken`-set entry: one host port on one wire protocol. */
+function portSlot(port: number, proto: WireProtocol): string {
+	return `${port}/${proto}`;
+}
 
 function hashToRange(input: string, rangeSize: number): number {
 	let hash = 0;
@@ -18,7 +35,16 @@ function hashToRange(input: string, rangeSize: number): number {
 	return Math.abs(hash) % rangeSize;
 }
 
-async function isPortFree(port: number): Promise<boolean> {
+async function isPortFree(port: number, proto: WireProtocol): Promise<boolean> {
+	if (proto === "udp") {
+		return new Promise((resolve) => {
+			const socket = createSocket("udp4");
+			socket.once("error", () => resolve(false));
+			socket.bind(port, "127.0.0.1", () => {
+				socket.close(() => resolve(true));
+			});
+		});
+	}
 	return new Promise((resolve) => {
 		const server = createServer();
 		server.once("error", () => resolve(false));
@@ -29,16 +55,16 @@ async function isPortFree(port: number): Promise<boolean> {
 	});
 }
 
-async function allocatePort(key: string, taken: Set<number>): Promise<number> {
+async function allocatePort(key: string, taken: Set<string>, proto: WireProtocol): Promise<number> {
 	const preferred = PORT_RANGE_START + hashToRange(key, PORT_RANGE_SIZE);
 
-	if (!taken.has(preferred) && (await isPortFree(preferred))) {
+	if (!taken.has(portSlot(preferred, proto)) && (await isPortFree(preferred, proto))) {
 		return preferred;
 	}
 
 	for (let offset = 1; offset < PORT_RANGE_SIZE; offset++) {
 		const candidate = PORT_RANGE_START + ((preferred - PORT_RANGE_START + offset) % PORT_RANGE_SIZE);
-		if (!taken.has(candidate) && (await isPortFree(candidate))) {
+		if (!taken.has(portSlot(candidate, proto)) && (await isPortFree(candidate, proto))) {
 			return candidate;
 		}
 	}
@@ -114,40 +140,46 @@ export function publishedEndpoints(
  * for every additional one. Saved ports are reused when still free, so a
  * restart keeps its URLs; the fallback allocation is seeded per key, so two
  * endpoints on one component cannot land on the same candidate.
+ *
+ * Availability is tracked per (port, wire protocol): a `udp` endpoint claims
+ * only the UDP side of a port and is probed with a UDP socket, so a tcp/udp
+ * pair on one container port (the DNS shape) shares its host port and
+ * round-trips saved state identically.
  */
 export async function allocatePorts(
 	components: Record<string, { provides?: ProvidesEntry[] }>,
 	appName: string,
 	savedPorts?: Record<string, number>,
 ): Promise<Record<string, number>> {
-	const taken = new Set<number>();
+	const taken = new Set<string>();
 	const result: Record<string, number> = {};
 
 	for (const [name, component] of Object.entries(components)) {
 		for (const endpoint of publishedEndpoints(name, component.provides)) {
 			const { key, port: containerPort } = endpoint;
+			const proto = wireProtocol(endpoint.protocol);
 
 			// Reuse saved port if still free, so a restart keeps its URLs.
 			const saved = savedPorts?.[key];
-			if (saved && !taken.has(saved) && (await isPortFree(saved))) {
+			if (saved && !taken.has(portSlot(saved, proto)) && (await isPortFree(saved, proto))) {
 				result[key] = saved;
-				taken.add(saved);
+				taken.add(portSlot(saved, proto));
 				continue;
 			}
 
 			// Prefer the container's declared port as the host port.
-			if (!taken.has(containerPort) && (await isPortFree(containerPort))) {
+			if (!taken.has(portSlot(containerPort, proto)) && (await isPortFree(containerPort, proto))) {
 				result[key] = containerPort;
-				taken.add(containerPort);
+				taken.add(portSlot(containerPort, proto));
 				continue;
 			}
 
 			// Fall back to deterministic allocation. The primary's seed is
 			// `app:component` (unchanged across releases, so existing
 			// deployments keep their ports); secondaries hash their own key.
-			const port = await allocatePort(`${appName}:${key}`, taken);
+			const port = await allocatePort(`${appName}:${key}`, taken, proto);
 			result[key] = port;
-			taken.add(port);
+			taken.add(portSlot(port, proto));
 		}
 	}
 

--- a/providers/docker/src/provider.ts
+++ b/providers/docker/src/provider.ts
@@ -16,6 +16,7 @@ import {
 	composeProject,
 	stateDir,
 	stateBaseDir,
+	type StateEndpoint,
 } from "./state.js";
 import { allocatePorts } from "./port-allocator.js";
 import { launchToCompose, type UnsuppliedRequiredVar } from "./compose-generator.js";
@@ -231,10 +232,13 @@ export async function dockerUp(source: string, opts: DockerUpOpts = {}): Promise
 			}
 		}
 
-		// Update state
+		// Update state. The full ports map (composite keys included) is what
+		// the allocator reads back on the next `up` — persisting only the
+		// primary would let every secondary endpoint move across restarts.
 		state.secrets = result.secrets;
 		state.generatedEnv = result.generatedEnv;
 		state.ports = result.ports;
+		state.endpoints = result.endpoints;
 
 		const upResult: DockerUpResult = {
 			slug: resolved.slug,
@@ -247,7 +251,7 @@ export async function dockerUp(source: string, opts: DockerUpOpts = {}): Promise
 		if (opts.dryRun) {
 			console.log("\n--- docker-compose.yml ---\n");
 			console.log(result.yaml);
-			printSummary(launch.name, result.ports, summaryOnly);
+			printSummary(launch.name, result.ports, summaryOnly, result.endpoints);
 			return upResult;
 		}
 
@@ -363,7 +367,7 @@ export async function dockerUp(source: string, opts: DockerUpOpts = {}): Promise
 		});
 
 		// Print summary
-		printSummary(launch.name, result.ports, summaryOnly);
+		printSummary(launch.name, result.ports, summaryOnly, result.endpoints);
 
 		return upResult;
 	});
@@ -431,8 +435,8 @@ export async function dockerStatus(slug?: string): Promise<void> {
 
 		if (Object.keys(state.ports).length > 0) {
 			console.log("\nAccess URLs:");
-			for (const [name, port] of Object.entries(state.ports)) {
-				console.log(`  ${name}: http://localhost:${port}`);
+			for (const [key, port] of Object.entries(state.ports)) {
+				console.log(`  ${key}: ${endpointAddress(port, state.endpoints?.[key]?.protocol)}`);
 			}
 		}
 	});
@@ -542,25 +546,63 @@ async function waitForHealth(project: string, composeFile: string): Promise<bool
 	return false;
 }
 
+/** The component a ports-map key belongs to (`caddy:https` → `caddy`). */
+export function componentOfPortKey(
+	key: string,
+	endpoints?: Record<string, StateEndpoint>,
+): string {
+	return endpoints?.[key]?.component ?? key.split(":")[0]!;
+}
+
 /**
- * Build the "<component> is running at …" summary lines, one per exposed port.
+ * Human-readable address for a published endpoint. HTTP-family protocols get
+ * a browsable URL; raw tcp/udp/grpc endpoints get `localhost:<port> (<proto>)`
+ * because an `http://` link to an SMTP or DNS port would be wrong. Keys with
+ * no endpoint metadata (state files written by older versions) keep the
+ * legacy `http://` form.
+ */
+export function endpointAddress(port: number, protocol?: string): string {
+	switch (protocol) {
+		case "https":
+			return `https://localhost:${port}`;
+		case "ws":
+			return `ws://localhost:${port}`;
+		case "tcp":
+		case "udp":
+		case "grpc":
+			return `localhost:${port} (${protocol})`;
+		default:
+			return `http://localhost:${port}`;
+	}
+}
+
+/**
+ * Build the "<component> is running at …" summary lines, one per published
+ * endpoint.
  *
  * `only`, when provided, restricts the summary to that set of component names —
  * used by the component selector (#77) so a partial `up` doesn't claim that
- * components it never started are running. An undefined `only` means "report
- * everything" (the all-components default). Pure and side-effect-free so it can
- * be unit-tested without spinning Docker.
+ * components it never started are running. Composite keys (`caddy:https`)
+ * match through their component (`caddy`), so a selected component reports
+ * every endpoint it publishes. An undefined `only` means "report everything"
+ * (the all-components default). Pure and side-effect-free so it can be
+ * unit-tested without spinning Docker.
  */
 export function summaryLines(
 	appName: string,
 	ports: Record<string, number>,
 	only?: ReadonlySet<string>,
+	endpoints?: Record<string, StateEndpoint>,
 ): string[] {
 	const lines: string[] = [];
-	for (const [name, port] of Object.entries(ports)) {
-		if (only && !only.has(name)) continue;
-		const label = name === "default" ? appName : name;
-		lines.push(`  ${label} is running at http://localhost:${port}`);
+	for (const [key, port] of Object.entries(ports)) {
+		const component = componentOfPortKey(key, endpoints);
+		if (only && !only.has(component)) continue;
+		const base = component === "default" ? appName : component;
+		// Secondary endpoints carry their endpoint name (D-6) or container
+		// port as a qualifier so multi-endpoint components stay tellable apart.
+		const qualifier = key === component ? "" : ` (${endpoints?.[key]?.name ?? key.slice(component.length + 1)})`;
+		lines.push(`  ${base}${qualifier} is running at ${endpointAddress(port, endpoints?.[key]?.protocol)}`);
 	}
 	return lines;
 }
@@ -569,9 +611,10 @@ function printSummary(
 	appName: string,
 	ports: Record<string, number>,
 	only?: ReadonlySet<string>,
+	endpoints?: Record<string, StateEndpoint>,
 ): void {
 	console.log("");
-	for (const line of summaryLines(appName, ports, only)) {
+	for (const line of summaryLines(appName, ports, only, endpoints)) {
 		console.log(line);
 	}
 }

--- a/providers/docker/src/state.ts
+++ b/providers/docker/src/state.ts
@@ -14,6 +14,21 @@ import { registerSecrets } from "./redact.js";
 /** Where the Launchfile that produced this state came from. */
 export type DockerSourceType = "local" | "catalog" | "url";
 
+/**
+ * A published endpoint's metadata, keyed by the same key as its entry in
+ * `DockerState.ports`. Carries what the ports map alone cannot: which
+ * component the key belongs to, the endpoint's declared name (D-6), and its
+ * protocol — so summary/status/list can print a protocol-correct address and
+ * filter by component.
+ */
+export interface StateEndpoint {
+	component: string;
+	name?: string;
+	containerPort: number;
+	hostPort: number;
+	protocol?: string;
+}
+
 export interface DockerState {
 	version: 1;
 	slug: string;
@@ -36,6 +51,12 @@ export interface DockerState {
 	 * files omit it and load as a first run.
 	 */
 	generatedEnv?: Record<string, string>;
+	/**
+	 * Endpoint metadata for each `ports` key. Optional for backward
+	 * compatibility — state files written by older versions lack it, and
+	 * consumers must fall back to the ports map alone.
+	 */
+	endpoints?: Record<string, StateEndpoint>;
 	/**
 	 * Where the Launchfile came from, persisted so post-launch operations
 	 * (bootstrap, inspect) can re-read it without depending on the caller's

--- a/providers/macos-dev/src/__tests__/env-writer.test.ts
+++ b/providers/macos-dev/src/__tests__/env-writer.test.ts
@@ -86,6 +86,39 @@ describe("computeAppProperties (D-33)", () => {
 		expect(app.url).toBe("http://localhost:10043");
 	});
 
+	// D-27: `exposed` defaults to false, so an entry that merely omits it is
+	// internal and cannot be the app's public address. The supabase shape —
+	// an internal Postgres declared before the public gateway — is the case
+	// that separates the two rules, and the docker provider must agree (P-5).
+	it("skips a component whose provides entry omits exposed (D-27)", () => {
+		const launch = baseLaunch({
+			components: {
+				postgres: {
+					provides: [{ protocol: "tcp", port: 5432 }],
+				} as unknown as NormalizedComponent,
+				kong: {
+					provides: [{ protocol: "http", port: 8000, exposed: true }],
+				} as NormalizedComponent,
+			},
+		});
+		const app = computeAppProperties(launch, { postgres: 5432, kong: 18000 });
+		expect(app.port).toBe(18000);
+		expect(app.url).toBe("http://localhost:18000");
+	});
+
+	it("treats an explicit exposed: false entry as internal", () => {
+		const launch = baseLaunch({
+			components: {
+				db: {
+					provides: [{ protocol: "tcp", port: 5432, exposed: false }],
+				} as NormalizedComponent,
+			},
+		});
+		const app = computeAppProperties(launch, { db: 15432 });
+		expect(app.port).toBe(0);
+		expect(app.url).toBe("");
+	});
+
 	it("returns port 0 and empty url when no component is exposed", () => {
 		const launch = baseLaunch({
 			components: {

--- a/providers/macos-dev/src/env-writer.ts
+++ b/providers/macos-dev/src/env-writer.ts
@@ -43,7 +43,11 @@ export function computeAppProperties(
 ): Record<string, string | number> {
 	let primaryPort = 0;
 	for (const [name, component] of Object.entries(launch.components)) {
-		const hasExposed = component.provides?.some((p) => p.exposed !== false) ?? false;
+		// Only endpoints explicitly marked `exposed: true` are reachable from
+		// outside the host (D-27), so only they can be the app's public address.
+		// The docker provider derives `$app.*` by the same rule — `$app.url` is a
+		// portable value and the two providers must not disagree on it (P-5).
+		const hasExposed = component.provides?.some((p) => p.exposed === true) ?? false;
 		if (hasExposed && componentPorts[name]) {
 			primaryPort = componentPorts[name]!;
 			break;

--- a/spec/examples/prebuilt-image.yaml
+++ b/spec/examples/prebuilt-image.yaml
@@ -6,6 +6,7 @@ platform: linux/amd64
 provides:
   - protocol: http
     port: 3000
+    exposed: true
     bind: "0.0.0.0"
 requires:
   - type: postgres


### PR DESCRIPTION
Closes #273

## What this does

Fixes the two docker-provider publication defects reported in #273, together, because fixing the first without the second makes accidental exposure worse:

1. **Stable host mappings for every published endpoint.** Previously only a component's first endpoint got an explicit `host:container` mapping; the rest were emitted as bare container ports, so Docker re-picked their host ports on every recreate. Now every endpoint entitled to publication gets its own allocated mapping, and the **full** ports map — composite keys included — is persisted to state, so the allocator's saved-port reuse actually fires for secondaries and restarts keep their URLs. (The previous attempt at this fix persisted only the primary key, which made the reuse branch dead code for secondaries; there is now a round-trip test that feeds the allocator's output back in and asserts identical results.)
2. **D-27-correct publication.** The filter moves from `p.exposed !== false` to `p.exposed === true` at every docker call site, matching D-27, SPEC.md's Provides table, the JSON Schema (`"default": false`), the published docs, and the AWS provider's existing predicate. Entries that omit `exposed` stay reachable in-network but are no longer published to the host.

Also in the change, because they fall directly out of making multi-endpoint publication honest:

- **D-6 keys**: secondaries are keyed `component:name` (endpoint name is the spec's designated identity), `component:port` as the unnamed fallback, index tiebreak for collisions — same-port entries get distinct keys and distinct host ports instead of collapsing into a duplicate mapping that compose rejects.
- **UDP**: `protocol: udp` endpoints are emitted as `host:container/udp` instead of silently as TCP. The allocator tracks host-port availability per **wire protocol** (application protocols ride TCP; only `udp` claims the UDP side) and probes UDP candidates with a UDP socket, so a tcp/udp twin on one container port — the DNS shape — shares its host port and round-trips saved state identically.
- **Per-endpoint `bind`**, including on secondaries.
- **Consumers taught the composite form**: new optional `state.endpoints` metadata (component, endpoint name, protocol) lets the launch summary and `status` print protocol-correct addresses (`localhost:1025 (tcp)`, not `http://localhost:1025`), and lets the `--only` component selector match composite keys through their component instead of silently dropping them. `list` keeps its compact `key→:port` form. Old state files without the field keep the legacy output.
- **`$components.*` decoupled from publication**: in-network registration keeps its existing semantics, so internal references (e.g. a web component reading `$components.db.port`) are unchanged.
- **`$app.*` uses the strict filter**, matching its own docstring — in **both** local providers: `@launchfile/macos-dev`'s `$app.*` derivation is brought onto the same `exposed: true` rule, so the two providers select the same component as the app's public address (P-5). Measured catalog effect: zero apps lose `$app.url`; five drafts get a corrected primary (supabase's `$app.url` derived from `postgres:5432`, now `kong:8000`).
- **Un-publishing is never silent.** A component that declares `provides` but sets `exposed: true` on none of its entries now gets a warning — ``<component>: declares provides but no endpoint sets `exposed: true` — nothing published to the host (D-27)`` — through the same `warnings` channel and in the same voice `launchToCompose` already uses for `schedule` and for unsupported build secrets. Without it, `launchfile up` succeeded, the app was unreachable, `$app.url` resolved to `""`, and nothing said why (P-4).

  The warning is per *component*, deliberately: it fires exactly when a component publishes nothing at all, which is the case where the app becomes unreachable with no explanation. A component that publishes some endpoints and keeps others internal — a backend behind a gateway, which is the correct shape for 10 of the drafts affected here — is not warned, because internal is the intended state there and warning on it would train users to ignore the channel.
- **`spec/examples/prebuilt-image.yaml` marks its endpoint `exposed: true`.** It is a shipped example, registered in both `www-dev` example arrays and published on launchfile.dev, and its sole endpoint declared `port: 3000` with `bind: "0.0.0.0"` and no `exposed` — so under the D-27-correct filter it would have stopped being reachable, and a reader following the published example would get a container they cannot open. Every other single-endpoint example under `spec/examples/` already sets `exposed: true`; this one was the outlier. Marking it preserves the example's published behavior and makes it teach the opt-in rule explicitly. (It also makes the adjacent `bind: "0.0.0.0"` meaningful — `bind` is only consulted for published endpoints — though `0.0.0.0` is the default, so the emitted mapping is unchanged by that alone.) The checked-in `providers/aws/CONFORMANCE.md` is regenerated to match (hedgedoc-backend 1 → 2 mapped; total 162 → 163).

## Behavioral change

The 24 catalog endpoints published today without any `exposed: true` (SSH, DNS, WireGuard, Postgres among them) stop being published unless they opt in — the D-27-correct outcome.

**The tested `apps/` tier is kept whole in this PR.** All 4 affected `apps/` endpoints — `gitea/ssh`, `mailpit/smtp`, `openclaw/bridge`, `opengist/ssh` — are the defining interfaces of their apps (a mail catcher you cannot point SMTP at is not doing its job), so a `catalog:` commit here marks them `exposed: true`, preserving the published behavior of the tested tier, consistent with the `prebuilt-image.yaml` example decision. All four were in the "moving host port on every recreate" group, so this is also their upgrade from unreliable to stable — and they become the first catalog users of multi-endpoint publication, so the new machinery lands exercised.

The remaining **20 endpoints are all in `drafts/`**; 10 of those are internal components behind a gateway that were leaking onto the host, and for them losing publication is the fix. The per-app pass deciding each of those calls (with upstream READMEs read) is filed as #274; this PR does not pre-decide them.

## What this does NOT include

The `providers/macos-dev` `schedule` warning from the original report ships as its own PR — it is an independent change in a sibling package.

## Rebase note (2026-08-25)

The branch is rebased onto current `main`, across the D-49/D-52 provider train (#217, #218, #220 all touch the same files). Two consequences:

- The three `spec:` commits that added and then reverted a PROVIDERS.md §10 bullet netted to zero and were dropped in the rebase — the "Not in this PR" section below still holds: no spec-text changes beyond the example line.
- One new commit adapts two upstream test files to this branch's contract: the D-52 tests' port-allocator mock factories gain the `publishedEndpoints` export their code under test now pulls, and the D-35 `computeAppProperties` fixture marks its endpoint `exposed: true` (the adjacent "headless" test pins the degrade-to-empty behavior for unmarked endpoints).

## Verification

All counts below are at the rebased HEAD, 2026-08-25.

- `providers/docker`: `bun run test` — 225 pass / 0 fail (17 files, includes the 12 requires.config tests merged in #268 — this branch rebased cleanly over that merge); `bun run typecheck` clean.
- `providers/macos-dev` (its `$app.*` derivation changes here): 189 pass / 0 fail; typecheck clean.
- `sdk` (validates every `spec/examples/*.yaml`): 364 pass / 0 fail; typecheck clean. `providers/aws`: 55 pass / 0 fail; typecheck clean. `packages/launchfile`: 53 pass / 0 fail; typecheck clean. Catalog unit suite: 26 pass / 0 fail.
- **The example fix verified through the real generator**, not only the schema: `spec/examples/prebuilt-image.yaml` at HEAD produces `ports = {"default":3000}` and a `ports:` key in the compose file; with the `exposed: true` line removed it produces `ports = {}`, no `ports:` key, and the new warning.
- **Live docker smoke** on a real multi-endpoint stack (nginx, two `exposed: true` endpoints, one unmarked endpoint, one `protocol: udp` endpoint), re-run at the rebased HEAD through the real CLI (`launchfile up/down --docker`):
  - Both exposed endpoints got explicit host mappings (`0.0.0.0:16681->80/tcp`, `0.0.0.0:16712->443/tcp`) and the http endpoint served over its mapping (`curl` → 200).
  - The unmarked endpoint (container `8080`) got **no** host mapping — only the three published entries appear.
  - The UDP endpoint was emitted and published as `0.0.0.0:51820->51820/udp`.
  - Two full `down` → `up` recreate cycles produced **byte-identical** mappings and an identical persisted ports map (`{"web":16681,"web:https":16712,"web:vpn":51820}`), including the composite secondary keys, with full `state.endpoints` metadata.
  - Teardown left the host's pre-existing containers untouched and zero smoke containers behind.
- New tests cover: the allocator saved-state round trip, D-6 key derivation, D-27 filter behavior at allocator and generator, UDP emission, per-endpoint bind, same-port collision handling, duplicate-mapping suppression, allocator→generator→`result.ports` key round trip, composite-key summary filtering, protocol-correct address rendering, the publish-nothing warning (that it fires and names only the offending component, and that it stays quiet when something is published), and the tcp/udp twin shape (shared host port fresh and from saved state, plus UDP-socket probing of udp candidates).
- Catalog impact measured by parsing all 113 Launchfiles with the SDK (numbers in #273).

## Changeset

`@launchfile/docker` minor and `@launchfile/macos-dev` minor — behavior changes in published pre-1.0 packages.

## Not in this PR

An earlier revision added a publication bullet to `spec/PROVIDERS.md` §10; it is reverted here. A provider conformance rule deserves its own governance loop with a real `D-*` entry — this PR makes **no** spec-text changes beyond the `prebuilt-image.yaml` example line above.
