### PR TITLE
governance+chore: document merge mechanics, add PR template, align the self-assessment rule

### DIFF
--- a/.github/ISSUE_TEMPLATE/spec-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/spec-proposal.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Proposals are evaluated against the [13 design principles](https://github.com/launchfile/launchfile/blob/main/spec/DESIGN.md) by an AI Steward. See [GOVERNANCE.md](https://github.com/launchfile/launchfile/blob/main/spec/GOVERNANCE.md) for how decisions are made.
+        Proposals are evaluated against the [14 design principles](https://github.com/launchfile/launchfile/blob/main/spec/DESIGN.md) by an AI Steward. See [GOVERNANCE.md](https://github.com/launchfile/launchfile/blob/main/governance/GOVERNANCE.md) for how decisions are made.
   - type: textarea
     id: problem
     attributes:
@@ -31,6 +31,8 @@ body:
   - type: textarea
     id: principles
     attributes:
-      label: Principle Check (optional)
-      description: Does this align with the design principles? Note any tensions.
+      label: Principle Check
+      description: Required for spec proposals — walk P-1 through P-14 and note alignment or tensions.
       placeholder: "e.g. Aligns with P-2 (incrementally adoptable) — new optional field. Tension with P-1 if this is too infra-specific."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/spec-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/spec-proposal.yml
@@ -32,7 +32,7 @@ body:
     id: principles
     attributes:
       label: Principle Check
-      description: Required for spec proposals — walk P-1 through P-14 and note alignment or tensions.
+      description: Required. For a spec change, walk P-1 through P-14 and note alignment or tensions. For a process, documentation, or catalog-fix proposal, write "no principle applies" — P-1 through P-14 govern the Launchfile format, not project process.
       placeholder: "e.g. Aligns with P-2 (incrementally adoptable) — new optional field. Tension with P-1 if this is too infra-specific."
     validations:
       required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!--
+Thanks for contributing to Launchfile!
+
+Preferred flow: open this PR as a DRAFT, iterate until it is ready, then mark
+it "Ready for review". The required `steward/review` check blocks merging
+either way, so draft status is a courtesy signal, not a gate — it tells
+reviewers you are still working.
+
+See governance/GOVERNANCE.md → "Merge mechanics" for what the merge-box
+states mean and what happens when you push new commits. Fork contributors:
+CI runs need a maintainer's approval — see the same section.
+-->
+
+## What
+
+<!-- One or two sentences: what does this PR change? -->
+
+## Why
+
+<!-- Link the issue this implements. Spec changes must link an accepted
+     proposal issue: Closes #NNN -->
+
+## Checklist
+
+- [ ] CI is green
+- [ ] Spec change? Linked to its proposal issue, and self-assessed against
+      P-1 through P-14 (`spec/DESIGN.md`)
+- [ ] Not a spec change? No principle self-assessment needed — process,
+      documentation, and catalog-fix PRs state that no principle applies

--- a/governance/GOVERNANCE.md
+++ b/governance/GOVERNANCE.md
@@ -60,7 +60,7 @@ Open a GitHub issue with:
 - Problem statement
 - Proposed solution
 - 3+ real-app motivations from the [catalog](../catalog/)
-- Self-assessment against P-1 through P-14
+- Self-assessment against P-1 through P-14 — required for spec proposals. Process, documentation, and catalog-fix changes state that no principle applies instead of force-fitting citations; P-1 through P-14 govern the Launchfile format, not project process.
 
 ### 2. AI Evaluation
 
@@ -88,6 +88,22 @@ Output: **ACCEPT** / **REJECT** / **DEFER** with structured reasoning.
 
 - PR against SPEC.md + JSON Schema + examples
 - New D-\* entry in DESIGN.md documenting the decision
+
+### 5. Merge mechanics
+
+Every pull request into `main` must pass the `steward/review` status check plus the repository's required CI checks. The `steward/review` check is named here because this document explains what it means; the CI check names are not, because they change as jobs are added or consolidated. The merge box on your PR always shows the current list.
+
+What the `steward/review` state in your PR's merge box means, and what to do:
+
+- **"Expected — waiting for status"** — this commit has not been reviewed yet. Merging is blocked until a review concludes.
+- **In progress** — a steward review is running.
+- **Green** — the steward accepted this exact commit.
+- **Red** — the review found blockers. Read the review and its inline suggestions; suggestions can be committed with one click.
+- **"Action required"** — an Author decision is pending. No verdict has been posted.
+
+The check binds to the head commit. Pushing new commits dismisses the previous review and returns the merge box to "Expected": the new commit is unreviewed, and that is expected behavior, not a malfunction.
+
+**Contributing from a fork:** a maintainer must approve each CI workflow run on a fork pull request before it starts. This is a supply-chain safety measure applied to all external contributors, not a judgment of the contribution. If your CI shows "workflows awaiting approval", a maintainer will act on it — no action is needed from you.
 
 ---
 

--- a/governance/GOVERNANCE.md
+++ b/governance/GOVERNANCE.md
@@ -99,7 +99,8 @@ What the `steward/review` state in your PR's merge box means, and what to do:
 - **In progress** — a steward review is running.
 - **Green** — the steward accepted this exact commit.
 - **Red** — the review found blockers. Read the review and its inline suggestions; suggestions can be committed with one click.
-- **"Action required"** — an Author decision is pending. No verdict has been posted.
+- **"Action required"** — the review did not reach a decision on this commit. Check the pull request conversation and the linked proposal issue: either a point is with the Authors to decide, or the review returned the PR to you as incomplete or already covered elsewhere — in that case the next move is yours.
+- **Cancelled** — a review started on this commit and stopped before reaching a decision. Merging stays blocked until a review concludes on your current commit; a maintainer re-runs it. If it stays cancelled, ask in a comment.
 
 The check binds to the head commit. Pushing new commits dismisses the previous review and returns the merge box to "Expected": the new commit is unreviewed, and that is expected behavior, not a malfunction.
 

--- a/governance/GOVERNANCE.md
+++ b/governance/GOVERNANCE.md
@@ -91,7 +91,7 @@ Output: **ACCEPT** / **REJECT** / **DEFER** with structured reasoning.
 
 ### 5. Merge mechanics
 
-Every pull request into `main` must pass the `steward/review` status check plus the repository's required CI checks. The `steward/review` check is named here because this document explains what it means; the CI check names are not, because they change as jobs are added or consolidated. The merge box on your PR always shows the current list.
+Every pull request into `main` must pass the `steward/review` status check plus the repository's required CI checks. The merge box on your PR always shows the current list.
 
 What the `steward/review` state in your PR's merge box means, and what to do:
 


### PR DESCRIPTION
Closes #310.

Documents the contributor-facing merge process and aligns proposal requirements across the docs:

- `governance/GOVERNANCE.md` gains §5 "Merge mechanics": every PR into `main` requires the `steward/review` check plus the repository's required CI checks; what each merge-box state means and what to do; pushing new commits returns the check to "Expected" (the new commit is unreviewed — expected behavior, not a malfunction); fork PRs wait for a maintainer to approve CI runs.
- The P-1..P-14 self-assessment is scoped to spec proposals — process, documentation, and catalog-fix changes state that no principle applies. The same rule now appears identically in GOVERNANCE.md §1, the new PR template, and the spec-proposal issue template.
- New `.github/PULL_REQUEST_TEMPLATE.md` with the draft-first convention and checklist.
- Template fixes: principle count 13 → 14, and the GOVERNANCE.md link now points at `governance/`.

Addresses the steward verdict on #310: CI check names are not listed (they change as jobs are consolidated — the merge box shows the live list).
