### PR TITLE
spec+www-dev: state the D-48 duration grammar in the schema field descriptions

### DIFF
--- a/spec/schema/launchfile.schema.json
+++ b/spec/schema/launchfile.schema.json
@@ -302,10 +302,10 @@
       "properties": {
         "path": { "type": "string", "description": "HTTP path to check" },
         "command": { "type": "string", "description": "Command for non-HTTP checks. If both path and command are present, path takes precedence." },
-        "interval": { "type": "string", "description": "Check interval (e.g., '30s')" },
-        "timeout": { "type": "string", "description": "Timeout per check" },
+        "interval": { "type": "string", "description": "Check interval — a duration: an integer immediately followed by one unit ms|s|m|h, e.g. '30s'. No spaces, no compound values like '1m30s' (D-48)." },
+        "timeout": { "type": "string", "description": "Timeout per check — a duration: an integer immediately followed by one unit ms|s|m|h, e.g. '5s'. No spaces, no compound values like '1m30s' (D-48)." },
         "retries": { "type": "integer", "minimum": 1, "description": "Failures before unhealthy" },
-        "start_period": { "type": "string", "description": "Grace period before failures count" }
+        "start_period": { "type": "string", "description": "Grace period before failures count — a duration: an integer immediately followed by one unit ms|s|m|h, e.g. '30s'. No spaces, no compound values like '1m30s' (D-48)." }
       },
       "additionalProperties": false
     },
@@ -320,7 +320,7 @@
       "required": ["command"],
       "properties": {
         "command": { "type": "string" },
-        "timeout": { "type": "string" },
+        "timeout": { "type": "string", "description": "Command timeout — a duration: an integer immediately followed by one unit ms|s|m|h, e.g. '5m'. No spaces, no compound values like '1m30s' (D-48)." },
         "capture": {
           "type": "object",
           "description": "Named captures extracted from this command's stdout via regex (D-34). Supersedes the top-level outputs: placement from D-23.",

--- a/www-dev/public/schema/v1
+++ b/www-dev/public/schema/v1
@@ -302,10 +302,10 @@
       "properties": {
         "path": { "type": "string", "description": "HTTP path to check" },
         "command": { "type": "string", "description": "Command for non-HTTP checks. If both path and command are present, path takes precedence." },
-        "interval": { "type": "string", "description": "Check interval (e.g., '30s')" },
-        "timeout": { "type": "string", "description": "Timeout per check" },
+        "interval": { "type": "string", "description": "Check interval — a duration: an integer immediately followed by one unit ms|s|m|h, e.g. '30s'. No spaces, no compound values like '1m30s' (D-48)." },
+        "timeout": { "type": "string", "description": "Timeout per check — a duration: an integer immediately followed by one unit ms|s|m|h, e.g. '5s'. No spaces, no compound values like '1m30s' (D-48)." },
         "retries": { "type": "integer", "minimum": 1, "description": "Failures before unhealthy" },
-        "start_period": { "type": "string", "description": "Grace period before failures count" }
+        "start_period": { "type": "string", "description": "Grace period before failures count — a duration: an integer immediately followed by one unit ms|s|m|h, e.g. '30s'. No spaces, no compound values like '1m30s' (D-48)." }
       },
       "additionalProperties": false
     },
@@ -320,7 +320,7 @@
       "required": ["command"],
       "properties": {
         "command": { "type": "string" },
-        "timeout": { "type": "string" },
+        "timeout": { "type": "string", "description": "Command timeout — a duration: an integer immediately followed by one unit ms|s|m|h, e.g. '5m'. No spaces, no compound values like '1m30s' (D-48)." },
         "capture": {
           "type": "object",
           "description": "Named captures extracted from this command's stdout via regex (D-34). Supersedes the top-level outputs: placement from D-23.",


### PR DESCRIPTION
## What

Updates the four duration-shaped field descriptions in the JSON Schema so they state the D-48 grammar (`^(\d+)(ms|s|m|h)$`) instead of the pre-D-48 wording:

- `health.interval`
- `health.timeout`
- `health.start_period`
- `commands.<name>.timeout` (previously had no description at all)

Patches **both** tracked copies identically — `spec/schema/launchfile.schema.json` and `www-dev/public/schema/v1` (the copy resolved by editors via the `# yaml-language-server: $schema=` line, `www-dev/src/pages/installation.astro:22`) — as two separate commits per the repo's one-commit-one-directory convention. Verified byte-identical after the edit:

```
$ diff spec/schema/launchfile.schema.json www-dev/public/schema/v1
$ echo $?
0
```

## How the verdict's bound shape was addressed

Per the [steward's ACCEPT verdict on #206](https://github.com/launchfile/launchfile/issues/206#issuecomment-5492610910):

1. **Both schema copies patched identically** — see diff above.
2. **Each description states the grammar's shape and what it rules out** (no spaces, no compound values like `1m30s`), citing `(D-48)` inline — the same pattern `commands.<name>.capture` already uses to cite `(D-34)`.
3. **No `pattern`/`format`/`enum`/`minLength` added**, `sdk/src/schema.ts` untouched, no new `D-*` entry — this applies D-48, it doesn't amend it. D-48 chose a `validate`-only warning on purpose (P-13); a schema keyword would turn it into a hard failure.
4. **No incorrect rationale carried forward** — this PR description doesn't repeat the issue's mistaken claim that a `pattern` would invalidate an existing whitespace-form catalog file (D-48 records that no catalog file uses a whitespace form; enforcement is deliberately warning-only).

## Verification

- `cd sdk && bun run typecheck` — clean.
- `cd sdk && bun run build && bun run test` (vitest) — 425/425 passing, including the existing byte-identity assertion between the two schema copies (`sdk/src/__tests__/deprecations.test.ts:128`).
- `bun test` (Bun's built-in runner) correctly refused with the repo's test-guard message, confirming CI's `vitest run` is what actually ran above.
- Description-only change — no field, type, or validation keyword changed, so no live `launchfile validate` behavior to observe; the existing suite's schema-identity and deprecation-warning coverage is the relevant regression check.

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)
