### PR TITLE
fix(docker): mount a backing service's volume where it keeps its data

### DIFF
--- a/.changeset/proud-buckets-attack.md
+++ b/.changeset/proud-buckets-attack.md
@@ -7,3 +7,5 @@ A backing service's volume is mounted where that service actually stores its dat
 **Behavior change:** an app already running a non-redis backing service gets a different compose file, and its containers recreate on the next `up` with the volume mounted at the real data path. Data written before the upgrade lives in an anonymous volume and does not survive that recreate — it would not have survived any other `down` either. Back up anything you need (`docker compose exec <service> pg_dump …`) before upgrading a deployment whose data you care about.
 
 The data path is a required field on each service definition, so a type added later cannot silently inherit a wrong default.
+
+One consequence for postgres: `config.extensions` is applied by an init script that postgres runs only when its data directory is empty. Now that the data directory persists, adding an extension to a deployment that has already run does not apply it. Recreate that service's data volume, or add the extension by hand with `CREATE EXTENSION`.

--- a/.changeset/proud-buckets-attack.md
+++ b/.changeset/proud-buckets-attack.md
@@ -1,0 +1,9 @@
+---
+"@launchfile/docker": patch
+---
+
+A backing service's volume is mounted where that service actually stores its data. Every `requires:`-provisioned service was given `<name>-data:/data` regardless of type — correct for redis, minio and s3, wrong for every other type this provider can provision. These images declare their own `VOLUME`, so Docker mounted an anonymous volume at the real data path and the named `<name>-data` volume sat at `/data` holding nothing. `docker compose down` discards anonymous volumes, so a `requires: postgres` app came back from `up`, `down`, `up` with an empty database — while `down` printed "Data volumes preserved." The paths now used are each image's own declared `VOLUME`: postgres `/var/lib/postgresql/data`, mysql and mariadb `/var/lib/mysql`, mongodb `/data/db`, clickhouse `/var/lib/clickhouse`, rabbitmq `/var/lib/rabbitmq`, elasticsearch `/usr/share/elasticsearch/data` (its image declares none; this is `path.data` under the image's WORKDIR). `memcache` is in-memory and now gets no volume at all instead of an unused one.
+
+**Behavior change:** an app already running a non-redis backing service gets a different compose file, and its containers recreate on the next `up` with the volume mounted at the real data path. Data written before the upgrade lives in an anonymous volume and does not survive that recreate — it would not have survived any other `down` either. Back up anything you need (`docker compose exec <service> pg_dump …`) before upgrading a deployment whose data you care about.
+
+The data path is a required field on each service definition, so a type added later cannot silently inherit a wrong default.

--- a/providers/docker/src/__tests__/backing-data-path.test.ts
+++ b/providers/docker/src/__tests__/backing-data-path.test.ts
@@ -1,0 +1,86 @@
+/**
+ * A backing service's volume must be mounted where that service actually keeps
+ * its state. Mounted anywhere else it persists nothing, and silently: these
+ * images declare their own VOLUME, so Docker mounts an anonymous volume at the
+ * real path and `compose down` discards it, while the named volume survives
+ * holding whatever the service never wrote there.
+ *
+ * The expected paths below are each image's own declared VOLUME (elasticsearch
+ * excepted — it declares none, so its documented `path.data` stands in). Change
+ * one only against the image, never to make a test pass.
+ */
+
+import { readLaunch } from "@launchfile/sdk";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import { launchToCompose } from "../compose-generator.js";
+
+interface ComposeDoc {
+	services: Record<string, { volumes?: string[] }>;
+	volumes?: Record<string, unknown>;
+}
+
+const app = (type: string) => `
+name: app
+image: acme/app:1
+provides:
+  - { protocol: http, port: 3000, exposed: true }
+requires:
+  - type: ${type}
+`;
+
+const composeFor = (type: string): ComposeDoc =>
+	parse(launchToCompose(readLaunch(app(type))).yaml) as ComposeDoc;
+
+/** Resource type → the path that type's image stores its state at. */
+const DATA_PATHS: Record<string, string> = {
+	postgres: "/var/lib/postgresql/data",
+	mysql: "/var/lib/mysql",
+	mariadb: "/var/lib/mysql",
+	mongodb: "/data/db",
+	redis: "/data",
+	clickhouse: "/var/lib/clickhouse",
+	elasticsearch: "/usr/share/elasticsearch/data",
+	minio: "/data",
+	s3: "/data",
+	rabbitmq: "/var/lib/rabbitmq",
+};
+
+describe("backing service data paths", () => {
+	for (const [type, dataPath] of Object.entries(DATA_PATHS)) {
+		it(`mounts ${type}'s volume at ${dataPath}`, () => {
+			const doc = composeFor(type);
+			const service = doc.services[`app-${type}`];
+			expect(service?.volumes).toEqual([`app-${type}-data:${dataPath}`]);
+			expect(doc.volumes).toHaveProperty(`app-${type}-data`);
+		});
+	}
+
+	it("emits no volume for a service that holds nothing", () => {
+		const doc = composeFor("memcache");
+		expect(doc.services["app-memcache"]?.volumes).toBeUndefined();
+		expect(doc.volumes ?? {}).not.toHaveProperty("app-memcache-data");
+	});
+
+	it("keeps the data path when a declared extension swaps the image", () => {
+		const doc = parse(
+			launchToCompose(
+				readLaunch(`
+name: app
+image: acme/app:1
+provides:
+  - { protocol: http, port: 3000, exposed: true }
+requires:
+  - type: postgres
+    config:
+      extensions: [pgvector]
+`),
+			).yaml,
+		) as ComposeDoc & { services: Record<string, { image?: string }> };
+
+		expect(doc.services["app-postgres"]?.image).toBe("pgvector/pgvector:pg16");
+		expect(doc.services["app-postgres"]?.volumes).toEqual([
+			"app-postgres-data:/var/lib/postgresql/data",
+		]);
+	});
+});

--- a/providers/docker/src/compose-generator.ts
+++ b/providers/docker/src/compose-generator.ts
@@ -34,6 +34,17 @@ import type { StateEndpoint } from "./state.js";
 
 interface BackingService {
 	image: string;
+	/**
+	 * Where this service keeps its state INSIDE the container — the path the
+	 * generated volume is mounted at. Every value below is the image's own
+	 * declared VOLUME, read from its config rather than from memory.
+	 *
+	 * `null` means the service holds no state worth a volume (a cache), and no
+	 * volume is emitted for it. Required rather than optional on purpose: a new
+	 * factory that forgets it fails to compile, where a default would silently
+	 * mount the wrong path and lose the data the volume exists to keep.
+	 */
+	dataPath: string | null;
 	environment: Record<string, string>;
 	properties: Record<string, string>;
 	healthcheck?: ComposeHealthcheck;
@@ -204,6 +215,7 @@ function createBackingServices(
 			const pw = getPassword("postgres");
 			return {
 				image: "postgres:16-alpine",
+				dataPath: "/var/lib/postgresql/data",
 				environment: {
 					POSTGRES_USER: "launchfile",
 					POSTGRES_PASSWORD: pw,
@@ -230,6 +242,7 @@ function createBackingServices(
 			const pw = getPassword("mysql");
 			return {
 				image: "mysql:8",
+				dataPath: "/var/lib/mysql",
 				environment: {
 					MYSQL_ROOT_PASSWORD: pw,
 					MYSQL_USER: "launchfile",
@@ -257,6 +270,7 @@ function createBackingServices(
 			const pw = getPassword("mariadb");
 			return {
 				image: "mariadb:11",
+				dataPath: "/var/lib/mysql",
 				environment: {
 					MARIADB_ROOT_PASSWORD: pw,
 					MARIADB_USER: "launchfile",
@@ -282,6 +296,7 @@ function createBackingServices(
 
 		redis: (_name) => ({
 			image: "redis:7-alpine",
+			dataPath: "/data",
 			environment: {},
 			properties: {
 				host: `${_name}-redis`,
@@ -304,6 +319,9 @@ function createBackingServices(
 			const pw = getPassword("mongodb");
 			return {
 				image: "mongo:7",
+				// The image also declares /data/configdb; a single-node deployment keeps its
+				// metadata alongside its data.
+				dataPath: "/data/db",
 				environment: {
 					MONGO_INITDB_ROOT_USERNAME: "launchfile",
 					MONGO_INITDB_ROOT_PASSWORD: pw,
@@ -327,6 +345,7 @@ function createBackingServices(
 
 		clickhouse: (name) => ({
 			image: "clickhouse/clickhouse-server:latest",
+			dataPath: "/var/lib/clickhouse",
 			environment: {},
 			properties: {
 				// The image's shipped defaults: the `default` user with an empty
@@ -352,6 +371,10 @@ function createBackingServices(
 			const pw = getPassword("elasticsearch");
 			return {
 				image: "elasticsearch:8.17.0",
+				// The one entry not taken from a VOLUME declaration: this image declares none. It
+				// is `path.data` under the image's WORKDIR, which is what Elastic's own container
+				// documentation mounts.
+				dataPath: "/usr/share/elasticsearch/data",
 				environment: {
 					"discovery.type": "single-node",
 					"xpack.security.enabled": "true",
@@ -382,6 +405,8 @@ function createBackingServices(
 			const secretKey = getPassword("minio-secret");
 			return {
 				image: "minio/minio:latest",
+				// Matches the `server /data` command below.
+				dataPath: "/data",
 				environment: {
 					MINIO_ROOT_USER: accessKey,
 					MINIO_ROOT_PASSWORD: secretKey,
@@ -415,6 +440,8 @@ function createBackingServices(
 			const secretKey = getPassword("s3-secret");
 			return {
 				image: "minio/minio:latest",
+				// Matches the `server /data` command below.
+				dataPath: "/data",
 				environment: {
 					MINIO_ROOT_USER: accessKey,
 					MINIO_ROOT_PASSWORD: secretKey,
@@ -445,6 +472,8 @@ function createBackingServices(
 
 		memcache: (_name) => ({
 			image: "memcached:1-alpine",
+			// In-memory by design: no volume.
+			dataPath: null,
 			environment: {},
 			properties: {
 				host: `${_name}-memcache`,
@@ -465,6 +494,7 @@ function createBackingServices(
 			const pw = getPassword("rabbitmq");
 			return {
 				image: "rabbitmq:3-alpine",
+				dataPath: "/var/lib/rabbitmq",
 				environment: {
 					RABBITMQ_DEFAULT_USER: "launchfile",
 					RABBITMQ_DEFAULT_PASS: pw,
@@ -1454,9 +1484,11 @@ function addBackingService(
 			Object.assign(service, backing.extra);
 		}
 
-		const volName = `${serviceName}-data`;
-		service.volumes = [`${volName}:/data`];
-		volumes[volName] = {};
+		if (backing.dataPath !== null) {
+			const volName = `${serviceName}-data`;
+			service.volumes = [`${volName}:${backing.dataPath}`];
+			volumes[volName] = {};
+		}
 
 		services[serviceName] = service;
 	}


### PR DESCRIPTION
## What

Each backing-service factory in the docker provider now declares a `dataPath`
— where that image keeps its state — and `addBackingService` mounts the named
volume there instead of at a hardcoded `/data`. `memcache` declares `null` and
gets no volume at all.

| type | mounted at |
|---------------|--------------------------------|
| postgres | `/var/lib/postgresql/data` |
| mysql, mariadb| `/var/lib/mysql` |
| mongodb | `/data/db` |
| clickhouse | `/var/lib/clickhouse` |
| rabbitmq | `/var/lib/rabbitmq` |
| elasticsearch | `/usr/share/elasticsearch/data` |
| redis, minio, s3 | `/data` (unchanged) |
| memcache | no volume |

Every path is the image's own declared `VOLUME`, read from `docker image
inspect`:

| image | declared `VOLUME` | used |
|---|---|---|
| `postgres:16-alpine` | `/var/lib/postgresql/data` | same |
| `mysql:8` | `/var/lib/mysql` | same |
| `mariadb:11` | `/var/lib/mysql` | same |
| `redis:7-alpine` | `/data` | same |
| `mongo:7` | `/data/configdb`, `/data/db` | `/data/db` |
| `clickhouse/clickhouse-server:latest` | `/var/lib/clickhouse` | same |
| `minio/minio:latest` | `/data` | same |
| `rabbitmq:3-alpine` | `/var/lib/rabbitmq` | same |
| `elasticsearch:8.17.0` | *none* | `/usr/share/elasticsearch/data` |
| `memcached:1-alpine` | *none* | no volume |

Elasticsearch is the exception: its image declares none, so `path.data` under
the image's WORKDIR stands in. The field is required, not optional, so a type
added later cannot inherit a wrong default in silence.

## Why

Closes #270.

The issue says the data lived in the container's writable layer. It does not —
the mechanism is worse and quieter. These images declare their own `VOLUME`,
so Docker mounted an **anonymous** volume at the real data path while the named
`<name>-data` volume sat at `/data` holding nothing. `docker compose down`
discards anonymous volumes by default and keeps named ones, so the app came back
empty while the volume that looked like persistence survived intact.

Verified live, both arms, `up` → write a row → `down` (no `--destroy`) → `up` →
read back, on a real `requires: [postgres]` app:

- **at `origin/main`** — `docker inspect` shows two mounts,
  `…-postgres-data -> /data` and `c17add6e… -> /var/lib/postgresql/data`.
  Read-back fails: `relation "survivors" does not exist`. **Data lost.**
- **on this branch** — one mount,
  `…-postgres-data -> /var/lib/postgresql/data`. Row read back verbatim.
  **Data survived.**

`down` without `--destroy` prints "Data volumes preserved."
unconditionally (`providers/docker/src/provider.ts:748`) — it said so on the
run that lost the data.

## Not in this PR

`catalog/test/src/launch-to-compose.ts:698` reimplements this generator and
still hardcodes `:/data`. It is not a second instance of this bug: that harness
brings an app up, screenshots it, and tears it down with `down -v`
(`catalog/test/src/test-app.ts:277`), so nothing is expected to persist and the
wrong mount path costs nothing. What it is, is one more place the
reimplementation has drifted from the real generator — which is #230, and the
fix there is deleting the duplication rather than patching the copy.

## Checklist

- [x] CI is green — `tsc --noEmit` clean, `bun run test` 26 files / 352 tests
      passing in `providers/docker`
- [ ] Spec change? — no
- [x] Not a spec change? No principle applies: this is a provider bug fix, not
      a format change. Nothing in `spec/DESIGN.md` speaks to container mount
      paths.
