### PR TITLE
spec+governance: publish the steward escalation routing (implements #299)

### DIFF
--- a/governance/GOVERNANCE.md
+++ b/governance/GOVERNANCE.md
@@ -42,11 +42,12 @@ If no active Authors remain, the specification is frozen at its last published v
 An AI model that evaluates proposals against the documented principles:
 
 - Must cite specific P-\* and D-\* references in every recommendation
-- Flags uncertainty and defers to Authors on low-confidence decisions
+- Defers to Authors exactly where the escalation table in [`spec/DESIGN.md` §1b](../spec/DESIGN.md#uncertainty-escalation) routes a question to them
+- Changes to the Steward's operating rules — the evaluation process and the escalation table — are decided by Authors regardless of any Steward verdict; the Steward never self-ratifies a change to its own authority
 - Cannot amend principles — only apply them
 - Publishes all reasoning publicly
 
-The Steward posts on GitHub as `launchfile-steward[bot]` via a GitHub App, keeping its activity distinct from any human Author's. Its review framework grounds every verdict in the principles and decisions documented in `spec/DESIGN.md` and `spec/SPEC.md`, so any contributor can trace a review comment back to a published rule. Implementation lives outside this repository; the public commitment is the set of principles, decisions, and the transparent review output.
+The Steward posts on GitHub as `launchfile-steward[bot]` via a GitHub App, keeping its activity distinct from any human Author's. Its review framework grounds every verdict in the principles and decisions documented in `spec/DESIGN.md` and `spec/SPEC.md`, so any contributor can trace a review comment back to a published rule. Implementation lives outside this repository; the public commitment is the set of principles, decisions, and the transparent review output. Rules that change verdict outcomes — the evaluation axes and the escalation table — are part of the public commitment; the machinery that applies them is not.
 
 ---
 
@@ -72,6 +73,10 @@ The Steward evaluates on five axes:
 5. **Reversibility** — additive? can be removed without breaking existing files?
 
 Output: **ACCEPT** / **REJECT** / **DEFER** with structured reasoning.
+
+**How an evaluation is produced.** Every evaluation runs as a staged process, not a single pass: **intake** (fast triage — duplicate check, already-addressed check against the decision log, completeness, bundling scope; a proposal the record already resolves is answered directly with the citation), then **grounding** (every factual claim verified against the repository and mapped to the principles and decisions it touches, before any judgment is formed; unverifiable claims are labeled as such, never treated as fact), then the **verdict**, rendered by applying the escalation table in [`spec/DESIGN.md` §1b](../spec/DESIGN.md#uncertainty-escalation) and naming the row it routed through — so the routing itself is contestable.
+
+**Consistency measures.** For precedent-setting proposals the verdict stage runs twice, independently; any disagreement between the runs goes to the Authors instead of being posted. The Steward's tooling refuses to post a second verdict on a thread that already carries one: a superseding verdict must name what it replaces, and the replaced verdict is annotated and retained, never deleted.
 
 ### 3. Author Review
 

--- a/spec/DESIGN.md
+++ b/spec/DESIGN.md
@@ -112,13 +112,26 @@ The reject criterion "solves one app's problem but adds complexity for everyone"
 
 ### Uncertainty Escalation
 
-The AI Steward assigns a confidence level to each evaluation:
+The AI Steward's confidence measures **grounding completeness**, not comfort:
 
-- **High** — the proposal clearly passes or fails the principles with precedent support
-- **Medium** — the proposal is plausible but involves trade-offs not covered by existing D-\* decisions
-- **Low** — the proposal falls outside the scope of documented principles or creates novel precedent
+- **High** — every load-bearing factual claim in the proposal was verified against the repository (code, catalog, spec), and the escalation table below yields a route
+- **Medium / Low** — a load-bearing fact could not be verified, or the table routes the question to "Author-owned"
 
-Medium and low confidence evaluations are marked as **DEFER** and escalated to Authors for decision. The resulting Author decision becomes a new D-\* entry, expanding the precedent base.
+Confidence is never lowered because a question is hard — only because it is unverifiable or reserved to Authors.
+
+**Pre-check, before the table**: a proposal that changes the Steward's own operating rules — the evaluation process, this table, the verdict policy — always routes to the Authors with a recommendation, regardless of any Steward verdict. The Steward never self-ratifies a change to its own authority. The table below then informs the recommendation.
+
+The escalation table is applied top-down; the first matching row wins, and every verdict names the row it routed through:
+
+| # | Condition | Route |
+|---|-----------|-------|
+| 1 | The open question is **factual** — settleable by reading code, catalog, or spec | The Steward resolves it. Factual questions are never deferred. |
+| 2 | The proposal requires **changing the meaning of ratified P-\*/D-\* text** (amending, not applying), or **forecloses an option the record explicitly reserves to Authors** (e.g. expanding an enumeration the record calls a "high-bar future RFC") | **DEFER**, naming the exact sentence that must change and why the Steward cannot change it. |
+| 3 | Provider-conduct or provider-API work with **zero format/schema/parser change** and a **settled precedent family** — an existing D-\* class covering the same conduct or channel species (the [D-43](#d-43-source-acquisition--repository-as-canonical-origin-baseline-ref-as-a--fragment) / [D-50](#d-50-storagenamecontent-operator--operator-supplied-volume-content-bound-by-the-orchestrator-or-refused) / [D-52](#d-52-a-required-environment-variable-is-operator-supplied--providers-must-not-fabricate-one) orchestrator-channel family is the worked example) | The Steward renders **ACCEPT or REJECT** directly. Under-specified semantics are bound in the verdict's required implementing shape, not used to withhold or reject. If the work also touches a pinned classification, the verdict additionally binds a new `D-*` entry recording the applied reading; the entry lands via the implementing PR the Authors approve. (#290 is the worked example: `$app.*` stays [D-36](#d-36-the-three-homes-of-a-varying-value-p-1-litmus-refinement) home #3, the orchestrator-supplied URL a delegated input to the provider's computation — a reading pending ratification via #290's implementing PR.) |
+| 4 | The proposal touches a **pinned classification** — a boundary the record fixes explicitly, such as [D-36](#d-36-the-three-homes-of-a-varying-value-p-1-litmus-refinement)'s three homes — or otherwise **creates novel precedent**, outside any settled precedent family | **DEFER** to Authors, presenting the candidate readings with evidence for each. Novel precedent is Author-decided; the Author's call becomes the new `D-*` entry. |
+| 5 | The residual question is genuinely **value-laden** ("is this boundary where we want it", "is this niche worth its complexity") | **DEFER**, stating the value question in one sentence. |
+
+Author override remains available on every verdict, including directly-rendered ones. A DEFER's resulting Author decision becomes a new D-\* entry, expanding the precedent base.
 
 ---
 
@@ -673,6 +686,15 @@ The change is **annotation-only**. No `type`, `enum`, `required`, or `default` u
 **Rejected**: *A Launchfile field naming the external resource* — fails the [P-1](#p-1-app-focused-not-infra-focused) litmus outright: which instance satisfies a requirement varies per deployment while the app's need does not, and D-36 already homes the value with the orchestrator ([L-3](#l-3-no-environment-specific-overrides)). *Provider verification of the supplied resource* — a reachability probe turns a pure translation into a network operation and duplicates the app's own healthcheck; D-50's four-state model puts existence checks with the channel's owner, here the orchestrator. *A synthetic `depends_on` or healthcheck stub for the external resource* — [D-16](#d-16-depends_on-for-startup-ordering) orders startup only within the project the provider manages, and a fabricated readiness gate on a service it does not own is D-52's fabrication in readiness form. *Hard validation of supplied property names* — D-46 rejected registry enforcement as errors; supplied extras are the same species as the provider-extension properties D-46 permits, so tooling warns, never rejects.
 
 **Why**: The docker provider provisioned every `requires:` entry unconditionally and silently dropped every non-host `supports:` entry — an embedding platform with a pooled or managed database had no arrival channel for the exact value class the precedent base already names (D-36 home #2), so it had to fork the generator or post-process its output: the parallel-translator pressure [P-5](#p-5-provider-translatable) exists to remove. This is the fourth instance of an established pattern — orchestrator-supplied source (D-43 rule 1), volume content (D-50), required env (D-52) — and reuses their trust posture unchanged. Purely provider conduct ([P-11](#p-11-separate-intent-from-execution)): no schema, parser, or field change, every existing Launchfile keeps its meaning ([P-13](#p-13-additive-extensibility)), and with nothing supplied the output is byte-identical to before. Provider-conduct precedent: [D-49](#d-49-env-value-provenance--four-declaration-classes-with-per-layer-obligations), [D-51](#d-51-unexecuted-schedule-is-reported-loudly-not-silently-accepted), D-52, [D-55](#d-55-deployment-instance-identity--provider-state-is-keyed-by-app-identity-instance-label). See [#289](https://github.com/launchfile/launchfile/issues/289).
+
+
+### D-next: Steward escalation routing is public; Steward-rule changes are Author-decided
+
+**Decision**: (1) The Steward's escalation routing — §1b's confidence definition and five-row table — is public normative text; the Steward's operational copy is a pointer to it, and on any divergence the published text is normative. (2) Standing rule (§1b's pre-check): a proposal that changes the Steward's operating rules is decided by Authors regardless of any Steward verdict; such proposals route to the Authors with a recommendation. (3) The publication cadence trade is accepted for the table alone — future changes to it go through the decision process in `governance/GOVERNANCE.md`, deliberately giving up the same-day tuning private rules allowed. (4) Explicitly not settled here: whether governance-doc proposals satisfy the proposal template's "3+ real-app motivations" requirement — [#188](https://github.com/launchfile/launchfile/issues/188) is the vehicle for that precedent.
+
+**Rejected**: *Keeping the table private* — a verdict publicly citing "escalation row 3" of an unpublished table (the #290 reconciliation note) breaches `governance/GOVERNANCE.md`'s promise that a contributor can trace a review comment back to a published rule. *Transferring novel-precedent decisions to the Steward* — the proposal's first draft routed pinned-classification cases to Steward-rendered `D-*` entries; the Author declined: row 4 defers, and only the settled-family row renders directly, under live Author override.
+
+**Why**: On 2026-08-25, [#289](https://github.com/launchfile/launchfile/issues/289) and [#290](https://github.com/launchfile/launchfile/issues/290) each drew contradictory Steward verdicts minutes apart from concurrent review runs; the analysis found both sides were well-grounded readings of §1b's confidence-only scheme — the published rubric under-determined outcomes. The replacement routes by explicit condition, and publishes because rules that change verdict outcomes are commitment while machinery is implementation (the boundary `governance/GOVERNANCE.md` now records). Self-application is already on the record: the twin-run disagreement on the publishing proposal itself routed to the Author instead of posting, and the pre-check's first exercise was the Author ruling this entry records. See [#299](https://github.com/launchfile/launchfile/issues/299).
 
 ---
 


### PR DESCRIPTION
Closes #299.

Implements the accepted proposal exactly as bound by the [Author's ruling on the twin-run review](https://github.com/launchfile/launchfile/issues/299#issuecomment-5423014438): publishes the Steward's escalation routing where a contributor can read and contest it, and records the Author-decided fences.

**`spec/DESIGN.md` §1b** — the confidence-only scheme is replaced in place (original wording in git history, the D-49/D-50 update pattern exercised in #297): confidence redefined as grounding completeness; the Author-decided **pre-check** (Steward-rule changes route to Authors with a recommendation, regardless of verdict — closing the routing gap the twin split on #299 exposed, without renumbering rows already cited publicly); the five-row table with worked examples (the D-43/D-50/D-52 orchestrator-channel family; #290's home-#3 reading, marked **pending** until its implementing PR lands the recorded entry); row 5 with its full clause; Author override live on every verdict. A `D-next` entry records the rulings, the accepted cadence trade, and what is deliberately **not** settled (the "3+ real-app motivations" question for governance-doc proposals — #188 is the vehicle; this merge sets no precedent on it).

**`governance/GOVERNANCE.md`** — §2 gains the staged-process description (intake → grounding → verdict-by-table, row named) and the consistency measures (twin runs for precedent-setting proposals, disagreement to Authors; one-verdict-per-thread with annotated, retained supersession); the §Steward bullets point at the published table and carry the standing self-reference rule; the implementation-boundary sentence now draws the commitment/machinery line explicitly.

No model names, agent names, or tooling paths are published — stages and guarantees only, per the boundary this change itself records.

**Docs gate, assessed:** `www-org` auto-renders `DESIGN.md` (`design.astro`), so §1b and the new entry appear on the next build with no site edit; neither site renders `GOVERNANCE.md`, so no edit is due there. No schema, field, expression, or example changes — no `www-dev` surface.

**Sequencing:** based alongside the D-56 assignment PR; whichever merges second rebases trivially (disjoint hunks). This PR's `D-next` takes its concrete number as the final commit on this branch at APPROVE, per the D-number rule.
