### PR TITLE
sdk: validate warns when a storage entry carries keys the schema does not recognize

### DIFF
--- a/sdk/src/__tests__/cli.test.ts
+++ b/sdk/src/__tests__/cli.test.ts
@@ -225,6 +225,64 @@ describe("launchfile CLI", () => {
 				expect(result.warnings.join(" ")).toContain("D-40");
 			});
 		});
+
+		describe("unrecognized storage keys (#239)", () => {
+			it("warns but stays non-fatal for a component storage entry: exit 0, valid: true", () => {
+				const { stdout, exitCode } = run([
+					"validate",
+					fixture(
+						"version: launch/v1\nname: acme\ncomponents:\n  caddy:\n    image: caddy:2\n" +
+							"    storage:\n      caddyfile:\n        path: /etc/caddy\n" +
+							"        source: ./caddy\n        readonly: true\n",
+					),
+					"--json",
+				]);
+				expect(exitCode).toBe(0);
+				const result = JSON.parse(stdout);
+				expect(result.valid).toBe(true);
+				expect(result.warnings).toContain(
+					'storage "caddy.caddyfile": unrecognized keys "source", "readonly" ' +
+						"(known: path, size, persistent) — unknown keys are ignored and " +
+						"will not affect deployment",
+				);
+			});
+
+			it("warns for the top-level single-component storage spelling", () => {
+				const { stdout, exitCode } = run([
+					"validate",
+					fixture(
+						"version: launch/v1\nname: acme\nimage: app:1\n" +
+							"storage:\n  data:\n    path: /data\n    mode: \"0700\"\n",
+					),
+					"--json",
+				]);
+				expect(exitCode).toBe(0);
+				const result = JSON.parse(stdout);
+				expect(result.valid).toBe(true);
+				expect(result.warnings.join(" ")).toContain('storage "data"');
+				expect(result.warnings.join(" ")).toContain('"mode"');
+			});
+
+			it("stays silent for storage entries using only recognized keys", () => {
+				const { stdout, exitCode } = run(
+					[
+						"validate",
+						fixture(
+							"version: launch/v1\nname: acme\nimage: app:1\n" +
+								"storage:\n  data:\n    path: /data\n    size: 10Gi\n    persistent: true\n",
+						),
+						"--json",
+					],
+					// Silence the unrelated D-40 prebuilt-image diagnostic so an empty
+					// warnings list proves the storage check specifically stayed quiet.
+					{ LAUNCHFILE_NO_PORTABILITY_WARNINGS: "1" },
+				);
+				expect(exitCode).toBe(0);
+				const result = JSON.parse(stdout);
+				expect(result.valid).toBe(true);
+				expect(result.warnings ?? []).toEqual([]);
+			});
+		});
 	});
 
 	describe("inspect", () => {

--- a/sdk/src/__tests__/lint.test.ts
+++ b/sdk/src/__tests__/lint.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { lintDeprecations, lintLaunch } from "../lint.js";
-import { readLaunch } from "../reader.js";
+import { lintDeprecations, lintLaunch, lintUnknownStorageKeys } from "../lint.js";
+import { parseLaunchYaml, readLaunch } from "../reader.js";
 
 describe("lintLaunch — conflicting same-name resources (Q1)", () => {
 	it("warns when the same name declares a divergent version", () => {
@@ -523,5 +523,95 @@ requires:
 		for (const w of warnings) {
 			expect(w.toLowerCase()).not.toContain("deprecat");
 		}
+	});
+});
+
+describe("lintUnknownStorageKeys — unrecognized keys in storage entries (#239)", () => {
+	it("warns per offending entry, naming the entry, its keys, and the known set", () => {
+		const raw = parseLaunchYaml(`
+name: acme
+components:
+  caddy:
+    image: caddy:2
+    storage:
+      caddyfile:
+        path: /etc/caddy
+        source: ./caddy
+        readonly: true
+      data:
+        path: /data
+        persistent: true
+`);
+		const warnings = lintUnknownStorageKeys(raw);
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toBe(
+			'storage "caddy.caddyfile": unrecognized keys "source", "readonly" ' +
+				"(known: path, size, persistent) — unknown keys are ignored and " +
+				"will not affect deployment",
+		);
+	});
+
+	it("covers the top-level single-component storage spelling", () => {
+		const raw = parseLaunchYaml(`
+name: acme
+image: app:1
+storage:
+  data:
+    path: /data
+    mode: "0700"
+`);
+		const warnings = lintUnknownStorageKeys(raw);
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain('storage "data"');
+		expect(warnings[0]).toContain('"mode"');
+		expect(warnings[0]).toContain("known: path, size, persistent");
+	});
+
+	it("emits one warning per offending entry across components", () => {
+		const raw = parseLaunchYaml(`
+name: acme
+components:
+  api:
+    image: api:1
+    storage:
+      uploads:
+        path: /uploads
+        readonly: true
+  worker:
+    image: worker:1
+    storage:
+      cache:
+        path: /cache
+        source: ./cache
+`);
+		const warnings = lintUnknownStorageKeys(raw);
+		expect(warnings).toHaveLength(2);
+		expect(warnings.join(" ")).toContain('storage "api.uploads"');
+		expect(warnings.join(" ")).toContain('storage "worker.cache"');
+	});
+
+	it("stays silent for entries that only use recognized keys", () => {
+		const raw = parseLaunchYaml(`
+name: acme
+components:
+  api:
+    image: api:1
+    storage:
+      data:
+        path: /data
+        size: 10Gi
+        persistent: true
+`);
+		expect(lintUnknownStorageKeys(raw)).toEqual([]);
+	});
+
+	it("stays silent for files with no storage at all", () => {
+		expect(lintUnknownStorageKeys(parseLaunchYaml("name: acme\nimage: app:1\n"))).toEqual([]);
+	});
+
+	it("tolerates non-object documents and malformed storage shapes", () => {
+		expect(lintUnknownStorageKeys(null)).toEqual([]);
+		expect(lintUnknownStorageKeys("just a string")).toEqual([]);
+		expect(lintUnknownStorageKeys(parseLaunchYaml("name: acme\nstorage: not-a-map\n"))).toEqual([]);
 	});
 });

--- a/sdk/src/commands.ts
+++ b/sdk/src/commands.ts
@@ -9,8 +9,8 @@ import { readFileSync } from "node:fs";
 import { resolve, dirname, join } from "node:path";
 import { lintDeprecations } from "./deprecations.js";
 import type { Deprecation } from "./deprecations.js";
-import { lintLaunch } from "./lint.js";
-import { readLaunch } from "./reader.js";
+import { lintLaunch, lintUnknownStorageKeys } from "./lint.js";
+import { parseLaunchYaml, readLaunch, validateLaunch } from "./reader.js";
 import type { NormalizedLaunch } from "./types.js";
 
 // --- Color helpers ---
@@ -168,14 +168,21 @@ export function cmdValidate(path: string, opts: ValidateOpts = {}): ValidateResu
 	const yaml = readFile(resolvedPath, fmt);
 
 	try {
-		const launch = readLaunch(yaml);
+		// Parse once, feed both paths: schema validation strips unrecognized
+		// keys, so the unknown-storage-key lint can only see them on the raw
+		// document — never on the normalized result.
+		const raw = parseLaunchYaml(yaml);
+		const launch = validateLaunch(raw);
 		const componentNames = Object.keys(launch.components);
 		const allRequires = collectRequires(launch);
 		const hostCapabilities = collectHostCapabilities(launch);
-		const warnings = lintLaunch(launch, {
-			detached: opts.detached,
-			suppressPortabilityWarnings: envFlag("LAUNCHFILE_NO_PORTABILITY_WARNINGS"),
-		});
+		const warnings = [
+			...lintLaunch(launch, {
+				detached: opts.detached,
+				suppressPortabilityWarnings: envFlag("LAUNCHFILE_NO_PORTABILITY_WARNINGS"),
+			}),
+			...lintUnknownStorageKeys(raw),
+		];
 		const deprecations = lintDeprecations(launch);
 
 		const result: ValidateResult = {

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -17,8 +17,8 @@ export {
 	type UnsuppliedRequiredEnv,
 	unsuppliedRequiredEnv,
 } from "./env.js";
-export { lintLaunch } from "./lint.js";
-export { readLaunch, validateLaunch } from "./reader.js";
+export { lintLaunch, lintUnknownStorageKeys } from "./lint.js";
+export { parseLaunchYaml, readLaunch, validateLaunch } from "./reader.js";
 export { parseRepository } from "./repository.js";
 export type { RepositoryRef } from "./repository.js";
 export {

--- a/sdk/src/lint.ts
+++ b/sdk/src/lint.ts
@@ -11,6 +11,7 @@
 import { parseExpression } from "./resolver.js";
 import { RESOURCE_PROPERTY_VOCABULARY } from "./resource-properties.js";
 import { lintDurations } from "./durations.js";
+import { StorageVolumeSchema } from "./schema.js";
 import type { NormalizedLaunch, NormalizedRequirement } from "./types.js";
 
 export type { Deprecation, DeprecationRecord } from "./deprecations.js";
@@ -154,6 +155,59 @@ function checkResourceProperties(
 			}
 		}
 	}
+}
+
+/**
+ * Storage keys the schema recognizes, derived from the schema itself so a
+ * future ratified field can never produce a stale false warning.
+ */
+const KNOWN_STORAGE_KEYS = Object.keys(StorageVolumeSchema.shape);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Warn on unrecognized keys in storage entries (#239). Zod's default strip
+ * mode deletes unlisted keys at parse, so a `NormalizedLaunch` can never
+ * carry them — this check MUST take the raw YAML document (as returned by
+ * the reader's `parseLaunchYaml`), which is why it is a separate function rather
+ * than part of {@link lintLaunch}. Warn-only per D-46's unknown-vocabulary
+ * posture: parse still succeeds, `valid` and the exit code are untouched.
+ * Covers both spellings — `components.<name>.storage` and the top-level
+ * single-component `storage` block.
+ */
+export function lintUnknownStorageKeys(raw: unknown): string[] {
+	const warnings: string[] = [];
+	if (!isPlainObject(raw)) return warnings;
+
+	const checkBlock = (storage: unknown, prefix: string): void => {
+		if (!isPlainObject(storage)) return;
+		for (const [entryName, entry] of Object.entries(storage)) {
+			if (!isPlainObject(entry)) continue;
+			const unrecognized = Object.keys(entry).filter(
+				(key) => !KNOWN_STORAGE_KEYS.includes(key),
+			);
+			if (unrecognized.length === 0) continue;
+			warnings.push(
+				`storage "${prefix}${entryName}": unrecognized keys ` +
+					`${unrecognized.map((key) => `"${key}"`).join(", ")} ` +
+					`(known: ${KNOWN_STORAGE_KEYS.join(", ")}) — unknown keys are ` +
+					"ignored and will not affect deployment",
+			);
+		}
+	};
+
+	checkBlock(raw.storage, "");
+	if (isPlainObject(raw.components)) {
+		for (const [componentName, component] of Object.entries(raw.components)) {
+			if (isPlainObject(component)) {
+				checkBlock(component.storage, `${componentName}.`);
+			}
+		}
+	}
+
+	return warnings;
 }
 
 /**

--- a/sdk/src/reader.ts
+++ b/sdk/src/reader.ts
@@ -38,12 +38,24 @@ import type {
 const MAX_YAML_SIZE = 1_048_576; // 1 MB
 const MAX_ALIAS_COUNT = 100;
 
-/** Parse and validate a YAML string into a normalized Launch object */
-export function readLaunch(yaml: string): NormalizedLaunch {
+/**
+ * Parse a YAML string into a raw document with the size and alias caps
+ * applied. Exposed separately from {@link readLaunch} because schema
+ * validation strips unrecognized keys — a caller that needs to inspect
+ * what the author actually wrote (e.g. `validate`'s unknown-storage-key
+ * lint) must read the raw document, and this keeps that read behind the
+ * same security caps as the validated path.
+ */
+export function parseLaunchYaml(yaml: string): unknown {
 	if (yaml.length > MAX_YAML_SIZE) {
 		throw new Error(`Launchfile exceeds maximum size of ${MAX_YAML_SIZE} bytes`);
 	}
-	const raw = parse(yaml, { maxAliasCount: MAX_ALIAS_COUNT });
+	return parse(yaml, { maxAliasCount: MAX_ALIAS_COUNT });
+}
+
+/** Parse and validate a YAML string into a normalized Launch object */
+export function readLaunch(yaml: string): NormalizedLaunch {
+	const raw = parseLaunchYaml(yaml);
 	const validated = LaunchSchema.parse(raw) as Launch;
 	return normalizeLaunch(validated);
 }


### PR DESCRIPTION
Closes #239.

Implements the steward verdict's required fix shape, item for item:

1. **Warn, never error** — the diagnostic joins the existing `warnings: string[]` in `ValidateResult`; `valid`, exit code, and parsed output are untouched.
2. **Raw-doc check, forced placement** — the keys are deleted by zod's strip before any existing lint runs, so the check walks the raw YAML object. `parseLaunchYaml` is extracted from `readLaunch` (same 1MB/alias caps) so `cmdValidate` parses once and feeds both paths; the lint then reuses the already-public `validateLaunch` on the parsed side.
3. **Both spellings covered** — `components.<name>.storage` and top-level single-component `storage`.
4. **Generic message** — names the entry, the offending keys, the known set, and the consequence; never names any specific unratified field:

   ```
   storage "caddy.caddyfile": unrecognized keys "source", "readonly" (known: path, size, persistent) — unknown keys are ignored and will not affect deployment
   ```

5. **Known set derived from `StorageVolumeSchema.shape`** — a future ratified field cannot produce a stale false warning.
6. **Tests** — 6 unit tests (exact message, both spellings, one warning per offending entry, clean/absent storage silent, malformed shapes tolerated) + 3 CLI tests through the built `dist/cli.js` (`valid: true`, exit 0, `--json` carries the warning).
7. **Scope fences respected** — no `source`/`readonly` in zod or the JSON Schema (#211's question), no key preservation through parse → serialize (#171's question), no SPEC.md change, no new D-*.

Verified live: `validate` on a fixture carrying `source:`/`readonly:` prints the warning to stderr with `✓ valid` and exit 0; `--json` carries it in `warnings`.

Full sdk suite: 373/373. Typecheck clean.
