### PR TITLE
providers: docker logger redacts secrets inside error message/stack

### DIFF
--- a/.changeset/docker-logger-err-serializer.md
+++ b/.changeset/docker-logger-err-serializer.md
@@ -1,0 +1,5 @@
+---
+"@launchfile/docker": patch
+---
+
+Fix a secret leak in the docker provider's error logging. `logger.ts` configured pino's path-based `redact` but no `serializers.err`, so a caught `Error` logged through `span.logger.error({ err })` on span failure wrote its `message`/`stack` — and any property attached to it, such as `shell.ts`'s `result`/`display` — to stderr and the opt-in NDJSON file with any embedded credential intact (D-18, CWE-532). A new `serializers.err` runs pino's standard error serializer output through the provider's existing `redactSecrets()`, so a credential inside an error's text is masked the same way a `token` field already is. The construction-site scrubs in `shell.ts`/`release.ts` are unchanged — this is a second net for any error site that doesn't build its message through `redactSecrets` first.

--- a/providers/docker/src/__tests__/logger.test.ts
+++ b/providers/docker/src/__tests__/logger.test.ts
@@ -195,6 +195,39 @@ describe("err serializer", () => {
 		expect(serialized.message).toBe("container exited with code 137");
 	});
 
+	it("returns rather than throws on a self-referential attached property", () => {
+		registerSecret("registered-secret-value");
+		const response: Record<string, unknown> = {
+			name: "res",
+			detail: "denied for registered-secret-value",
+		};
+		response.self = response;
+		const err = Object.assign(new Error("boom"), { response });
+
+		const serialized = serializeErr(err);
+
+		const attached = serialized.response as Record<string, unknown>;
+		expect(attached.detail).toBe("denied for [REDACTED]");
+		expect(attached.self).toBe("[Circular]");
+	});
+
+	it("returns Date, Map, Set and Buffer values unchanged", () => {
+		const date = new Date("2026-01-01T00:00:00.000Z");
+		const err = Object.assign(new Error("boom"), {
+			date,
+			map: new Map([["k", "v"]]),
+			set: new Set(["v"]),
+			buf: Buffer.from("abcd"),
+		});
+
+		const serialized = serializeErr(err);
+
+		expect(serialized.date).toBe(date);
+		expect(serialized.map).toBeInstanceOf(Map);
+		expect(serialized.set).toBeInstanceOf(Set);
+		expect(Buffer.isBuffer(serialized.buf)).toBe(true);
+	});
+
 	it("is wired into the root logger for the `err` field", () => {
 		const lines: string[] = [];
 		const stream = new Writable({

--- a/providers/docker/src/__tests__/logger.test.ts
+++ b/providers/docker/src/__tests__/logger.test.ts
@@ -1,7 +1,10 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Writable } from "node:stream";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
 import pino from "pino";
-import { REDACT_CONFIG } from "../logger.js";
+import { REDACT_CONFIG, serializeErr } from "../logger.js";
+import { clearRegisteredSecrets, registerSecret } from "../redact.js";
 
 /**
  * Build an in-memory pino logger for testing JSON output and redaction.
@@ -139,6 +142,145 @@ describe("logger redaction", () => {
 		// If this becomes a requirement, enumerate concrete paths.
 		const two = entry!.two as Record<string, Record<string, unknown>>;
 		expect(two.inner!.password).toBe("two-deep");
+	});
+});
+
+describe("err serializer", () => {
+	beforeEach(() => {
+		clearRegisteredSecrets();
+	});
+
+	it("redacts a credential embedded in the error message and stack", () => {
+		const err = new Error(
+			"failed to pull https://user:ghp_abc123@registry.example.com/img",
+		);
+		const serialized = serializeErr(err);
+		expect(serialized.message).not.toContain("ghp_abc123");
+		expect(serialized.message).toBe(
+			"failed to pull https://user:[REDACTED]@registry.example.com/img",
+		);
+		expect(serialized.stack).not.toContain("ghp_abc123");
+	});
+
+	it("redacts a registered secret embedded in the message", () => {
+		registerSecret("registered-secret-value");
+		const err = new Error("refused: registered-secret-value");
+		const serialized = serializeErr(err);
+		expect(serialized.message).toBe("refused: [REDACTED]");
+	});
+
+	it("redacts secrets in properties attached to the error object", () => {
+		registerSecret("registered-secret-value");
+		const err = Object.assign(new Error("command failed"), {
+			result: { stdout: "token=registered-secret-value", exitCode: 1 },
+			display: "curl -H registered-secret-value",
+		});
+		const serialized = serializeErr(err);
+		const result = serialized.result as Record<string, unknown>;
+		expect(result.stdout).toBe("token=[REDACTED]");
+		expect(serialized.display).toBe("curl -H [REDACTED]");
+	});
+
+	it("keeps pino's standard error record shape", () => {
+		const err = new Error("plain failure");
+		const serialized = serializeErr(err);
+		expect(serialized).toHaveProperty("type", "Error");
+		expect(serialized).toHaveProperty("message", "plain failure");
+		expect(serialized).toHaveProperty("stack");
+	});
+
+	it("leaves non-sensitive text untouched", () => {
+		const err = new Error("container exited with code 137");
+		const serialized = serializeErr(err);
+		expect(serialized.message).toBe("container exited with code 137");
+	});
+
+	it("is wired into the root logger for the `err` field", () => {
+		const lines: string[] = [];
+		const stream = new Writable({
+			write(chunk, _encoding, callback) {
+				lines.push(chunk.toString().trim());
+				callback();
+			},
+		});
+		const testLogger = pino(
+			{
+				level: "trace",
+				timestamp: pino.stdTimeFunctions.isoTime,
+				redact: { paths: [...REDACT_CONFIG.paths], censor: REDACT_CONFIG.censor },
+				serializers: { err: serializeErr },
+			},
+			stream,
+		);
+
+		registerSecret("registered-secret-value");
+		testLogger.error(
+			{ err: new Error("boom: registered-secret-value") },
+			"span failed",
+		);
+
+		const [entry] = lines.map((line) => JSON.parse(line));
+		const loggedErr = entry.err as Record<string, unknown>;
+		expect(loggedErr.message).toBe("boom: [REDACTED]");
+	});
+});
+
+describe("err serializer — NDJSON file", () => {
+	// LAUNCHFILE_LOG_DIR is validated against a sensitive-path blocklist that
+	// includes "/var" — os.tmpdir() resolves to /var/folders/... on macOS, so
+	// the file goes under the package directory instead, cleaned up after.
+	//
+	// The module builds its file stream from LAUNCHFILE_LOG_DIR at import
+	// time, so getting a logger that writes to our temp dir means forcing a
+	// fresh module instance with vi.resetModules() — and resetting again
+	// afterwards so later tests (`span system`, below) re-import a logger
+	// that was never pointed at a directory this test just deleted.
+	let dir: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(process.cwd(), "lf-logger-ndjson-"));
+	});
+
+	afterEach(async () => {
+		rmSync(dir, { recursive: true, force: true });
+		delete process.env.LAUNCHFILE_LOG_DIR;
+		vi.resetModules();
+	});
+
+	it("scrubs a credential-bearing error from the on-disk NDJSON file", async () => {
+		process.env.LAUNCHFILE_LOG_DIR = dir;
+		vi.resetModules();
+		const fresh = await import("../logger.js");
+		const freshRedact = await import("../redact.js");
+		freshRedact.registerSecret("registered-secret-value");
+
+		const err = Object.assign(
+			new Error(
+				"failed https://user:hunter2pass@host.example.com/x and registered-secret-value",
+			),
+			{ display: "curl registered-secret-value" },
+		);
+		fresh.logger.error({ err }, "span failed");
+
+		// The file destination opens and writes asynchronously (mkdir + fd
+		// open happen off the constructor call), so poll rather than assume
+		// a single flush() call has already landed the write.
+		const logPath = join(dir, "launchfile-docker.log");
+		let contents = "";
+		const deadline = Date.now() + 3000;
+		while (Date.now() < deadline) {
+			try {
+				contents = readFileSync(logPath, "utf8");
+				if (contents.includes("span failed")) break;
+			} catch {
+				// file not created yet
+			}
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+		expect(contents).not.toContain("hunter2pass");
+		expect(contents).not.toContain("registered-secret-value");
+		expect(contents).toContain("[REDACTED]");
+		expect(contents).toContain("span failed");
 	});
 });
 

--- a/providers/docker/src/logger.ts
+++ b/providers/docker/src/logger.ts
@@ -148,15 +148,19 @@ export const REDACT_CONFIG = {
  * serializer output and runs `redactSecrets()` over every string it finds, so
  * a credential embedded in prose is caught the same way a `token` field is.
  */
-function deepRedact(value: unknown): unknown {
+function deepRedact(value: unknown, seen = new WeakSet<object>()): unknown {
 	if (typeof value === "string") return redactSecrets(value);
-	if (Array.isArray(value)) return value.map(deepRedact);
-	if (value !== null && typeof value === "object") {
-		return Object.fromEntries(
-			Object.entries(value).map(([key, val]) => [key, deepRedact(val)]),
-		);
-	}
-	return value;
+	if (value === null || typeof value !== "object") return value;
+	if (seen.has(value)) return "[Circular]";
+	seen.add(value);
+	if (Array.isArray(value)) return value.map((item) => deepRedact(item, seen));
+	const entries = Object.entries(value);
+	// Date, Map, Set and Buffer expose no own enumerable string leaves to
+	// scrub, and rebuilding them from entries() erases or explodes them.
+	if (entries.length === 0 || Buffer.isBuffer(value)) return value;
+	return Object.fromEntries(
+		entries.map(([key, val]) => [key, deepRedact(val, seen)]),
+	);
 }
 
 /** `serializers.err` — see `deepRedact` for why `redact.paths` isn't enough. */

--- a/providers/docker/src/logger.ts
+++ b/providers/docker/src/logger.ts
@@ -26,6 +26,7 @@ import { homedir } from "node:os";
 import { randomUUID } from "node:crypto";
 import pino from "pino";
 import pinoPretty from "pino-pretty";
+import { redactSecrets } from "./redact.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -140,6 +141,30 @@ export const REDACT_CONFIG = {
 	censor: "[REDACTED]",
 } as const;
 
+/**
+ * `redact` above only matches object paths — it never sees text inside an
+ * `Error.message` or `Error.stack`, or a value copied onto the error object
+ * (`shell.ts` attaches `result`/`display`). This walks pino's standard error
+ * serializer output and runs `redactSecrets()` over every string it finds, so
+ * a credential embedded in prose is caught the same way a `token` field is.
+ */
+function deepRedact(value: unknown): unknown {
+	if (typeof value === "string") return redactSecrets(value);
+	if (Array.isArray(value)) return value.map(deepRedact);
+	if (value !== null && typeof value === "object") {
+		return Object.fromEntries(
+			Object.entries(value).map(([key, val]) => [key, deepRedact(val)]),
+		);
+	}
+	return value;
+}
+
+/** `serializers.err` — see `deepRedact` for why `redact.paths` isn't enough. */
+export function serializeErr(err: unknown): Record<string, unknown> {
+	const serialized = pino.stdSerializers.err(err as Error) as Record<string, unknown>;
+	return deepRedact(serialized) as Record<string, unknown>;
+}
+
 // ---------------------------------------------------------------------------
 // Root logger
 // ---------------------------------------------------------------------------
@@ -155,6 +180,7 @@ export const logger: pino.Logger = pino(
 			paths: [...REDACT_PATHS],
 			censor: REDACT_CONFIG.censor,
 		},
+		serializers: { err: serializeErr },
 	},
 	buildStream(),
 );


### PR DESCRIPTION
Closes #330

## What

`providers/docker/src/logger.ts` configured pino's path-based `redact` but no `serializers.err`. `redact` matches object paths only — it never reaches text inside `Error.message`/`Error.stack` — so an error logged through `span.logger.error({ err })` on span failure (`endSpan`, `logger.ts:239`) could write an embedded credential to stderr and the opt-in NDJSON file under `LAUNCHFILE_LOG_DIR` unmasked (D-18, CWE-532).

## How the steward's ACCEPT verdict shape was addressed

Per the [issue verdict](https://github.com/launchfile/launchfile/issues/330#issuecomment-issue-verdict):

1. Added `serializers: { err: serializeErr }` beside the existing `redact` block. `serializeErr` runs pino's standard error serializer (`pino.stdSerializers.err`) through a `deepRedact` walk that calls the provider's existing `redactSecrets()` on every string it finds — reusing the same function `shell.ts`/`release.ts` already use, not a second masker.
2. `deepRedact` also scrubs properties attached to the error object (e.g. `shell.ts`'s `result`/`display`), since pino's standard serializer copies own enumerable properties onto the record.
3. `redact.paths` and every construction-site scrub in `shell.ts`/`release.ts` are unchanged — the serializer is a second net, not a replacement (`launchfile diagnose` never passes through pino and still needs those).
4. Pino's record shape (`type`, `message`, `stack`, `cause`) is preserved — `deepRedact` only replaces string leaves.
5. Test coverage exercises the real on-disk NDJSON file, not only an in-memory stream, per the verdict's requirement.
6. Change is scoped to `providers/docker` only, matching the verdict's scope note (`providers/aws` has the same gap but no live call site; `providers/macos-dev` has no pino logger).

The verdict's "Concretely" correction is reflected in the changeset/commit message: the motivating `docker compose` example already scrubs at construction, so the real gap named is any future `Error` built inside a `withSpan` block that skips `redactSecrets` at construction.

Out of scope (per verdict item 6, and the neighbouring gap it flagged): `source-resolver.ts:120`'s unmasked `url` in a pre-span throw — that never reaches pino and needs its own issue; not filed yet, see follow-ups below.

## Testing

- `cd providers/docker && bun run typecheck` — clean
- `cd providers/docker && bun run test` — 361/361 passing (26 files), including 6 new unit tests for `serializeErr` and one integration test that logs a credential-bearing error through the real logger, polls the actual `LAUNCHFILE_LOG_DIR` NDJSON file on disk, and asserts the raw secret and URL password never appear while `[REDACTED]` and the surrounding message text do.
- Verified live: the NDJSON-file test is the live check — it exercises the real `pino.destination` file sink (not a mock), confirming the fix closes the gap on the actual write path the issue was about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)