### PR TITLE
sdk: warn on bare env: references with no resource to resolve against

### DIFF
--- a/.changeset/gov-lint-bare-prop-env.md
+++ b/.changeset/gov-lint-bare-prop-env.md
@@ -1,0 +1,5 @@
+---
+"@launchfile/sdk": minor
+---
+
+`lintLaunch` now warns on a bare `$prop` reference inside an `env:` value (#184). `env:` is evaluated with no resource in context, so `$host`/`${port:-5432}`-style references written there can never resolve against a resource the way the same syntax does in `set_env:` — they always fall through to their `:-default` fallback, or to an empty string when they have none, regardless of spelling. The check shares the `bareReferences()` helper already used by the D-46 known-property-vocabulary check, stays warn-only, and touches neither the resolver nor validation's `valid`/exit-code outcome. Command-string references (`commands.*.command`) fail the same way but are tracked separately in #227.

--- a/sdk/src/__tests__/lint.test.ts
+++ b/sdk/src/__tests__/lint.test.ts
@@ -289,6 +289,112 @@ components:
 	});
 });
 
+describe("lintLaunch — env: values reference no resource (#184)", () => {
+	it("warns on a bare reference in a literal env: value", () => {
+		const launch = readLaunch(`
+name: acme
+components:
+  api:
+    image: api:latest
+    env:
+      DB_HOST: $host
+`);
+		const warnings = lintLaunch(launch, { suppressPortabilityWarnings: true });
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toBe(
+			'components.api.env.DB_HOST: "$host" has no resource to resolve against — ' +
+				"env values are not evaluated in a resource's context, so it always resolves to an empty string",
+		);
+	});
+
+	it("warns on a bare reference in the expanded default: form", () => {
+		const launch = readLaunch(`
+name: acme
+components:
+  api:
+    image: api:latest
+    env:
+      DB_HOST:
+        default: $host
+        required: true
+`);
+		const warnings = lintLaunch(launch, { suppressPortabilityWarnings: true });
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain("components.api.env.DB_HOST:");
+	});
+
+	it("names the fallback instead of empty string when the reference carries one", () => {
+		const launch = readLaunch(`
+name: acme
+components:
+  api:
+    image: api:latest
+    env:
+      PORT: "\${port:-5432}"
+`);
+		const warnings = lintLaunch(launch, { suppressPortabilityWarnings: true });
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toBe(
+			'components.api.env.PORT: "$port" has no resource to resolve against — ' +
+				"env values are not evaluated in a resource's context, so the fallback " +
+				'"5432" is always used instead',
+		);
+	});
+
+	it("stays silent for reserved namespaces and cross-resource references", () => {
+		const launch = readLaunch(`
+name: acme
+components:
+  api:
+    image: api:latest
+    env:
+      PUBLIC_URL: $app.url
+      API_KEY: $secrets.api-key
+      CACHE_URL: $redis.url
+      DATA_DIR: $storage.data.path
+`);
+		expect(lintLaunch(launch, { suppressPortabilityWarnings: true })).toEqual([]);
+	});
+
+	it("stays silent for non-string defaults and plain literals", () => {
+		const launch = readLaunch(`
+name: acme
+components:
+  api:
+    image: api:latest
+    env:
+      DEBUG: false
+      RETRIES: 3
+      NAME: acme-api
+`);
+		expect(lintLaunch(launch, { suppressPortabilityWarnings: true })).toEqual([]);
+	});
+
+	it("names the top-level single-component as components.default", () => {
+		const launch = readLaunch(`
+name: acme
+image: api:latest
+env:
+  DB_HOST: $host
+`);
+		const warnings = lintLaunch(launch, { suppressPortabilityWarnings: true });
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain("components.default.env.DB_HOST:");
+	});
+
+	it("does not warn on commands.*.command bare references (#227's scope)", () => {
+		const launch = readLaunch(`
+name: acme
+components:
+  api:
+    image: api:latest
+    commands:
+      bootstrap: "sh -c 'test -f $CFG'"
+`);
+		expect(lintLaunch(launch, { suppressPortabilityWarnings: true })).toEqual([]);
+	});
+});
+
 describe("lintLaunch — resource types that name Object.prototype keys", () => {
 	const PROTOTYPE_KEYS = [
 		"constructor",

--- a/sdk/src/lint.ts
+++ b/sdk/src/lint.ts
@@ -99,26 +99,35 @@ const PRODUCT_SPELLINGS: Record<string, string> = {
 	podman: "container_runtime: docker",
 };
 
+/** A bare single-segment reference found in a value, with its fallback if any. */
+interface BareReference {
+	/** The referenced property name (the reference's one path segment). */
+	prop: string;
+	/** The `${prop:-default}` fallback, when the reference carries one. */
+	fallback?: string;
+}
+
 /**
  * Extract every bare single-segment reference (`$prop` / `${prop}` /
- * `${prop:-default}`) from a set_env value. Bare references always target the
+ * `${prop:-default}`) from a value. Bare references always target the
  * enclosing resource, so the resource type is unambiguous. Multi-segment
  * references (`$name.prop`, `$components.x.url`, …) are excluded: their first
  * segment names a namespace or another resource, not a property of this one.
  */
-function bareReferences(value: string): string[] {
+function bareReferences(value: string): BareReference[] {
 	const parsed = parseExpression(value);
-	const refs: { path: string[] }[] =
+	const refs: { path: string[]; fallback?: string }[] =
 		parsed.kind === "reference"
 			? [parsed]
 			: parsed.kind === "template"
 				? parsed.parts.filter(
-						(p): p is { kind: "ref"; path: string[] } => p.kind === "ref",
+						(p): p is { kind: "ref"; path: string[]; fallback?: string } =>
+							p.kind === "ref",
 					)
 				: [];
 	return refs
 		.filter((r) => r.path.length === 1 && !RESERVED_NAMESPACES.has(r.path[0]!))
-		.map((r) => r.path[0]!);
+		.map((r) => ({ prop: r.path[0]!, fallback: r.fallback }));
 }
 
 /**
@@ -145,13 +154,52 @@ function checkResourceProperties(
 				: undefined;
 			if (!vocabulary || !req.set_env) continue;
 			for (const value of Object.values(req.set_env)) {
-				for (const prop of bareReferences(value)) {
+				for (const { prop } of bareReferences(value)) {
 					if (vocabulary.includes(prop)) continue;
 					warnings.push(
 						`"$${prop}" is not in the standard vocabulary for ${req.type} ` +
 							`(known: ${vocabulary.join(", ")})`,
 					);
 				}
+			}
+		}
+	}
+}
+
+/**
+ * `env:` bare-reference check (#184): a bare single-segment reference in an
+ * `env:` value can never resolve, because `env:` is evaluated with no
+ * enclosing resource in context (`resolver.ts`'s `ResolverContext.resource`
+ * is only ever populated for a `set_env` value) — so `$anything` written
+ * there always falls through to its `${prop:-default}` fallback, or to an
+ * empty string when it has none. This is the same D-46-adjacent gap as
+ * {@link checkResourceProperties}'s check but a different question: that
+ * check asks whether a property is in a *known* resource's vocabulary; this
+ * one asks whether there is any resource at all to resolve against, so it
+ * applies regardless of vocabulary. Warn-only — never touches `resolver.ts`
+ * or changes what a value resolves to. Command-string references
+ * (`commands.*.command`) fail the same way but are #227's scope, not this
+ * one's; both share {@link bareReferences} so the two checks can't drift.
+ * Covers both the literal (`env: { PORT: "$host" }`) and expanded
+ * (`env: { PORT: { default: "$host" } }`) forms — both normalize to
+ * `NormalizedEnvVar.default`.
+ */
+function checkEnvBareReferences(
+	launch: NormalizedLaunch,
+	warnings: string[],
+): void {
+	for (const [componentName, component] of Object.entries(launch.components)) {
+		for (const [key, envVar] of Object.entries(component.env ?? {})) {
+			if (typeof envVar.default !== "string") continue;
+			for (const { prop, fallback } of bareReferences(envVar.default)) {
+				const outcome =
+					fallback !== undefined
+						? `the fallback "${fallback}" is always used instead`
+						: "it always resolves to an empty string";
+				warnings.push(
+					`components.${componentName}.env.${key}: "$${prop}" has no resource to ` +
+						`resolve against — env values are not evaluated in a resource's context, so ${outcome}`,
+				);
 			}
 		}
 	}
@@ -274,6 +322,8 @@ function checkPortability(
  *   names a known host capability is warned about: host capabilities require
  *   the `host:` marker so the privilege surface stays machine-extractable.
  * - Non-standard resource properties (D-46): see {@link checkResourceProperties}.
+ * - Bare references in `env:` values that can never resolve (#184): see
+ *   {@link checkEnvBareReferences}.
  * - Reduced-portability build path and source reachability (D-40, D-43): see
  *   {@link checkPortability}. Suppressible via `opts.suppressPortabilityWarnings`.
  *
@@ -340,6 +390,7 @@ export function lintLaunch(
 	}
 
 	checkResourceProperties(launch, warnings);
+	checkEnvBareReferences(launch, warnings);
 	checkOperatorStorageContradiction(launch, warnings);
 	checkPortability(launch, warnings, opts);
 

--- a/spec/DESIGN.md
+++ b/spec/DESIGN.md
@@ -734,7 +734,7 @@ Each limitation includes the problem, current stance, and future considerations.
 
 **Problem**: The standard properties (`url`, `host`, `port`, `user`, `password`, `name`) are convention, not enforced by the schema. A typo like `$hoost` passes validation and silently resolves to an empty string.
 **Current stance**: The resolver returns empty string for unknown properties, which usually causes a clear app error. The GAPS.md tracks this.
-**Future**: Delivered by [D-46](#d-46-resource-property-registry--vocabulary-is-standard-but-open) — the registry is `spec/schema/resource-properties.json` and SDK lint warns (advisory, never an error) on properties outside a known type's standard vocabulary.
+**Future**: Delivered by [D-46](#d-46-resource-property-registry--vocabulary-is-standard-but-open) — the registry is `spec/schema/resource-properties.json` and SDK lint warns (advisory, never an error) on properties outside a known type's standard vocabulary. The `$hoost`-in-`env:` case D-46 didn't reach — a bare reference used where no resource is ever in context, so it always resolves empty or to its fallback regardless of spelling — is covered by SDK lint's `env:` bare-reference check (#184).
 
 ### L-5: `set_env` co-location vs. flat visibility trade-off
 


### PR DESCRIPTION
Closes #184

## What

`lintLaunch` now warns when an `env:` value carries a bare single-segment `$prop` reference. `env:` is evaluated with no enclosing resource in context, so `$host` (correctly spelled) and `$hoost` (a typo) both silently resolve to the same thing today — an empty string, or the `:-default` fallback when one is given. Nothing reported this before.

## How the steward's verdict was addressed

Per the [ACCEPT verdict](https://github.com/launchfile/launchfile/issues/184#issuecomment-issue-184-verdict) on #184, this PR:

1. **Scope is `env:` values only** — both top-level and component-level, both the literal shorthand and the expanded `default:` form. Both normalize to `NormalizedEnvVar.default` in the reader, so one check point covers both.
2. **Does not touch `commands.*.command`** — that's #227's scope (an unresolvable `$ref` inside a command string). This PR names #227 explicitly in code comments so the two checks don't get written twice.
3. **Warn-only** — `sdk/src/resolver.ts` is untouched. Making this an error is a separate proposal; D-46's rejected alternatives already established that unknown-resolves-to-empty-string is load-bearing for forward compatibility.
4. **Names the fallback** — `${port:-5432}` in an `env:` value gets a warning that says the fallback is always what's used, not a generic "resolves to empty" message.
5. **Shares `bareReferences()`** with the existing D-46 check (`checkResourceProperties`) rather than duplicating the extraction logic. The helper now also returns each reference's `fallback` so both checks can use it.
6. **Names its site** — `components.<name>.env.<KEY>: …`, matching the dotted-path convention `deprecations.ts` already uses (including `components.default...` for the single-component form), not a generic sentence another check could also emit.
7. **Fixes the record** — `spec/DESIGN.md`'s L-4 "Future" line credited D-46 with delivering the full `$hoost` fix; it now names this check as the `env:` remainder D-46 didn't reach. No new `D-*` entry — this is a documentation correction.
8. **Motivation is honest** — a sweep of all 113 catalog Launchfiles against the built CLI found 0 hits (verified live below). This is a typo guard for authored files, not a fix for a bug found in the catalog.

## What I verified live

- Built the SDK → docker/macos-dev providers → CLI package chain and ran `launchfile validate` against fixture Launchfiles:
  - A file with `env: { DB_HOST: $host, DB_PORT: "${port:-5432}" }` produces both warnings verbatim, including the fallback-specific wording.
  - A file using only reserved-namespace references (`$app.url`, `$secrets.api-key`) stays clean.
- Ran the built CLI's `validate` against every one of the 113 `catalog/**/Launchfile` files: **0 hits**, confirming the verdict's motivation claim still holds.
- `sdk`: `bun run typecheck`, `bun run build`, `bun run test` (vitest — the actual CI runner) all pass, 432/432 tests (7 new). `bun test` (Bun's own runner) correctly refuses via the repo's runner guard and points at `bun run test`.

## Changeset

Added for `@launchfile/sdk` (minor — new advisory warning, no API or behavior break).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
