### PR TITLE
cli/providers/catalog: implement the D-50 --storage channel and bind/refuse contract

### DIFF
--- a/catalog/test/src/launch-to-compose.test.ts
+++ b/catalog/test/src/launch-to-compose.test.ts
@@ -12,8 +12,9 @@
  * run this manually: `cd catalog/test && bun install && bun run test`.
  */
 
-import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
 import { parse } from "yaml";
@@ -432,5 +433,108 @@ env:
       for (const v of unsuppliedRequired) failures.push(`${app} [${v.component}]: ${v.key}`);
     }
     expect(failures).toEqual([]);
+  });
+});
+
+describe("content: operator volumes (D-50)", () => {
+  const MARKED = `
+name: media
+image: navidrome:latest
+storage:
+  music:
+    path: /music
+    content: operator
+    persistent: true
+  data:
+    path: /data
+`;
+
+  it("binds a supplied, existing path instead of an anonymous volume (row 1)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "lf-harness-content-"));
+    try {
+      const result = launchToCompose(readLaunch(MARKED), { storagePaths: { music: dir } });
+      expect(result.storageRefusals).toEqual([]);
+      expect(result.yaml).toContain(`${dir}:/music`);
+      // The unmarked volume keeps its anonymous-volume form.
+      expect(result.yaml).toContain("- /data");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses an unbound marked volume — no mount, no empty volume (row 2)", () => {
+    const result = launchToCompose(readLaunch(MARKED));
+    expect(result.storageRefusals).toHaveLength(1);
+    expect(result.storageRefusals[0]).toMatchObject({ component: "default", volume: "music" });
+    expect(result.yaml).not.toContain("/music");
+  });
+
+  it("refuses a supplied path that does not exist — never creates it (row 3)", () => {
+    const missing = join(tmpdir(), `lf-harness-missing-${Date.now()}`);
+    const result = launchToCompose(readLaunch(MARKED), { storagePaths: { music: missing } });
+    expect(result.storageRefusals).toHaveLength(1);
+    expect(result.storageRefusals[0]!.message).toContain("does not exist or is not readable");
+    expect(existsSync(missing)).toBe(false);
+    expect(result.yaml).not.toContain(missing);
+  });
+
+  it("leaves an unmarked launch byte-identical whether or not storagePaths is passed (row 4)", () => {
+    const yaml = `
+name: plain
+image: nginx
+storage:
+  data:
+    path: /data
+`;
+    const without = launchToCompose(readLaunch(yaml));
+    const withMap = launchToCompose(readLaunch(yaml), { storagePaths: { data: "/srv/data" } });
+    expect(withMap.yaml).toBe(without.yaml);
+    expect(withMap.warnings.join("\n")).toContain("matches no `content: operator` volume");
+  });
+
+  it("routes component.volume keys by the first dot; an unknown left half stays a volume name", () => {
+    const dirA = mkdtempSync(join(tmpdir(), "lf-harness-a-"));
+    const dirB = mkdtempSync(join(tmpdir(), "lf-harness-b-"));
+    try {
+      const launch = readLaunch(`
+name: shelf
+components:
+  web:
+    image: shelf:latest
+    storage:
+      library:
+        path: /library
+        content: operator
+  sync:
+    image: syncer:latest
+    storage:
+      drop.box:
+        path: /drop
+        content: operator
+`);
+      const result = launchToCompose(launch, {
+        storagePaths: { "web.library": dirA, "drop.box": dirB },
+      });
+      expect(result.storageRefusals).toEqual([]);
+      expect(result.yaml).toContain(`${dirA}:/library`);
+      expect(result.yaml).toContain(`${dirB}:/drop`);
+    } finally {
+      rmSync(dirA, { recursive: true, force: true });
+      rmSync(dirB, { recursive: true, force: true });
+    }
+  });
+
+  it("no shipped catalog app is refused: none carries the marker yet (adoption gate)", () => {
+    // D-50 Conformance at adoption: the marker lands in the catalog only
+    // after every surface (this harness included) implements the channel.
+    const appsDir = fileURLToPath(new URL("../../apps", import.meta.url));
+    const refused: string[] = [];
+    for (const app of readdirSync(appsDir)) {
+      const file = resolve(appsDir, app, "Launchfile");
+      if (!existsSync(file)) continue;
+      const { storageRefusals } = launchToCompose(readLaunch(readFileSync(file, "utf-8")));
+      for (const r of storageRefusals) refused.push(`${app} [${r.component}]: ${r.volume}`);
+    }
+    expect(refused).toEqual([]);
   });
 });

--- a/catalog/test/src/launch-to-compose.ts
+++ b/catalog/test/src/launch-to-compose.ts
@@ -5,6 +5,7 @@
  * Generates a compose file that can spin up an app with its backing services.
  */
 
+import { accessSync, constants as fsConstants } from "node:fs";
 import { stringify } from "yaml";
 import {
   resolveExpression,
@@ -232,6 +233,16 @@ export interface ComposeResult {
    * `health_check_passed: true` certify apps the shipped provider refuses.
    */
   unsuppliedRequired: { component: string; key: string; sensitive: boolean }[];
+  /**
+   * `content: operator` volumes this compose cannot honestly satisfy (D-50):
+   * no host path supplied, or the supplied path is absent/unreadable — the
+   * directory is never created. Their mounts are ABSENT from the emitted
+   * compose, never an empty volume. The runner turns a non-empty list into a
+   * hard failure naming the app and the volume, exactly as it does for
+   * `unsuppliedRequired` — a silent pass here would let catalog adoption of
+   * the marker flip `health_check_passed` without anyone deciding it.
+   */
+  storageRefusals: { component: string; volume: string; message: string }[];
 }
 
 export interface ComposeOpts {
@@ -244,14 +255,42 @@ export interface ComposeOpts {
    * than a guess.
    */
   testEnv?: Record<string, string>;
+  /**
+   * Host paths for `content: operator` volumes (D-50), keyed by volume name
+   * or `component.volume` — the same map the Docker provider's
+   * `ComposeOpts.storagePaths` takes, with the same first-dot key rule: a
+   * left half naming a component qualifies the key to that component;
+   * anything else is a bare volume name, dots included. Values must be
+   * absolute host paths that exist and are readable — an absent path is
+   * refused, never created.
+   */
+  storagePaths?: Record<string, string>;
 }
 
 export function launchToCompose(launch: NormalizedLaunch, opts: ComposeOpts = {}): ComposeResult {
   const warnings: string[] = [];
   const images: string[] = [];
   const unsuppliedRequired: ComposeResult["unsuppliedRequired"] = [];
+  const storageRefusals: ComposeResult["storageRefusals"] = [];
   const services: Record<string, Record<string, unknown>> = {};
   const volumes: Record<string, Record<string, unknown>> = {};
+
+  // D-50 storage-path keys, classified once against the component set — the
+  // same first-dot rule as the Docker provider's compose-generator: a key
+  // whose left half names a component is component-qualified; anything else
+  // is a bare volume name, dots included.
+  const componentSet = new Set(Object.keys(launch.components));
+  const qualifiedPaths = new Map<string, { path: string; key: string }>();
+  const barePaths = new Map<string, { path: string; key: string }>();
+  for (const [key, path] of Object.entries(opts.storagePaths ?? {})) {
+    const dot = key.indexOf(".");
+    if (dot > 0 && componentSet.has(key.slice(0, dot))) {
+      qualifiedPaths.set(key, { path, key });
+    } else {
+      barePaths.set(key, { path, key });
+    }
+  }
+  const usedStorageKeys = new Set<string>();
 
   // Pre-generate app-wide secrets
   const secretValues: Record<string, string> = {};
@@ -487,10 +526,46 @@ export function launchToCompose(launch: NormalizedLaunch, opts: ComposeOpts = {}
     }
 
     // Storage volumes — use anonymous volumes to preserve image filesystem ownership
-    // (named volumes mount as root, which breaks non-root containers)
+    // (named volumes mount as root, which breaks non-root containers). A
+    // `content: operator` volume (D-50) is instead bound to the supplied host
+    // path, mirroring the Docker provider's four states: path supplied →
+    // bind; no path → refused; path absent/unreadable → refused, never
+    // created; no marker → unchanged. A refused volume gets NO mount — an
+    // empty volume standing in for the operator's content is exactly the
+    // fabrication whose health pass this harness must not certify.
     if (component.storage) {
       const svcVolumes: string[] = [];
-      for (const [, vol] of Object.entries(component.storage)) {
+      for (const [volName, vol] of Object.entries(component.storage)) {
+        if (vol.content === "operator") {
+          const bound =
+            qualifiedPaths.get(`${componentName}.${volName}`) ?? barePaths.get(volName);
+          if (!bound) {
+            storageRefusals.push({
+              component: componentName,
+              volume: volName,
+              message: `no host path supplied for this \`content: operator\` volume — pass storagePaths ({ "${volName}": "<path>" })`,
+            });
+            continue;
+          }
+          usedStorageKeys.add(bound.key);
+          let readable = false;
+          try {
+            accessSync(bound.path, fsConstants.R_OK);
+            readable = true;
+          } catch {
+            // fall through to the refusal below
+          }
+          if (!readable) {
+            storageRefusals.push({
+              component: componentName,
+              volume: volName,
+              message: `supplied path "${bound.path}" does not exist or is not readable — refusing to create it (D-50)`,
+            });
+            continue;
+          }
+          svcVolumes.push(`${bound.path}:${vol.path}`);
+          continue;
+        }
         svcVolumes.push(vol.path);
       }
       if (svcVolumes.length > 0) {
@@ -526,6 +601,16 @@ export function launchToCompose(launch: NormalizedLaunch, opts: ComposeOpts = {}
     }
   }
 
+  // A storage-path key that bound nothing surfaces as a warning — only
+  // `content: operator` volumes are bindable, and a typo'd name should not
+  // vanish silently (the unbound marked volume it left behind is refused
+  // separately, so this alone never masks a refusal).
+  for (const key of Object.keys(opts.storagePaths ?? {})) {
+    if (!usedStorageKeys.has(key)) {
+      warnings.push(`storagePaths key "${key}" matches no \`content: operator\` volume — ignored`);
+    }
+  }
+
   const compose: Record<string, unknown> = { services };
   if (Object.keys(volumes).length > 0) {
     compose.volumes = volumes;
@@ -536,6 +621,7 @@ export function launchToCompose(launch: NormalizedLaunch, opts: ComposeOpts = {}
     warnings,
     images: [...new Set(images)],
     unsuppliedRequired,
+    storageRefusals,
   };
 }
 

--- a/catalog/test/src/portability-lint-counts.test.ts
+++ b/catalog/test/src/portability-lint-counts.test.ts
@@ -32,10 +32,10 @@ describe("D-40/D-43 catalog counts (issue #155 verdict, T6)", () => {
 		expect(counts.d43WarningsDetached).toBe(0);
 	});
 
-	it("spec/examples/: D-40 fires on 4/12 files (prebuilt-image, storage-paths, host-container-runtime, post-start-capture)", () => {
+	it("spec/examples/: D-40 fires on 5/13 files (prebuilt-image, storage-paths, host-container-runtime, post-start-capture, operator-content)", () => {
 		const counts = countCorpus(specExamplesPaths(specExamplesRoot));
-		expect(counts.files).toBe(12);
-		expect(counts.d40Files).toBe(4);
+		expect(counts.files).toBe(13);
+		expect(counts.d40Files).toBe(5);
 	});
 
 	it("spec/examples/: D-43 stays silent attached (every file is an in-tree read)", () => {

--- a/catalog/test/src/test-app.ts
+++ b/catalog/test/src/test-app.ts
@@ -98,6 +98,19 @@ if (result.unsuppliedRequired.length > 0) {
   process.exit(1);
 }
 
+// A `content: operator` volume the translator could not bind is the same
+// class of hard failure (D-50): starting the app over an empty volume where
+// the operator's content belongs would record `health_check_passed: true`
+// for a configuration the shipped Docker provider refuses to deploy. Fails
+// before any pull, container, or volume exists.
+if (result.storageRefusals.length > 0) {
+  console.error(`\n=== ${appName}: FAIL — operator-supplied storage not bound (D-50) ===`);
+  for (const { component, volume, message } of result.storageRefusals) {
+    console.error(`  - ${appName} [${component}]: ${volume} — ${message}`);
+  }
+  process.exit(1);
+}
+
 if (result.warnings.length > 0) {
   console.log(`\nWarnings:`);
   for (const w of result.warnings) {

--- a/packages/launchfile/src/__tests__/cli-args.test.ts
+++ b/packages/launchfile/src/__tests__/cli-args.test.ts
@@ -7,7 +7,14 @@
 import { execFileSync } from "node:child_process";
 import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
-import { flagPresent, getFlagValue, getPositional, hasFlag } from "../cli-args.js";
+import {
+	flagPresent,
+	getFlagValue,
+	getFlagValues,
+	getPositional,
+	hasFlag,
+	parseStoragePairs,
+} from "../cli-args.js";
 
 describe("getPositional (#248)", () => {
 	it("skips the value of a value-taking flag", () => {
@@ -37,6 +44,53 @@ describe("getPositional (#248)", () => {
 	it("does not skip the token after a boolean flag", () => {
 		const args = ["up", "--dry-run", "ghost"];
 		expect(getPositional(args, 1)).toBe("ghost");
+	});
+
+	it("skips --storage values so a pair is never the up target (D-50)", () => {
+		const args = ["up", "--storage", "music=/srv/music", "--storage", "books=/srv/books"];
+		expect(getPositional(args, 0)).toBe("up");
+		expect(getPositional(args, 1)).toBeUndefined();
+		expect(getPositional(["up", "--storage", "music=/x", "ghost"], 1)).toBe("ghost");
+	});
+});
+
+describe("getFlagValues (repeatable --storage, D-50)", () => {
+	it("collects every occurrence, in order", () => {
+		const args = ["up", "--storage", "music=/a", "--storage", "books=/b"];
+		expect(getFlagValues(args, "storage")).toEqual(["music=/a", "books=/b"]);
+	});
+
+	it("reads the inline --flag=value form too, mixed with the separate form", () => {
+		const args = ["up", "--storage=music=/a", "--storage", "books=/b"];
+		expect(getFlagValues(args, "storage")).toEqual(["music=/a", "books=/b"]);
+	});
+
+	it("returns an empty list when the flag is absent", () => {
+		expect(getFlagValues(["up"], "storage")).toEqual([]);
+	});
+});
+
+describe("parseStoragePairs (D-50)", () => {
+	it("splits each pair on the first = only", () => {
+		expect(parseStoragePairs(["music=/srv/music", "web.books=/x=y"])).toEqual({
+			music: "/srv/music",
+			"web.books": "/x=y",
+		});
+	});
+
+	it("rejects a pair with no =", () => {
+		expect(() => parseStoragePairs(["music"])).toThrow('Invalid --storage value "music"');
+	});
+
+	it("rejects an empty volume name or an empty path", () => {
+		expect(() => parseStoragePairs(["=/srv/music"])).toThrow("Invalid --storage value");
+		expect(() => parseStoragePairs(["music="])).toThrow("Invalid --storage value");
+	});
+
+	it("rejects a duplicate key instead of silently picking one", () => {
+		expect(() => parseStoragePairs(["music=/a", "music=/b"])).toThrow(
+			'Duplicate --storage key "music"',
+		);
 	});
 });
 

--- a/packages/launchfile/src/__tests__/up-storage.test.ts
+++ b/packages/launchfile/src/__tests__/up-storage.test.ts
@@ -1,0 +1,109 @@
+/**
+ * The D-50 `--storage` channel at the command layer (#281): the parsed
+ * volume-to-path map reaches the docker provider as typed, and the macOS
+ * provider refuses the flag instead of silently dropping the operator's
+ * paths and provisioning provider-owned storage where their content belongs.
+ *
+ * Directories are injected temp paths — nothing touches the real
+ * ~/.launchfile and nothing talks to docker.
+ */
+
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { DockerUpOpts, DockerUpResult } from "@launchfile/docker";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { handleUp } from "../commands/up.js";
+
+let indexDir: string;
+let recordDir: string;
+let projectDir: string;
+
+let output: string[];
+let restore: (() => void) | null = null;
+
+beforeEach(async () => {
+	indexDir = await mkdtemp(join(tmpdir(), "lf-storage-index-"));
+	recordDir = await mkdtemp(join(tmpdir(), "lf-storage-records-"));
+	projectDir = await mkdtemp(join(tmpdir(), "lf-storage-project-"));
+	await writeFile(join(projectDir, "Launchfile"), "name: stor\n");
+
+	output = [];
+	const log = console.log;
+	const err = console.error;
+	console.log = (...args: unknown[]) => output.push(args.join(" "));
+	console.error = (...args: unknown[]) => output.push(args.join(" "));
+	restore = () => {
+		console.log = log;
+		console.error = err;
+	};
+});
+
+afterEach(() => {
+	restore?.();
+	restore = null;
+});
+
+function fakeUp(calls: DockerUpOpts[]) {
+	return async (_source: string, opts: DockerUpOpts): Promise<DockerUpResult> => {
+		calls.push(opts);
+		return { slug: "stor", appName: "stor", sourceType: "local" };
+	};
+}
+
+describe("up --storage reaches the docker provider (D-50)", () => {
+	it("threads the volume-to-path map into the provider opts, keys as typed", async () => {
+		const calls: DockerUpOpts[] = [];
+		await handleUp(
+			projectDir,
+			{ storage: { music: "/srv/music", "web.books": "/srv/books" } },
+			{ up: fakeUp(calls), indexDir, recordDir },
+		);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]!.storage).toEqual({ music: "/srv/music", "web.books": "/srv/books" });
+	});
+
+	it("passes no map when --storage is absent", async () => {
+		const calls: DockerUpOpts[] = [];
+		await handleUp(projectDir, {}, { up: fakeUp(calls), indexDir, recordDir });
+		expect(calls[0]!.storage).toBeUndefined();
+	});
+});
+
+describe("the macOS provider refuses --storage (D-50 silent-drop ban)", () => {
+	it("errors clearly before anything launches", async () => {
+		const exit = process.exit;
+		let exited: number | undefined;
+		let launched = false;
+		process.exit = (code?: number) => {
+			exited = code;
+			throw new Error("exited");
+		};
+		try {
+			await expect(
+				handleUp(
+					projectDir,
+					{ native: true, storage: { music: "/srv/music" } },
+					{
+						importMacos: async () =>
+							({
+								launchUp: async () => {
+									launched = true;
+								},
+							}) as unknown as typeof import("@launchfile/macos-dev"),
+						indexDir,
+						recordDir,
+					},
+				),
+			).rejects.toThrow("exited");
+		} finally {
+			process.exit = exit;
+		}
+
+		expect(exited).toBe(1);
+		expect(launched).toBe(false);
+		expect(output.join("\n")).toContain(
+			"--storage is not yet supported by the macOS native provider",
+		);
+	});
+});

--- a/packages/launchfile/src/cli-args.ts
+++ b/packages/launchfile/src/cli-args.ts
@@ -13,6 +13,7 @@ export const VALUE_FLAGS: ReadonlySet<string> = new Set([
 	"name",
 	"component",
 	"schema-path",
+	"storage",
 ]);
 
 export function hasFlag(args: readonly string[], flag: string): boolean {
@@ -33,6 +34,54 @@ export function getFlagValue(args: readonly string[], flag: string): string | un
 		if (arg.startsWith(inlinePrefix)) return arg.slice(inlinePrefix.length);
 	}
 	return undefined;
+}
+
+/**
+ * Every value of a repeatable flag, in order — `--flag <value>` and
+ * `--flag=<value>` forms both count. `--storage` (D-50) repeats once per
+ * operator-supplied volume.
+ */
+export function getFlagValues(args: readonly string[], flag: string): string[] {
+	const inlinePrefix = `--${flag}=`;
+	const values: string[] = [];
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i]!;
+		if (arg === `--${flag}`) {
+			if (args[i + 1] !== undefined) values.push(args[i + 1]!);
+		} else if (arg.startsWith(inlinePrefix)) {
+			values.push(arg.slice(inlinePrefix.length));
+		}
+	}
+	return values;
+}
+
+/**
+ * Parse repeated `--storage <key>=<path>` values (D-50) into a key-to-path
+ * map. The key half — a volume name, or `component.volume` — passes through
+ * as typed: the first-dot split needs the parsed Launchfile's component
+ * names, so it happens in the provider. A malformed pair or a duplicate key
+ * is rejected with the offending value, never guessed at.
+ */
+export function parseStoragePairs(values: readonly string[]): Record<string, string> {
+	const pairs: Record<string, string> = {};
+	for (const value of values) {
+		const eq = value.indexOf("=");
+		const key = eq === -1 ? "" : value.slice(0, eq);
+		const path = eq === -1 ? "" : value.slice(eq + 1);
+		if (!key || !path) {
+			throw new Error(
+				`Invalid --storage value "${value}". Expected --storage <volume>=<host-path>, ` +
+					"or --storage <component>.<volume>=<host-path> where the volume name is ambiguous.",
+			);
+		}
+		if (pairs[key] !== undefined) {
+			throw new Error(
+				`Duplicate --storage key "${key}". Each volume takes one path; repeat the flag for different volumes.`,
+			);
+		}
+		pairs[key] = path;
+	}
+	return pairs;
 }
 
 /**

--- a/packages/launchfile/src/cli.ts
+++ b/packages/launchfile/src/cli.ts
@@ -28,8 +28,10 @@ import { cmdValidate, cmdInspect, cmdSchema } from "@launchfile/sdk";
 import {
 	hasFlag as argsHasFlag,
 	getFlagValue as argsGetFlagValue,
+	getFlagValues as argsGetFlagValues,
 	getPositional as argsGetPositional,
 	flagPresent as argsFlagPresent,
+	parseStoragePairs,
 } from "./cli-args.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -58,6 +60,12 @@ function getNameFlag(): string | undefined {
 	}
 	return value;
 }
+
+/** The D-50 `--storage` volume-to-path map, or undefined when the flag is absent. */
+const storageFlag = (): Record<string, string> | undefined => {
+	const values = argsGetFlagValues(args, "storage");
+	return values.length > 0 ? parseStoragePairs(values) : undefined;
+};
 
 const command = getPositional(0);
 const target = getPositional(1);
@@ -90,6 +98,11 @@ Options:
   --follow, -f     Stream logs continuously
   --name <label>   Launch a separate named instance of the app — its own
                     state, volumes, network, and ports (Docker provider)
+  --storage <volume>=<path>
+                   Host path for a volume marked \`content: operator\` — you
+                    supply its content; the provider binds it there instead of
+                    creating an empty volume. Repeat per volume; spell the key
+                    <component>.<volume> where the volume name is ambiguous
   --component <n>  Limit bootstrap to a single component
   --detached       (validate) Evaluate as fetched standalone, not read from the
                     app's own checkout — enables the D-43 reduced-portability check
@@ -129,6 +142,7 @@ async function main(): Promise<void> {
 				detach: hasFlag("detach"),
 				dryRun: hasFlag("dry-run"),
 				name: getNameFlag(),
+				storage: storageFlag(),
 			});
 			break;
 
@@ -141,6 +155,7 @@ async function main(): Promise<void> {
 				detach: hasFlag("detach"),
 				dryRun: hasFlag("dry-run"),
 				name: getNameFlag(),
+				storage: storageFlag(),
 			});
 			break;
 

--- a/packages/launchfile/src/commands/up.ts
+++ b/packages/launchfile/src/commands/up.ts
@@ -8,6 +8,8 @@ import {
 	dockerUp,
 	type DockerUpOpts,
 	type DockerUpResult,
+	MissingOperatorStoragePathError,
+	UnboundOperatorStorageError,
 	UnsuppliedRequiredEnvError,
 } from "@launchfile/docker";
 import { isLaunchError, type LaunchPhase } from "@launchfile/sdk";
@@ -33,6 +35,13 @@ export interface UpFlags {
 	detach?: boolean;
 	dryRun?: boolean;
 	name?: string;
+	/**
+	 * Host paths for `content: operator` volumes (D-50), keyed as typed on the
+	 * repeatable `--storage <volume>=<path>` / `--storage <component>.<volume>=<path>`
+	 * flag — the component/volume split happens in the provider, against the
+	 * parsed Launchfile.
+	 */
+	storage?: Record<string, string>;
 }
 
 /**
@@ -139,13 +148,19 @@ export async function handleUp(
 						detach: flags.detach,
 						dryRun: flags.dryRun,
 						name: flags.name,
+						storage: flags.storage,
 					}),
 				recordDir,
 			);
 		} catch (err) {
-			// An unsupplied `required:` variable (D-52) is an operator's problem to
-			// fix, not a bug — it gets the provider's own message, not a stack trace.
-			if (err instanceof UnsuppliedRequiredEnvError) {
+			// An unsupplied `required:` variable (D-52) or an unbound/absent
+			// operator storage path (D-50) is an operator's problem to fix, not a
+			// bug — it gets the provider's own message, not a stack trace.
+			if (
+				err instanceof UnsuppliedRequiredEnvError ||
+				err instanceof UnboundOperatorStorageError ||
+				err instanceof MissingOperatorStoragePathError
+			) {
 				console.error(`\n${err.message}`);
 				process.exit(1);
 			}
@@ -210,6 +225,16 @@ export async function handleUp(
 			console.error("--name is not yet supported by the macOS native provider.");
 			console.error(
 				"It runs one instance per project directory. Use a second checkout for a second instance, or the Docker provider (--docker) for named instances.",
+			);
+			process.exit(1);
+		}
+		// D-50's channel has no macOS implementation yet: refusing beats silently
+		// dropping the operator's paths and provisioning provider-owned storage
+		// where their content belongs — the silent-drop D-50 forbids.
+		if (flags.storage && Object.keys(flags.storage).length > 0) {
+			console.error("--storage is not yet supported by the macOS native provider.");
+			console.error(
+				"It provisions provider-owned storage only. Use the Docker provider (--docker) to bind operator-supplied content (D-50).",
 			);
 			process.exit(1);
 		}

--- a/providers/docker/src/__tests__/operator-storage.test.ts
+++ b/providers/docker/src/__tests__/operator-storage.test.ts
@@ -1,0 +1,289 @@
+/**
+ * The D-50 `content: operator` channel in the compose generator and in
+ * `dockerUp` (#281).
+ *
+ * Rule 2's four rows, in generator terms: a marked volume with a supplied path
+ * becomes a bind mount; with no path its mount is withheld and the volume
+ * recorded for the caller to refuse; a supplied-but-absent path is refused by
+ * `dockerUp` before anything exists; an unmarked volume is byte-identical to
+ * today. Key resolution splits on the first dot — a left half naming no
+ * component keeps the whole key as a volume name.
+ *
+ * The dockerUp tests redirect $HOME to a temp dir (node:os.homedir() honors it
+ * on POSIX) so the real ~/.launchfile is never touched; everything runs
+ * --dry-run, so no docker is needed past the prereq check.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readLaunch } from "@launchfile/sdk";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { launchToCompose } from "../compose-generator.js";
+import { checkPrereqs } from "../prereqs.js";
+import {
+	dockerUp,
+	MissingOperatorStoragePathError,
+	UnboundOperatorStorageError,
+} from "../provider.js";
+
+const prereqs = await checkPrereqs();
+
+// it.runIf is a vitest-only API; the bun test runner doesn't provide it.
+const itIfPrereqsOk = prereqs.ok ? it : it.skip;
+
+const MARKED = `
+name: media
+image: navidrome:latest
+storage:
+  music:
+    path: /music
+    content: operator
+    persistent: true
+  data:
+    path: /data
+`;
+
+describe("launchToCompose content: operator (D-50)", () => {
+	it("binds a supplied path instead of creating a named volume (row 1)", () => {
+		const launch = readLaunch(MARKED);
+		const result = launchToCompose(launch, { storagePaths: { music: "/srv/music" } });
+
+		expect(result.yaml).toContain("/srv/music:/music");
+		// The marked volume creates NO named volume; the unmarked one still does.
+		expect(result.yaml).not.toContain("media-music");
+		expect(result.yaml).toContain("media-data:/data");
+		expect(result.storageBinds).toEqual([
+			{
+				component: "default",
+				volume: "music",
+				key: "music",
+				hostPath: "/srv/music",
+				containerPath: "/music",
+			},
+		]);
+		expect(result.unboundOperatorVolumes).toEqual([]);
+	});
+
+	it("withholds the mount and records the volume when no path covers it (row 2)", () => {
+		const launch = readLaunch(MARKED);
+		const result = launchToCompose(launch);
+
+		expect(result.unboundOperatorVolumes).toEqual([
+			{ component: "default", volume: "music", flag: "--storage music=<path>" },
+		]);
+		// Never a fabricated empty volume, and no mount at its container path.
+		expect(result.yaml).not.toContain("media-music");
+		expect(result.yaml).not.toContain(":/music");
+	});
+
+	it("leaves an unmarked launch byte-identical whether or not storagePaths is passed (row 4)", () => {
+		const yaml = `
+name: plain
+image: nginx
+storage:
+  data:
+    path: /data
+`;
+		const without = launchToCompose(readLaunch(yaml));
+		const withMap = launchToCompose(readLaunch(yaml), {
+			storagePaths: { data: "/srv/data" },
+		});
+		expect(withMap.yaml).toBe(without.yaml);
+		// The key bound nothing (only marked volumes are bindable) and says so.
+		expect(withMap.warnings).toContain(
+			"--storage data matches no `content: operator` volume — ignored",
+		);
+		expect(without.warnings).toHaveLength(0);
+	});
+
+	it("keeps $storage.<name>.path resolving to the container path under a bind (D-39)", () => {
+		const launch = readLaunch(`
+name: media
+image: navidrome:latest
+storage:
+  music:
+    path: /music
+    content: operator
+env:
+  ND_MUSICFOLDER: $storage.music.path
+`);
+		const result = launchToCompose(launch, { storagePaths: { music: "/srv/music" } });
+		expect(result.yaml).toContain("ND_MUSICFOLDER: /music");
+	});
+
+	describe("first-dot key disambiguation", () => {
+		const TWO_COMPONENTS = `
+name: shelf
+components:
+  web:
+    image: shelf:latest
+    storage:
+      library:
+        path: /library
+        content: operator
+  sync:
+    image: syncer:latest
+    storage:
+      library:
+        path: /import
+        content: operator
+`;
+
+		it("routes component.volume keys to that component only", () => {
+			const launch = readLaunch(TWO_COMPONENTS);
+			const result = launchToCompose(launch, {
+				storagePaths: { "web.library": "/srv/books", "sync.library": "/srv/inbox" },
+			});
+			expect(result.yaml).toContain("/srv/books:/library");
+			expect(result.yaml).toContain("/srv/inbox:/import");
+			expect(result.unboundOperatorVolumes).toEqual([]);
+		});
+
+		it("binds a bare volume name to every component declaring it", () => {
+			const launch = readLaunch(TWO_COMPONENTS);
+			const result = launchToCompose(launch, { storagePaths: { library: "/srv/shared" } });
+			expect(result.yaml).toContain("/srv/shared:/library");
+			expect(result.yaml).toContain("/srv/shared:/import");
+		});
+
+		it("prefers the component-qualified key over a bare one for the same volume", () => {
+			const launch = readLaunch(TWO_COMPONENTS);
+			const result = launchToCompose(launch, {
+				storagePaths: { library: "/srv/shared", "web.library": "/srv/books" },
+			});
+			expect(result.yaml).toContain("/srv/books:/library");
+			expect(result.yaml).toContain("/srv/shared:/import");
+		});
+
+		it("suggests the component.volume flag when the bare name is ambiguous", () => {
+			const launch = readLaunch(TWO_COMPONENTS);
+			const result = launchToCompose(launch);
+			expect(result.unboundOperatorVolumes).toEqual([
+				{ component: "web", volume: "library", flag: "--storage web.library=<path>" },
+				{ component: "sync", volume: "library", flag: "--storage sync.library=<path>" },
+			]);
+		});
+
+		it("treats a dotted key whose left half names no component as a volume name", () => {
+			const launch = readLaunch(`
+name: dotted
+image: app:1
+storage:
+  drop.box:
+    path: /drop
+    content: operator
+`);
+			const result = launchToCompose(launch, {
+				storagePaths: { "drop.box": "/srv/drop" },
+			});
+			expect(result.yaml).toContain("/srv/drop:/drop");
+			expect(result.unboundOperatorVolumes).toEqual([]);
+			expect(result.warnings).toHaveLength(0);
+		});
+	});
+});
+
+describe("dockerUp --dry-run operator storage (D-50)", () => {
+	let prevHome: string | undefined;
+	let prevDockerConfig: string | undefined;
+	let tmpHome: string;
+	let projectDir: string;
+	let contentDir: string;
+	let output: string[];
+	let restore: (() => void) | null = null;
+
+	const LAUNCHFILE = `version: launch/v1
+name: opstore
+image: navidrome:latest
+storage:
+  music:
+    path: /music
+    content: operator
+    persistent: true
+commands:
+  start: sleep 300
+`;
+
+	beforeEach(() => {
+		prevHome = process.env.HOME;
+		prevDockerConfig = process.env.DOCKER_CONFIG;
+		tmpHome = mkdtempSync(join(tmpdir(), "lf-opstore-home-"));
+		// Docker's CLI plugins (compose v2) resolve via $DOCKER_CONFIG, which
+		// defaults to $HOME/.docker — pin it to the real one before HOME moves.
+		if (prevHome && !prevDockerConfig) {
+			process.env.DOCKER_CONFIG = join(prevHome, ".docker");
+		}
+		process.env.HOME = tmpHome;
+		projectDir = mkdtempSync(join(tmpdir(), "lf-opstore-app-"));
+		contentDir = mkdtempSync(join(tmpdir(), "lf-opstore-content-"));
+		writeFileSync(join(projectDir, "Launchfile"), LAUNCHFILE);
+
+		output = [];
+		const log = console.log;
+		const err = console.error;
+		console.log = (...args: unknown[]) => output.push(args.join(" "));
+		console.error = (...args: unknown[]) => output.push(args.join(" "));
+		restore = () => {
+			console.log = log;
+			console.error = err;
+		};
+	});
+
+	afterEach(() => {
+		restore?.();
+		restore = null;
+		if (prevHome === undefined) delete process.env.HOME;
+		else process.env.HOME = prevHome;
+		if (prevDockerConfig === undefined) delete process.env.DOCKER_CONFIG;
+		else process.env.DOCKER_CONFIG = prevDockerConfig;
+		rmSync(tmpHome, { recursive: true, force: true });
+		rmSync(projectDir, { recursive: true, force: true });
+		rmSync(contentDir, { recursive: true, force: true });
+	});
+
+	itIfPrereqsOk("refuses an unbound marked volume, naming volume and flag (row 2)", async () => {
+		await expect(dockerUp(projectDir, { dryRun: true })).rejects.toThrow(
+			UnboundOperatorStorageError,
+		);
+		await expect(dockerUp(projectDir, { dryRun: true })).rejects.toThrow(
+			/music.*--storage music=<path>/s,
+		);
+	});
+
+	itIfPrereqsOk("emits the bind mount when the path is supplied (row 1)", async () => {
+		await dockerUp(projectDir, { dryRun: true, storage: { music: contentDir } });
+		expect(output.join("\n")).toContain(`${contentDir}:/music`);
+	});
+
+	itIfPrereqsOk("absolutizes a relative path against the cwd", async () => {
+		const prevCwd = process.cwd();
+		process.chdir(contentDir);
+		try {
+			await dockerUp(projectDir, { dryRun: true, storage: { music: "." } });
+		} finally {
+			process.chdir(prevCwd);
+		}
+		expect(output.join("\n")).toContain(`${contentDir}:/music`);
+	});
+
+	itIfPrereqsOk("refuses a supplied path that does not exist — never creates it (row 3)", async () => {
+		const missing = join(contentDir, "no-such-dir");
+		await expect(
+			dockerUp(projectDir, { dryRun: true, storage: { music: missing } }),
+		).rejects.toThrow(MissingOperatorStoragePathError);
+		// The refusal did not create the directory.
+		const { existsSync } = await import("node:fs");
+		expect(existsSync(missing)).toBe(false);
+	});
+
+	itIfPrereqsOk("a named instance binds too, under the effective slug (D-55 interplay)", async () => {
+		const result = await dockerUp(projectDir, {
+			dryRun: true,
+			name: "test-x",
+			storage: { music: contentDir },
+		});
+		expect(result.slug).toBe("opstore-test-x");
+		expect(output.join("\n")).toContain(`${contentDir}:/music`);
+	});
+});

--- a/providers/docker/src/compose-generator.ts
+++ b/providers/docker/src/compose-generator.ts
@@ -559,6 +559,35 @@ export interface ComposeOpts {
 	 * generated, so an operator's credential cannot survive into captured output.
 	 */
 	supplied?: Record<string, Record<string, string>>;
+	/**
+	 * Operator-supplied host paths for `content: operator` volumes (D-50),
+	 * keyed by volume name or `component.volume`. A key splits on its FIRST
+	 * dot: if the left half names a component, the key is component-qualified;
+	 * otherwise the whole key is a volume name (dots included). The qualified
+	 * form wins when both match one volume. Values must be absolute — the
+	 * compose file lives in state, not the project dir, so a relative path
+	 * would rebase silently; `dockerUp` resolves flag values against its cwd
+	 * and verifies each bound path exists before launching (rule 2 row 3).
+	 */
+	storagePaths?: Record<string, string>;
+}
+
+/** A `content: operator` volume bound to an operator-supplied host path (D-50 row 1). */
+export interface StorageBind {
+	component: string;
+	volume: string;
+	/** The `storagePaths` key that supplied the path, as the operator wrote it. */
+	key: string;
+	hostPath: string;
+	containerPath: string;
+}
+
+/** A `content: operator` volume no supplied path covers (D-50 row 2). */
+export interface UnboundOperatorVolume {
+	component: string;
+	volume: string;
+	/** The exact flag that satisfies the volume, e.g. `--storage music=<path>`. */
+	flag: string;
 }
 
 /** A `required:` variable neither the Launchfile nor the operator supplied. */
@@ -602,6 +631,19 @@ export interface ComposeResult {
 	 * pure generator.
 	 */
 	unsuppliedRequired: UnsuppliedRequiredVar[];
+	/**
+	 * Bind mounts emitted for `content: operator` volumes (D-50 row 1). The
+	 * generator is pure, so the caller owns row 3: verify each `hostPath`
+	 * exists and is readable before launching — refuse, never create.
+	 */
+	storageBinds: StorageBind[];
+	/**
+	 * `content: operator` volumes with no supplied path (D-50 row 2). Their
+	 * mounts are ABSENT from the emitted compose — never a fabricated empty
+	 * volume. Same shape as `unsuppliedRequired`, deliberately NOT folded into
+	 * `warnings`: a deploying verb reads this field and refuses.
+	 */
+	unboundOperatorVolumes: UnboundOperatorVolume[];
 }
 
 export function launchToCompose(
@@ -622,6 +664,33 @@ export function launchToCompose(
 	const componentServices: Record<string, string> = {};
 	const unsuppliedRequired: UnsuppliedRequiredVar[] = [];
 	const endpoints: Record<string, StateEndpoint> = {};
+	const storageBinds: StorageBind[] = [];
+	const unboundOperatorVolumes: UnboundOperatorVolume[] = [];
+
+	// D-50 storage-path keys, classified once against the component set: a key
+	// whose first-dot left half names a component is component-qualified;
+	// anything else — no dot, or a left half naming no component — is a bare
+	// volume name, dots included.
+	const componentSet = new Set(Object.keys(launch.components));
+	const qualifiedPaths = new Map<string, { path: string; key: string }>();
+	const barePaths = new Map<string, { path: string; key: string }>();
+	for (const [key, path] of Object.entries(opts.storagePaths ?? {})) {
+		const dot = key.indexOf(".");
+		if (dot > 0 && componentSet.has(key.slice(0, dot))) {
+			qualifiedPaths.set(key, { path, key });
+		} else {
+			barePaths.set(key, { path, key });
+		}
+	}
+	const usedStorageKeys = new Set<string>();
+	// How many components declare a volume of each name — an ambiguous name gets
+	// the `component.volume` spelling in the refusal's suggested flag.
+	const volumeNameCount = new Map<string, number>();
+	for (const comp of Object.values(launch.components)) {
+		for (const volName of Object.keys(comp.storage ?? {})) {
+			volumeNameCount.set(volName, (volumeNameCount.get(volName) ?? 0) + 1);
+		}
+	}
 	// Set by any component that declares `provides` and is actually translated,
 	// so a component skipped earlier (refused capability, non-local build
 	// context) can't be mistaken for a missing `exposed: true`.
@@ -925,10 +994,41 @@ export function launchToCompose(
 			service.healthcheck = translateHealth(component.health, component.provides);
 		}
 
-		// Storage — named volumes for persistence
+		// Storage — named volumes for persistence. A `content: operator` volume
+		// (D-50) is instead bound to the operator-supplied host path, or — when
+		// no path covers it — its mount is withheld and the volume recorded for
+		// the caller to refuse: an empty named volume where the operator's
+		// content belongs is D-52's fabrication in storage form. An unmarked
+		// volume is untouched by `storagePaths` (row 4: byte-identical).
 		if (component.storage) {
 			const svcVolumes: string[] = [];
 			for (const [volName, vol] of Object.entries(component.storage)) {
+				if (vol.content === "operator") {
+					const bound =
+						qualifiedPaths.get(`${componentName}.${volName}`) ?? barePaths.get(volName);
+					if (!bound) {
+						const flagKey =
+							(volumeNameCount.get(volName) ?? 0) > 1
+								? `${componentName}.${volName}`
+								: volName;
+						unboundOperatorVolumes.push({
+							component: componentName,
+							volume: volName,
+							flag: `--storage ${flagKey}=<path>`,
+						});
+						continue;
+					}
+					usedStorageKeys.add(bound.key);
+					svcVolumes.push(`${bound.path}:${vol.path}`);
+					storageBinds.push({
+						component: componentName,
+						volume: volName,
+						key: bound.key,
+						hostPath: bound.path,
+						containerPath: vol.path,
+					});
+					continue;
+				}
 				const namedVolume = `${serviceName}-${volName}`;
 				svcVolumes.push(`${namedVolume}:${vol.path}`);
 				volumes[namedVolume] = {};
@@ -956,6 +1056,17 @@ export function launchToCompose(
 		warnings.push(
 			`${launch.name}: no endpoint sets \`exposed: true\` — nothing is published to the host, so the app is not reachable (D-27)`,
 		);
+	}
+
+	// A storage-path key that bound nothing would otherwise vanish without a
+	// trace — a typo'd name surfaces here (the unbound marked volume it left
+	// behind is refused separately, so this alone never masks a refusal). Only
+	// `content: operator` volumes are bindable: row 4 keeps unmarked volumes
+	// byte-identical, so a key naming one is unused too.
+	for (const key of Object.keys(opts.storagePaths ?? {})) {
+		if (!usedStorageKeys.has(key)) {
+			warnings.push(`--storage ${key} matches no \`content: operator\` volume — ignored`);
+		}
 	}
 
 	// Add network
@@ -986,6 +1097,8 @@ export function launchToCompose(
 		endpoints,
 		services: componentServices,
 		unsuppliedRequired,
+		storageBinds,
+		unboundOperatorVolumes,
 	};
 }
 

--- a/providers/docker/src/index.ts
+++ b/providers/docker/src/index.ts
@@ -12,6 +12,8 @@ export {
 	UnsuppliedRequiredEnvError,
 	ForeignSourceError,
 	type ForeignSourceDetails,
+	UnboundOperatorStorageError,
+	MissingOperatorStoragePathError,
 	type DockerUpOpts,
 	type DockerUpResult,
 } from "./provider.js";
@@ -30,6 +32,8 @@ export {
 	launchToCompose,
 	type ComposeResult,
 	type ComposeOpts,
+	type StorageBind,
+	type UnboundOperatorVolume,
 	type UnsuppliedRequiredVar,
 } from "./compose-generator.js";
 export { resolveSource, type ResolvedSource } from "./source-resolver.js";

--- a/providers/docker/src/provider.ts
+++ b/providers/docker/src/provider.ts
@@ -2,8 +2,9 @@
  * Main provider orchestration — docker compose lifecycle management.
  */
 
-import { realpathSync } from "node:fs";
+import { accessSync, constants as fsConstants, realpathSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
+import { resolve as resolvePath } from "node:path";
 import { createInterface } from "node:readline";
 import { readLaunch, selectionClosure } from "@launchfile/sdk";
 import { checkPrereqs, composeSupportsIgnoreBuildable } from "./prereqs.js";
@@ -21,7 +22,12 @@ import {
 	type StateEndpoint,
 } from "./state.js";
 import { allocatePorts } from "./port-allocator.js";
-import { launchToCompose, type UnsuppliedRequiredVar } from "./compose-generator.js";
+import {
+	launchToCompose,
+	type StorageBind,
+	type UnboundOperatorVolume,
+	type UnsuppliedRequiredVar,
+} from "./compose-generator.js";
 import { planReleases, runReleases } from "./release.js";
 import { shell, shellStream } from "./shell.js";
 import { getLogger, withSpan } from "./logger.js";
@@ -58,6 +64,16 @@ export interface DockerUpOpts {
 	 * all components.
 	 */
 	components?: string[];
+	/**
+	 * Operator-supplied host paths for `content: operator` volumes (D-50):
+	 * `--storage <volume>=<path>` / `--storage <component>.<volume>=<path>`,
+	 * keyed as typed (the component/volume split happens against the parsed
+	 * Launchfile). Relative paths resolve against the invocation cwd. The
+	 * explicit flag map is the only source this provider consults today; per
+	 * D-50 rule 1 it takes precedence over any provider-config map, so a
+	 * config channel added later slots in below it, never above.
+	 */
+	storage?: Record<string, string>;
 }
 
 /**
@@ -105,6 +121,63 @@ export class ForeignSourceError extends Error {
 	constructor(details: ForeignSourceDetails) {
 		super(foreignSourceMessage(details));
 		this.name = "ForeignSourceError";
+	}
+}
+
+/**
+ * A deploy refused because a `content: operator` volume arrived with no host
+ * path (D-50 rule 2, row 2). Creating the volume empty and starting anyway is
+ * D-52's fabrication in storage form — the silent success this refusal closes.
+ * Each line names the volume and the exact flag that satisfies it.
+ */
+export class UnboundOperatorStorageError extends Error {
+	/** An operator-fixable precondition, not a crash — see `ExpectedRefusal`. */
+	readonly expectedRefusal = true as const;
+	readonly volumes: UnboundOperatorVolume[];
+
+	constructor(volumes: UnboundOperatorVolume[]) {
+		const lines = volumes.map(
+			({ component, volume, flag }) => `  - ${component}: ${volume} — supply it with ${flag}`,
+		);
+		super(
+			`Cannot launch: ${volumes.length} volume${volumes.length === 1 ? "" : "s"} marked ` +
+				"`content: operator` had no host path.\n" +
+				`${lines.join("\n")}\n` +
+				"The Launchfile declares that you supply this content (D-50); this provider will not\n" +
+				"create an empty volume in its place. Provide each path and run `up` again.",
+		);
+		this.name = "UnboundOperatorStorageError";
+		this.volumes = volumes;
+	}
+}
+
+/**
+ * A deploy refused because an operator-supplied storage path is absent or
+ * unreadable on the host (D-50 rule 2, row 3). The directory is never
+ * created: a silently minted empty `~/Music` would reintroduce the
+ * empty-library failure through this channel's own flag.
+ */
+export class MissingOperatorStoragePathError extends Error {
+	/** An operator-fixable precondition, not a crash — see `ExpectedRefusal`. */
+	readonly expectedRefusal = true as const;
+	readonly binds: StorageBind[];
+
+	constructor(binds: StorageBind[]) {
+		const lines = binds.map(
+			({ component, volume, key, hostPath }) =>
+				`  - ${component}: ${volume} — --storage ${key}=${hostPath}`,
+		);
+		super(
+			(binds.length === 1
+				? "Cannot launch: a supplied storage path does not exist or is not readable."
+				: `Cannot launch: ${binds.length} supplied storage paths do not exist or are not readable.`) +
+				`\n${lines.join("\n")}\n` +
+				"The volume is marked `content: operator` (D-50), so this provider refuses to create\n" +
+				"the directory — an empty one here is the missing-content failure the marker exists\n" +
+				"to catch. Check each path and run `up` again.",
+		);
+		this.name = "MissingOperatorStoragePathError";
+		this.binds = binds;
 	}
 }
 
@@ -364,6 +437,15 @@ export async function dockerUp(source: string, opts: DockerUpOpts = {}): Promise
 		// Generate compose. `process.env` is this provider's operator channel for
 		// `required:` variables the Launchfile supplies no value for (PROVIDERS.md
 		// §10 rule 8) — `URL=https://wiki.example.com launchfile up` supplies one.
+		// Storage paths (D-50) are absolutized here, against the invocation
+		// cwd — the compose file lives in state, so a relative path in it
+		// would rebase against whatever directory compose later runs from.
+		const storagePaths = opts.storage
+			? Object.fromEntries(
+					Object.entries(opts.storage).map(([key, path]) => [key, resolvePath(path)]),
+				)
+			: undefined;
+
 		const result = await inPhase("provision", failure(), async () =>
 			launchToCompose(launch, {
 				secrets: state.secrets,
@@ -371,6 +453,7 @@ export async function dockerUp(source: string, opts: DockerUpOpts = {}): Promise
 				hostPorts,
 				projectDir: resolved.dir,
 				operatorEnv: process.env,
+				storagePaths,
 			}),
 		);
 
@@ -388,6 +471,29 @@ export async function dockerUp(source: string, opts: DockerUpOpts = {}): Promise
 		const blocking = result.unsuppliedRequired.filter((v) => launching.has(v.component));
 		if (blocking.length > 0) {
 			throw new UnsuppliedRequiredEnvError(blocking);
+		}
+
+		// D-50 rule 2, rows 2 and 3 — refused before the compose file is
+		// written and before any volume exists, dry-run included. Scoped the
+		// same way as required-env (§5 rule 4): a marked volume on a component
+		// outside the start-set blocks nothing.
+		const unboundStorage = result.unboundOperatorVolumes.filter((v) =>
+			launching.has(v.component),
+		);
+		if (unboundStorage.length > 0) {
+			throw new UnboundOperatorStorageError(unboundStorage);
+		}
+		const missingPaths: StorageBind[] = [];
+		for (const bind of result.storageBinds) {
+			if (!launching.has(bind.component)) continue;
+			try {
+				accessSync(bind.hostPath, fsConstants.R_OK);
+			} catch {
+				missingPaths.push(bind);
+			}
+		}
+		if (missingPaths.length > 0) {
+			throw new MissingOperatorStoragePathError(missingPaths);
 		}
 
 		// Past the refusal gate — from here the provider starts leaving things on

--- a/spec/CLI-ROADMAP.md
+++ b/spec/CLI-ROADMAP.md
@@ -13,7 +13,7 @@ launchfile <verb> [target] [flags]
 ```
 VERB          TARGET              FLAGS                         PHASE
 ────────────────────────────────────────────────────────────────────
-up            [slug|path]         --docker/--native/-d/--dry-run  1 ✓
+up            [slug|path]         --docker/--native/-d/--dry-run/--name/--storage  1 ✓
 down          [id|slug|name]      --destroy                       1 ✓
 status        [id|slug|name]                                      1 ✓
 logs          [id|slug|name]      --follow                        1 ✓


### PR DESCRIPTION
Refs #281 (left open — see below).

Implements the D-50 operator-storage channel (the second half of the governed pair the decision text bound) across **two of the three** surfaces D-50's Conformance-at-adoption paragraph names — providers/docker and the catalog harness translator — plus the CLI. The third surface, **providers/macos-dev, is tracked separately as #286**: this PR ships only the loud CLI-level `--storage` refusal for the native provider; macos-dev's own bind/refuse contract (its `provisionStorage` still `mkdir -p`s marked volumes) remains open, so catalog adoption of the marker stays gated until #286 lands. #281 stays open to track that surface.

## What changed

- **`packages:`** — repeatable `--storage <volume>=<path>` / `--storage <component>.<volume>=<path>` on `up` and `dev` (inline `--storage=...` form too). `storage` joins `VALUE_FLAGS` so `getPositional` never reads a pair as the target (#248 class); `getFlagValues` (plural) collects every occurrence in order; first-`=` split with clear errors on malformed pairs and duplicate keys. The map threads into `dockerUp`; the macOS path refuses `--storage` before launch ("not yet supported by the macOS native provider"), mirroring the `--name` refusal — silent drop is forbidden.
- **`providers:`** — `ComposeOpts.storagePaths` (structural twin of `hostPorts`); first-dot key classification against the component set per D-50 rule 1. The four-row table implemented: marked volume + path → **bind mount** (host path absolutized first), no named volume created; marked + no path → **refusal** naming the volume and the exact flag (`UnboundOperatorStorageError`, expected-refusal — print-and-exit, no diagnose record); marked + path absent/unreadable → **refusal, never create** (`MissingOperatorStoragePathError`, existence checked at generation time, before the compose file or state exist); unmarked → byte-identical named-volume behavior. `$storage.<name>.path` keeps resolving to the container path (D-39).
- **`catalog:`** — the harness's independent translator (`launch-to-compose.ts`) accepts the same map with the same four-row behavior; `test-app.ts` treats a non-empty `storageRefusals` as a hard failure before any pull, so catalog adoption cannot flip `health_check_passed` silently (closing the D-52/#192-shaped gap D-50 recorded). A test pins that no shipped catalog app is refused today (none carries the marker yet). Also repins the non-CI portability-lint counts (4/12 → 5/13): #280's `spec/examples/operator-content.yaml` is a D-40 file that suite hadn't counted.

## Notes

- Duplicate `--storage` keys are rejected rather than last-wins — D-50 is silent there; rejection is the only non-silent option.
- The first-dot rule means a volume literally named `web.data` is unaddressable while a component `web` exists — inherent to D-50 rule 1 as written; a dotted key whose left half names no component works and is tested.
- Rebased onto main `1c0c882` (post-#283/#282/#285), so the channel composes with instance isolation and follows the D-55 renumbering. A `spec:` commit also brings CLI-ROADMAP's `up` row up to date (`--name`, `--storage`).

## Verification

Tests (post-rebase, all observed): providers/docker 292, packages/launchfile 188, catalog/test 32, sdk 408, macos-dev 189; typecheck + build clean.

Verified live (dry-run, temp HOME with before/after diff of the real `~/.launchfile` proving zero writes): (a) no `--storage` → the unbound refusal naming `music` and `--storage music=<path>`, exit 1; (b) `--storage music=<tmp>` → the generated compose carries the bind mount with the provider-owned sibling still a named volume, exit 0; (c) nonexistent path → row-3 refusal, directory never created (unit-covered in both docker and harness suites); (d) `--name test-x --storage music=<tmp>` → bind present AND state keyed under the effective slug (`verify2-test-x`), composing with D-55 (instance identity; recorded as D-59, renumbered by #285).
