### PR TITLE
catalog+spec: listmonk release command, rallly and glance health checks

### DIFF
--- a/catalog/apps/glance/Launchfile
+++ b/catalog/apps/glance/Launchfile
@@ -14,4 +14,5 @@ storage:
   config:
     path: /app/data
     persistent: true
+health: /api/healthz
 restart: always

--- a/catalog/apps/listmonk/Launchfile
+++ b/catalog/apps/listmonk/Launchfile
@@ -29,5 +29,10 @@ env:
     generator: secret
     sensitive: true
     description: "Admin password"
-health: /api/health
+  LISTMONK_db__ssl_mode:
+    default: "disable"
+    description: "Postgres SSL mode. listmonk sets no default and omits empty fields from the DSN, so without this the release command connects with sslmode unset"
+commands:
+  release: "./listmonk --install --idempotent --yes --config '' && ./listmonk --upgrade --yes --config ''"
+health: /health
 restart: always

--- a/catalog/apps/listmonk/metadata.yaml
+++ b/catalog/apps/listmonk/metadata.yaml
@@ -2,18 +2,18 @@ category: Email
 tagline: High-performance self-hosted newsletter and mailing list manager
 homepage: https://listmonk.app
 test_results:
-  last_tested: 2026-04-08
-  pull_time_seconds: 3
-  startup_time_seconds: 8
-  total_disk_mb: 292
-  health_check_passed: true
-  notes: ""
+  last_tested: 2026-08-28
+  pull_time_seconds: 2
+  startup_time_seconds: 7
+  total_disk_mb: 123
+  health_check_passed: false
+  notes: Harness result only. The harness does not execute commands.release, so listmonk starts over an uninstalled schema and never serves. Verified passing with the reference Docker provider, which does run release (D-48).
 images:
   - name: listmonk/listmonk:latest
-    size_mb: 33
+    size_mb: 14
     platform:
       - linux/arm64
   - name: postgres:16-alpine
-    size_mb: 259
+    size_mb: 109
     platform:
       - linux/arm64

--- a/catalog/apps/rallly/Launchfile
+++ b/catalog/apps/rallly/Launchfile
@@ -20,4 +20,5 @@ env:
     sensitive: true
   NEXT_PUBLIC_BASE_URL:
     default: "http://localhost:3000"
+health: /api/status
 restart: always

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -451,6 +451,8 @@ Platforms execute well-known commands in this order: **build → release → sta
 | `seed` | Seed the database with initial data | On demand (first deploy or explicit trigger) |
 | `test` | Run the test suite | On demand (CI or explicit trigger) |
 
+One-time initialization that must complete before the app serves (schema install, first-run setup) belongs in `release`. Guard it with the app's own idempotent flags (install-if-needed) so it is safe to run on every deploy — the same idempotency recommendation the spec makes for [bootstrap](#bootstrap-stage). The stakes differ: `bootstrap` is user-invoked and non-deploy-failing, while `release` runs automatically on every deploy and a non-zero exit fails that deploy.
+
 Additional named commands are allowed and invoked on demand.
 
 ```yaml


### PR DESCRIPTION
Two commits.

## `catalog:` — listmonk did not deploy; two apps had no health check

**listmonk was broken three ways.** All observed with the reference Docker provider (Docker Desktop 29.7.2, `listmonk/listmonk:latest` v6.2.0, linux/arm64) — not inferred from source:

| Defect | Evidence | Fix |
|---|---|---|
| No `release`, so the schema is never installed | `main.go:159: the database does not appear to be setup. Run --install.` repeating in a restart loop until the 120s health gate expires — this is `main` today | `commands.release` running listmonk's own documented install/upgrade |
| `--config ''` reads config from env only; listmonk sets no `db.ssl_mode` default and omits empty fields from the DSN (`cmd/init.go`), so `sslmode` never reaches the connection string | release exits 1 on `pq: SSL is not enabled on the server` | `LISTMONK_db__ssl_mode: disable`, which upstream's own compose pairs with the same command |
| `health: /api/health` sits behind the auth middleware (`cmd/handlers.go`) | `403 {"message":"invalid session"}` | `health: /health`, upstream's "Public health API endpoint" |

Verified end to end: release completes, the health gate passes, `GET /health` returns `200 {"data":true}`, `GET /admin/login` returns `200`. A redeploy over the installed database logs `skipping install as database appears to be already setup` and `no upgrades to run`, and exits 0 — which is what `--idempotent` buys, and the claim the spec paragraph makes.

`metadata.yaml` is a fresh harness record. It reads `health_check_passed: false` because the catalog harness drops `commands.release` (no reference to it anywhere in `catalog/test/src`), so it reproduces the very crash loop this PR fixes. Only `notes` is hand-edited, to say so.

**rallly** — `health: /api/status`. Upstream defines an unauthenticated `GET /api/status` (`apps/web/src/app/api/status/route.ts`); its own compose health-checks only the DB. Verified live: `200`, `"database":"connected"`.

**glance** — `health: /api/healthz`. Upstream registers it (`internal/glance/glance.go:458`). **Not verified live:** the entry mounts its volume at `/app/data` while the image entrypoint is `--config /app/config/glance.yml`, so glance crash-loops before it serves. That is a separate pre-existing defect, not touched here.

## `spec:` — make the release-stage init pattern legible

One paragraph in SPEC's Commands section. One-time initialization that must complete before the app serves belongs in `release`, guarded by the app's own idempotent flags so it is safe to run on every deploy.

It states `release`'s own failure semantics rather than borrowing `bootstrap`'s. Both stages carry the same idempotency recommendation, but D-48 separated them on disposition: `bootstrap` is user-invoked and non-deploy-failing, while `release` runs automatically and a non-zero exit fails the deploy.

listmonk is the worked example, and the first `catalog/apps/` entry to declare `release`.

Kept as two commits, one top-level directory each, per the repo's commit convention.
