### PR TITLE
chore: changesets for the D-50 channel, D-55 instance isolation, and the validate storage warnings

### DIFF
--- a/.changeset/instance-isolation-name.md
+++ b/.changeset/instance-isolation-name.md
@@ -1,0 +1,10 @@
+---
+"launchfile": minor
+"@launchfile/docker": minor
+---
+
+`--name <label>` isolates a deployment (D-55). An unnamed `up` and each `--name <label>` from the same source are now distinct deployment instances: the effective slug becomes `<base>-<label>` and keys the state directory, compose project, network, volumes, and persisted host ports, so two instances of one app never share or clobber each other's state. The deployment index is keyed by (source, name), and a bare `down`/`status`/`logs` that matches more than one instance lists them instead of guessing. `--name` requires a value, and the macOS native provider refuses the flag rather than pretending to isolate.
+
+**Behavior change:** an `up` that finds existing state recorded from a *different* source (any source type) now refuses to adopt it, with the remedies in the message — previously it silently adopted or clobbered the same-named stack. Re-running `up` from the same source is unaffected.
+
+Also fixes #248: CLI flag parsing no longer consumes a value flag's argument as the positional target, so `launchfile up --name blue` no longer treats `blue` as the app to deploy.

--- a/.changeset/operator-content-marker.md
+++ b/.changeset/operator-content-marker.md
@@ -1,0 +1,5 @@
+---
+"@launchfile/sdk": minor
+---
+
+The D-50 `content: operator` storage marker. The SDK parses, round-trips, and serializes `content: operator` on a storage entry — the author's declaration that a volume's content is supplied by the operator at deploy time, not created empty by the provider — and rejects any other `content:` value. `launchfile validate` lists operator-supplied volumes in its privilege summary (an `operator-supplied storage:` line, `operatorStorage` in `--json`), so the marker is visible before anything runs. A new advisory lint warns when `persistent: false` sits beside the marker — operator-supplied content on a non-persistent volume is almost certainly a mistake.

--- a/.changeset/operator-storage-channel.md
+++ b/.changeset/operator-storage-channel.md
@@ -1,0 +1,8 @@
+---
+"launchfile": minor
+"@launchfile/docker": minor
+---
+
+The D-50 operator-storage channel: repeatable `--storage <volume>=<path>` (and `<component>.<volume>=<path>` when the name is ambiguous) hands a `content: operator` volume its host content at `up` time. `@launchfile/docker` binds the supplied path into the volume, or refuses loudly: a marked volume with no supplied path, or a supplied path that is absent or unreadable on the host, stops the launch before anything starts — the provider never papers over a missing supply by creating an empty volume (D-52's fabrication rule, in storage form). The macOS native provider refuses `--storage`.
+
+**Behavior change:** a Launchfile carrying `content: operator` now refuses to `up` without a supplied path. The marker did not exist before this release, so no existing Launchfile is affected.

--- a/.changeset/validate-unknown-storage-keys.md
+++ b/.changeset/validate-unknown-storage-keys.md
@@ -1,0 +1,5 @@
+---
+"@launchfile/sdk": minor
+---
+
+`launchfile validate` warns when a storage entry carries keys the schema does not recognize (#239). Zod's default strip meant a typo like `persistant:` or a key from a newer spec vocabulary vanished silently — the entry validated, the intent was lost. The check runs on the raw document before parsing, names the unrecognized keys, and lists the known set so the fix is in the message. Warn-only per D-46's unknown-vocabulary posture: the exit code is unchanged, so no existing Launchfile starts failing validation.


### PR DESCRIPTION
PRs #278, #280, #283, and #284 merged today without changesets, so the pending release PR #204 would publish their code with no changelog record. This adds the four missing entries so 0.4.0's changelogs describe everything it ships:

- `validate-unknown-storage-keys` — @launchfile/sdk minor (#278 / #239)
- `operator-content-marker` — @launchfile/sdk minor (#280 / D-50)
- `instance-isolation-name` — launchfile + @launchfile/docker minor (#283 / D-55, #248), with the behavior change (foreign-source refusal) called out
- `operator-storage-channel` — launchfile + @launchfile/docker minor (#284 / D-50), with the behavior change (marked volume refuses without a supplied path) called out

Entries cite **D-55** (the current number post-#285), not D-59. `providers/macos-dev` gets no bump — #283/#284 touch no macos-dev files (the flag refusals live in the CLI). `bun run changeset status` parses clean.

Merge this before #204 so the release workflow rebuilds the version PR with these entries.
