### PR TITLE
fix: correct the anonymous-volume mechanism in the #316 data-path note

### DIFF
--- a/.changeset/proud-buckets-attack.md
+++ b/.changeset/proud-buckets-attack.md
@@ -6,7 +6,7 @@ A backing service's volume is mounted where that service actually stores its dat
 
 **Behavior change:** an app already running a non-redis backing service gets a different compose file, and its containers recreate on the next `up` with the volume mounted at the real data path.
 
-**Data written before this fix is not lost.** Each earlier `up` left it in an anonymous volume that is orphaned, not deleted. Recover it before upgrading:
+**Data written before this fix is not lost.** Each earlier `up` left it in an anonymous volume that is orphaned, not deleted. Recover it before upgrading. The commands below are the postgres case; every other affected type follows the same three steps — find the dangling volume, mount it into a throwaway container of that service's own image at that type's data path listed above, then dump it with that service's own tool (`mysqldump` for mysql and mariadb, `mongodump` for mongodb, and so on):
 
 ```sh
 docker volume ls -f dangling=true            # find the orphan
@@ -17,7 +17,7 @@ docker exec lf-recover pg_dump -U launchfile <app-name> > backup.sql
 docker rm -f lf-recover
 ```
 
-If the deployment set `config.extensions`, it ran a dedicated image (pgvector, postgis) rather than stock postgres — use that image in the recovery container, since the data directory belongs to it.
+If the deployment declared the `vector` (`pgvector`) or `postgis` extension in `config.extensions`, it ran a dedicated image — `pgvector/pgvector:pg16` or `postgis/postgis:16-3.4` — rather than stock postgres. Use that image in the recovery container, since the data directory belongs to it. Any other extension leaves the service on stock `postgres:16-alpine`, so the command above is already correct as written.
 
 The upgrade itself does not touch the orphaned volume, and neither does `launchfile down --destroy`. That command runs `docker compose down -v --remove-orphans`: `-v` removes the named volumes plus the anonymous volumes attached to the containers being removed, and the orphan is attached to nothing, while `--remove-orphans` removes orphaned containers, not volumes. `docker volume prune` does remove the orphan, because it is dangling — recover it before you prune.
 

--- a/.changeset/proud-buckets-attack.md
+++ b/.changeset/proud-buckets-attack.md
@@ -4,7 +4,7 @@
 
 A backing service's volume is mounted where that service actually stores its data. Every `requires:`-provisioned service was given `<name>-data:/data` regardless of type — correct for redis, minio and s3, wrong for every other type this provider can provision. These images declare their own `VOLUME`, so Docker mounted an anonymous volume at the real data path and the named `<name>-data` volume sat at `/data` holding nothing. `docker compose down` removes the container, and the next `up` builds a new one with a new anonymous volume — so a `requires: postgres` app came back from `up`, `down`, `up` with an empty database, while `down` printed "Data volumes preserved." The paths now used are each image's own declared `VOLUME`: postgres `/var/lib/postgresql/data`, mysql and mariadb `/var/lib/mysql`, mongodb `/data/db`, clickhouse `/var/lib/clickhouse`, rabbitmq `/var/lib/rabbitmq`, elasticsearch `/usr/share/elasticsearch/data` (its image declares none; this is `path.data` under the image's WORKDIR). `memcache` is in-memory and now gets no volume at all instead of an unused one.
 
-**Behavior change:** an app already running a non-redis backing service gets a different compose file, and its containers recreate on the next `up` with the volume mounted at the real data path. 
+**Behavior change:** an app already running a non-redis backing service gets a different compose file, and its containers recreate on the next `up` with the volume mounted at the real data path.
 
 **Data written before this fix is not lost.** Each earlier `up` left it in an anonymous volume that is orphaned, not deleted. Recover it before upgrading:
 
@@ -17,7 +17,9 @@ docker exec lf-recover pg_dump -U launchfile <app-name> > backup.sql
 docker rm -f lf-recover
 ```
 
-The upgrade itself does not touch the orphaned volume, but `launchfile down --destroy` and `docker volume prune` both remove it.
+If the deployment set `config.extensions`, it ran a dedicated image (pgvector, postgis) rather than stock postgres — use that image in the recovery container, since the data directory belongs to it.
+
+The upgrade itself does not touch the orphaned volume, and neither does `launchfile down --destroy`. That command runs `docker compose down -v --remove-orphans`: `-v` removes the named volumes plus the anonymous volumes attached to the containers being removed, and the orphan is attached to nothing, while `--remove-orphans` removes orphaned containers, not volumes. `docker volume prune` does remove the orphan, because it is dangling — recover it before you prune.
 
 The data path is a required field on each service definition, so a type added later cannot silently inherit a wrong default.
 

--- a/.changeset/proud-buckets-attack.md
+++ b/.changeset/proud-buckets-attack.md
@@ -2,9 +2,22 @@
 "@launchfile/docker": patch
 ---
 
-A backing service's volume is mounted where that service actually stores its data. Every `requires:`-provisioned service was given `<name>-data:/data` regardless of type — correct for redis, minio and s3, wrong for every other type this provider can provision. These images declare their own `VOLUME`, so Docker mounted an anonymous volume at the real data path and the named `<name>-data` volume sat at `/data` holding nothing. `docker compose down` discards anonymous volumes, so a `requires: postgres` app came back from `up`, `down`, `up` with an empty database — while `down` printed "Data volumes preserved." The paths now used are each image's own declared `VOLUME`: postgres `/var/lib/postgresql/data`, mysql and mariadb `/var/lib/mysql`, mongodb `/data/db`, clickhouse `/var/lib/clickhouse`, rabbitmq `/var/lib/rabbitmq`, elasticsearch `/usr/share/elasticsearch/data` (its image declares none; this is `path.data` under the image's WORKDIR). `memcache` is in-memory and now gets no volume at all instead of an unused one.
+A backing service's volume is mounted where that service actually stores its data. Every `requires:`-provisioned service was given `<name>-data:/data` regardless of type — correct for redis, minio and s3, wrong for every other type this provider can provision. These images declare their own `VOLUME`, so Docker mounted an anonymous volume at the real data path and the named `<name>-data` volume sat at `/data` holding nothing. `docker compose down` removes the container, and the next `up` builds a new one with a new anonymous volume — so a `requires: postgres` app came back from `up`, `down`, `up` with an empty database, while `down` printed "Data volumes preserved." The paths now used are each image's own declared `VOLUME`: postgres `/var/lib/postgresql/data`, mysql and mariadb `/var/lib/mysql`, mongodb `/data/db`, clickhouse `/var/lib/clickhouse`, rabbitmq `/var/lib/rabbitmq`, elasticsearch `/usr/share/elasticsearch/data` (its image declares none; this is `path.data` under the image's WORKDIR). `memcache` is in-memory and now gets no volume at all instead of an unused one.
 
-**Behavior change:** an app already running a non-redis backing service gets a different compose file, and its containers recreate on the next `up` with the volume mounted at the real data path. Data written before the upgrade lives in an anonymous volume and does not survive that recreate — it would not have survived any other `down` either. Back up anything you need (`docker compose exec <service> pg_dump …`) before upgrading a deployment whose data you care about.
+**Behavior change:** an app already running a non-redis backing service gets a different compose file, and its containers recreate on the next `up` with the volume mounted at the real data path. 
+
+**Data written before this fix is not lost.** Each earlier `up` left it in an anonymous volume that is orphaned, not deleted. Recover it before upgrading:
+
+```sh
+docker volume ls -f dangling=true            # find the orphan
+docker run -d --name lf-recover \
+  -v <volume-id>:/var/lib/postgresql/data \
+  -e POSTGRES_PASSWORD=unused postgres:16-alpine
+docker exec lf-recover pg_dump -U launchfile <app-name> > backup.sql
+docker rm -f lf-recover
+```
+
+The upgrade itself does not touch the orphaned volume, but `launchfile down --destroy` and `docker volume prune` both remove it.
 
 The data path is a required field on each service definition, so a type added later cannot silently inherit a wrong default.
 

--- a/providers/docker/src/__tests__/backing-data-path.test.ts
+++ b/providers/docker/src/__tests__/backing-data-path.test.ts
@@ -1,9 +1,11 @@
 /**
  * A backing service's volume must be mounted where that service actually keeps
  * its state. Mounted anywhere else it persists nothing, and silently: these
- * images declare their own VOLUME, so Docker mounts an anonymous volume at the
- * real path and `compose down` discards it, while the named volume survives
- * holding whatever the service never wrote there.
+ * images declare their own VOLUME, so Docker attaches an anonymous volume at
+ * the real path. `compose down` removes the container, the next `up` builds a
+ * new one with a new anonymous volume, and the previous one is left orphaned —
+ * while the named volume survives holding whatever the service never wrote to
+ * it.
  *
  * The expected paths below are each image's own declared VOLUME (elasticsearch
  * excepted — it declares none, so its documented `path.data` stands in). Change


### PR DESCRIPTION
## What

Two text corrections to what #316 landed. No behavior change — the fix in
#316 is right, its explanation of the old failure was not.

1. `.changeset/proud-buckets-attack.md` — replaces the "back up before you
   upgrade" warning with the recovery procedure.
2. `providers/docker/src/__tests__/backing-data-path.test.ts` — same
   correction in the header comment.

## Why

#316 said `docker compose down` "discards anonymous volumes," and told
operators that data written before the fix "does not survive." Both are wrong,
and the changeset is not yet released (#318 is still open), so this lands
before the note reaches a CHANGELOG.

`compose down` removes the **container**. The next `up` builds a new container
with a **new** anonymous volume; the previous one is orphaned on disk, not
deleted. Observed on a pre-fix `requires: [postgres]` app:

    run 1   5e2e7723…  -> /var/lib/postgresql/data
    run 2   eecc79ab…  -> /var/lib/postgresql/data    (different volume)

    $ docker volume inspect 5e2e7723…     # still resolves after `down`

So the data is recoverable. Verified end to end — write a row, `up`/`down`/`up`
until the relation is missing, then dump the row back out of the orphan:

    orphan present in `docker volume ls -f dangling=true`?  YES
    pg_dump off a throwaway postgres mounted on it:          1060 bytes
    contains the row written before the down?                YES

The changeset now carries those commands. This matters more than the wording:
an operator who has already lost a database reads a release note to find out
what to do, and "back up before upgrading" is advice that arrives too late to
act on.

## Note

The merged commit message on `0a94497` carries the same wrong mechanism. That
is published history and this PR does not touch it.

## Checklist

- [x] CI is green — `tsc --noEmit` clean, `bun run test` 26 files / 352 tests
      passing in `providers/docker`
- [ ] Spec change? — no
- [x] Not a spec change? No principle applies: this corrects a changeset note
      and a test comment.
