### PR TITLE
providers: mongo mounts only /data/db; document why /data/configdb stays anonymous

### DIFF
--- a/providers/docker/src/__tests__/backing-data-path.test.ts
+++ b/providers/docker/src/__tests__/backing-data-path.test.ts
@@ -58,6 +58,18 @@ describe("backing service data paths", () => {
 		});
 	}
 
+	it("mounts only /data/db for mongodb — /data/configdb is deliberately unmounted", () => {
+		// mongo:7 declares both /data/db and /data/configdb (`docker image
+		// inspect mongo:7 -f '{{json .Config.Volumes}}'`). Only /data/db is
+		// mounted: /data/configdb is written only by `mongod --configsvr`,
+		// which this provider never runs. See the mongodb factory in
+		// compose-generator.ts for the full rationale.
+		const doc = composeFor("mongodb");
+		expect(doc.services["app-mongodb"]?.volumes).toEqual([
+			"app-mongodb-data:/data/db",
+		]);
+	});
+
 	it("emits no volume for a service that holds nothing", () => {
 		const doc = composeFor("memcache");
 		expect(doc.services["app-memcache"]?.volumes).toBeUndefined();

--- a/providers/docker/src/compose-generator.ts
+++ b/providers/docker/src/compose-generator.ts
@@ -39,8 +39,10 @@ interface BackingService {
 	image: string;
 	/**
 	 * Where this service keeps its state INSIDE the container — the path the
-	 * generated volume is mounted at. Every value below is the image's own
-	 * declared VOLUME, read from its config rather than from memory.
+	 * generated volume is mounted at. Each value is a path from the image's own
+	 * config, read rather than assumed from memory. Where an image declares
+	 * more than one VOLUME, the factory's own comment says which are mounted
+	 * and why — see `mongodb` below for the one case this applies to today.
 	 *
 	 * `null` means the service holds no state worth a volume (a cache), and no
 	 * volume is emitted for it. Required rather than optional on purpose: a new
@@ -322,8 +324,13 @@ function createBackingServices(
 			const pw = getPassword("mongodb");
 			return {
 				image: "mongo:7",
-				// The image also declares /data/configdb; a single-node deployment keeps its
-				// metadata alongside its data.
+				// The image declares two volumes: /data/db and /data/configdb. Only
+				// /data/db is mounted here. /data/configdb is written only by
+				// `mongod --configsvr`, which this provider never runs, so it stays
+				// on an anonymous volume deliberately — not a gap in the #270
+				// invariant. If this factory ever runs mongo as a config server or
+				// in a sharded/replica-set topology, /data/configdb needs its own
+				// named volume at that point.
 				dataPath: "/data/db",
 				environment: {
 					MONGO_INITDB_ROOT_USERNAME: "launchfile",


### PR DESCRIPTION
Closes #322

## What was wrong

The mongo backing-service factory in `providers/docker/src/compose-generator.ts` mounted only `/data/db`, but its comment claimed `/data/configdb` was "kept alongside" the mounted data. It is not — mongo never writes anything there in this provider's configuration, so the comment told a reader the #270 no-anonymous-volumes invariant covered a path it does not.

## Evidence for the two-volume claim (verdict requirement 5)

The steward's ACCEPT verdict flagged this as the one fact it could not check without Docker. Ran it on this machine:

```
$ docker image inspect mongo:7 -f '{{json .Config.Volumes}}'
{"/data/configdb":{},"/data/db":{}}
```

Confirms `mongo:7` declares both `/data/configdb` and `/data/db` as VOLUMEs — the report's premise holds.

The author's earlier comment on the issue thread additionally showed `/data/configdb` is empty on a stock single-node `mongo:7` (nothing is lost today; the gap is in the invariant's documentation, not in anyone's data):

```
$ docker run -d --name mongoprobe mongo:7
$ docker exec mongoprobe sh -c "ls -A /data/configdb | wc -l"
0
```

## Fix (bound shape from the verdict — option 2, not a wider `dataPath`)

- Kept `dataPath` as a single string — did not widen it to `string | string[]`. No factory needs an array, and the type existing as a single required string is what makes a forgotten factory fail to compile.
- Replaced the wrong comment on the mongo factory (`compose-generator.ts:325-326` pre-change) with the rule that actually holds: the image declares two volumes, only `/data/db` is mounted, `/data/configdb` is written only by `mongod --configsvr`, which this provider never runs.
- Corrected the interface doc above `BackingService.dataPath` (`compose-generator.ts:41-43` pre-change), which promised "every value below is the image's own declared VOLUME" — true for one of mongo's two.
- Added a test in `backing-data-path.test.ts` asserting the generated mongo service has exactly one volume, ending in `:/data/db`, named so it states `/data/configdb` is deliberately unmounted.
- Kept the comment and test name greppable on `mongodb` and `/data/configdb` per requirement 6, so #323's proposed exception-list check can key off this recorded exception.
- Touched nothing outside `providers/docker`: no `spec/DESIGN.md` entry, no new `D-*` — per requirement 7, widening "every declared VOLUME must be mounted" into a spec-level rule is the Authors' call and out of scope here.

## Verified

- `bun run test` (vitest run) in `providers/docker`: 353/353 passed, including the new test.
- `bun run typecheck` in `providers/docker`: clean.
- `bun test` (bare Bun runner) in `providers/docker` correctly refuses with the `bun test` guard, confirming CI can't silently bypass vitest for this package.
- `docker image inspect mongo:7` run live on this machine (output above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
