### PR TITLE
providers: warn when postgres config.extensions cannot apply (closes #317)

### DIFF
--- a/.changeset/docker-pg-extensions-init-only.md
+++ b/.changeset/docker-pg-extensions-init-only.md
@@ -1,0 +1,9 @@
+---
+"@launchfile/docker": patch
+---
+
+Warn when postgres `config.extensions` cannot apply. The extensions reach postgres through an init script mounted into `/docker-entrypoint-initdb.d/`, and postgres reads that directory only while it initializes an empty data directory. Since the data directory moved onto the named volume that `launchfile down` preserves, an extension added to a deployment that has already run was never created — the image swapped to `pgvector/pgvector:pg16`, the SQL never ran, and nothing said so until the app's first query failed.
+
+`up` now resolves the volume Compose actually created for that service and, when it exists, warns before starting: it names the service and the declared extensions, states that postgres creates them only at first initialization, and gives both remedies — `launchfile down --destroy` then `launchfile up`, which deletes that service's data, or running the `CREATE EXTENSION` statements by hand, which does not. Detection only: the provider runs no SQL and asks the database nothing, so the warning reports what the provider does, never what the database contains.
+
+`ComposeResult` gains `initOnlyExtensions`, the pure generator's report of which services deliver extensions this way — the same split as `storageBinds`, where the generator names the requirement and the caller checks the host.

--- a/.changeset/docker-pg-extensions-init-only.md
+++ b/.changeset/docker-pg-extensions-init-only.md
@@ -1,5 +1,5 @@
 ---
-"@launchfile/docker": patch
+"@launchfile/docker": minor
 ---
 
 Warn when postgres `config.extensions` cannot apply. The extensions reach postgres through an init script mounted into `/docker-entrypoint-initdb.d/`, and postgres reads that directory only while it initializes an empty data directory. Since the data directory moved onto the named volume that `launchfile down` preserves, an extension added to a deployment that has already run was never created — the image swapped to `pgvector/pgvector:pg16`, the SQL never ran, and nothing said so until the app's first query failed.

--- a/providers/docker/src/__tests__/pg-extensions-init-only.test.ts
+++ b/providers/docker/src/__tests__/pg-extensions-init-only.test.ts
@@ -1,0 +1,167 @@
+/**
+ * PROVIDERS.md §10 rule 8 for postgres `config.extensions` (#317).
+ *
+ * The extensions reach postgres through an init script mounted into
+ * /docker-entrypoint-initdb.d/, which postgres reads only while it initializes
+ * an empty data directory. That directory lives on a named volume `down`
+ * preserves unless `--destroy` is passed, so an extension declared after the
+ * first run is never created — and, before this, was never reported.
+ *
+ * Detection only. The provider runs no SQL and asks the database nothing, so
+ * these tests pin the split: a pure generator that names the volume KEY, and a
+ * caller that resolves the project-scoped name Compose actually created.
+ */
+
+import { readLaunch } from "@launchfile/sdk";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import { launchToCompose } from "../compose-generator.js";
+import {
+	composeVolumeName,
+	initOnlyExtensionsWarning,
+	type VolumeProbe,
+} from "../provider.js";
+
+const app = (config: string, type = "postgres") => `
+name: app
+image: acme/app:1
+provides:
+  - { protocol: http, port: 3000, exposed: true }
+requires:
+  - type: ${type}${config}
+`;
+
+const withExtensions = app("\n    config:\n      extensions: [pgvector]");
+
+interface ComposeDoc {
+	services: Record<string, { volumes?: string[] }>;
+	volumes?: Record<string, unknown>;
+}
+
+/** A probe that records its argv and replays a canned result. */
+const probeReturning = (
+	stdout: string,
+	exitCode = 0,
+): { probe: VolumeProbe; calls: string[][] } => {
+	const calls: string[][] = [];
+	const probe: VolumeProbe = async (cmd, args) => {
+		calls.push([cmd, ...args]);
+		return { exitCode, stdout, stderr: "" };
+	};
+	return { probe, calls };
+};
+
+describe("generator reports init-only extension delivery", () => {
+	it("reports the postgres service, its component, and the SQL names", () => {
+		const { initOnlyExtensions } = launchToCompose(readLaunch(withExtensions));
+		expect(initOnlyExtensions).toEqual([
+			{
+				component: "default",
+				service: "app-postgres",
+				volume: "app-postgres-data",
+				extensions: ["vector"],
+			},
+		]);
+	});
+
+	it("names the volume KEY the compose file declares, not a host name", () => {
+		const result = launchToCompose(readLaunch(withExtensions));
+		const doc = parse(result.yaml) as ComposeDoc;
+		const key = result.initOnlyExtensions[0]?.volume;
+		expect(doc.volumes).toHaveProperty(key as string);
+		expect(doc.services["app-postgres"]?.volumes).toEqual([
+			`${key}:/var/lib/postgresql/data`,
+		]);
+	});
+
+	it("reports nothing when no extension is declared", () => {
+		expect(launchToCompose(readLaunch(app(""))).initOnlyExtensions).toEqual([]);
+	});
+
+	it("reports nothing for a type that has no extension delivery", () => {
+		const yaml = app("\n    config:\n      extensions: [pgvector]", "mysql");
+		expect(launchToCompose(readLaunch(yaml)).initOnlyExtensions).toEqual([]);
+	});
+
+	it("reports nothing when every declared extension name is rejected", () => {
+		const yaml = app('\n    config:\n      extensions: ["drop table"]');
+		const { initOnlyExtensions, warnings } = launchToCompose(readLaunch(yaml));
+		expect(initOnlyExtensions).toEqual([]);
+		expect(warnings.join(" ")).toContain("is not a valid identifier");
+	});
+});
+
+describe("composeVolumeName", () => {
+	it("queries by the project and the compose volume key", async () => {
+		const { probe, calls } = probeReturning("launchfile-app_app-postgres-data\n");
+		await composeVolumeName("launchfile-app", "app-postgres-data", probe);
+		expect(calls).toHaveLength(1);
+		const argv = calls[0]!.join(" ");
+		expect(argv).toContain("volume ls");
+		expect(argv).toContain("label=com.docker.compose.project=launchfile-app");
+		expect(argv).toContain("label=com.docker.compose.volume=app-postgres-data");
+	});
+
+	// The compose file's key is not a host volume name — Compose scopes what it
+	// creates to the project. A lookup that returned the bare key would report
+	// "absent" for a volume that exists, shipping this fix as silence.
+	it("returns the project-scoped name Compose created, not the key", async () => {
+		const { probe } = probeReturning("launchfile-app_app-postgres-data\n");
+		const name = await composeVolumeName(
+			"launchfile-app",
+			"app-postgres-data",
+			probe,
+		);
+		expect(name).toBe("launchfile-app_app-postgres-data");
+		expect(name).not.toBe("app-postgres-data");
+	});
+
+	it("returns null when no volume matches", async () => {
+		const { probe } = probeReturning("\n");
+		expect(await composeVolumeName("p", "v", probe)).toBeNull();
+	});
+
+	it("returns null when docker fails", async () => {
+		const { probe } = probeReturning("", 1);
+		expect(await composeVolumeName("p", "v", probe)).toBeNull();
+	});
+});
+
+describe("the warning", () => {
+	const entry = {
+		component: "default",
+		service: "app-postgres",
+		volume: "app-postgres-data",
+		extensions: ["vector"],
+	};
+	const w = initOnlyExtensionsWarning(entry, "launchfile-app_app-postgres-data");
+
+	it("names the service, the field, and the extensions", () => {
+		expect(w).toContain("app-postgres");
+		expect(w).toContain("config.extensions");
+		expect(w).toContain("vector");
+	});
+
+	it("states the rule that makes the delivery a no-op", () => {
+		expect(w).toContain("initializes an empty data directory");
+		expect(w).toContain("launchfile-app_app-postgres-data");
+	});
+
+	it("gives the destructive remedy with its cost", () => {
+		expect(w).toContain("launchfile down --destroy");
+		expect(w).toContain("deletes app-postgres's data");
+	});
+
+	it("gives the non-destructive remedy", () => {
+		expect(w).toContain("CREATE EXTENSION");
+		expect(w).toContain("keep the data");
+	});
+
+	// Rule 8 asks a provider to report what IT did. This provider queries no
+	// database, so it cannot know whether the extension is present — someone
+	// may have created it by hand after the first run.
+	it("says what the provider does, never what the database contains", () => {
+		expect(w).toContain("this run creates none of them");
+		expect(w).not.toMatch(/extension is (not installed|missing|absent)/);
+	});
+});

--- a/providers/docker/src/compose-generator.ts
+++ b/providers/docker/src/compose-generator.ts
@@ -130,21 +130,31 @@ const POSTGRES_EXTENSION_IMAGES: Record<string, string> = {
  * Honor `requires.config` for postgres (PROVIDERS.md §10.8: report gaps,
  * not silent drops). Declared extensions select a satisfying image and are
  * created via an init script the caller mounts into
- * /docker-entrypoint-initdb.d/ (runs when the database directory is
- * initialized). An extension no known image provides passes through
- * validated — if the image lacks it, initialization fails loudly at boot
- * instead of the app failing later on its first CREATE EXTENSION. Every
- * config key or extension the provider cannot honor is surfaced as a
- * warning, never dropped.
+ * /docker-entrypoint-initdb.d/. Every config key or extension the provider
+ * cannot honor is surfaced as a warning, never dropped.
  *
- * Returns the init SQL, or undefined when no extensions are declared.
- * Mutates `backing.image` when an extension requires a different image.
+ * Postgres reads that directory ONLY while initializing an empty data
+ * directory, and this provider keeps postgres's data directory on a named
+ * volume that `down` preserves unless `--destroy` is passed. Two effects
+ * therefore hold on a first run against an empty volume and on no other run:
+ * the `CREATE EXTENSION` statements below, and the loud boot failure when
+ * the selected image does not provide a declared extension. Against an
+ * existing volume the script is never read, so an extension added to a
+ * deployment that has already run is not created and nothing fails.
+ *
+ * This generator is pure and cannot see whether the volume exists, so it
+ * records each such service in `ComposeResult.initOnlyExtensions` and the
+ * caller checks and warns — the same division of labour as `storageBinds`.
+ *
+ * Returns the init SQL together with the SQL names it creates, or undefined
+ * when no extensions are declared. Mutates `backing.image` when an extension
+ * requires a different image.
  */
 function applyPostgresConfig(
 	config: Record<string, unknown>,
 	backing: BackingService,
 	warnings: string[],
-): string | undefined {
+): { sql: string; sqlNames: string[] } | undefined {
 	const sqlNames: string[] = [];
 	for (const [key, value] of Object.entries(config)) {
 		if (key !== "extensions") {
@@ -192,7 +202,10 @@ function applyPostgresConfig(
 		);
 	}
 
-	return `${sqlNames.map((n) => `CREATE EXTENSION IF NOT EXISTS "${n}";`).join("\n")}\n`;
+	return {
+		sql: `${sqlNames.map((n) => `CREATE EXTENSION IF NOT EXISTS "${n}";`).join("\n")}\n`,
+		sqlNames,
+	};
 }
 
 /**
@@ -631,6 +644,30 @@ export interface ComposeOpts {
 // two. Re-exported so this module's public API is unchanged.
 export type { StorageBind, UnboundOperatorVolume };
 
+/**
+ * A provisioned postgres service whose declared `config.extensions` reach the
+ * database only through `/docker-entrypoint-initdb.d/`, which postgres reads
+ * only while initializing an empty data directory.
+ *
+ * The generator is pure, so the caller owns the check: if the volume Compose
+ * creates for `volume` already exists, this run creates none of these
+ * extensions and must say so (PROVIDERS.md §10 rule 8). Same division of
+ * labour as `storageBinds`.
+ */
+export interface InitOnlyExtensions {
+	/** Component whose `requires:` entry created the backing service. */
+	component: string;
+	/** Generated compose service name (`<app>-postgres`). */
+	service: string;
+	/**
+	 * Volume KEY as written in the compose file. Compose creates the volume
+	 * under a project-scoped name, not this one — resolve it before querying.
+	 */
+	volume: string;
+	/** SQL names the init script creates, in the order it creates them. */
+	extensions: string[];
+}
+
 /** A `required:` variable neither the Launchfile nor the operator supplied. */
 export interface UnsuppliedRequiredVar {
 	component: string;
@@ -688,6 +725,14 @@ export interface ComposeResult {
 	 * `warnings`: a deploying verb reads this field and refuses.
 	 */
 	unboundOperatorVolumes: UnboundOperatorVolume[];
+	/**
+	 * Postgres services whose `config.extensions` are delivered by an
+	 * init script that only a first initialization runs. Empty unless a
+	 * `requires: postgres` entry declares `config.extensions`. The caller
+	 * resolves each `volume` to the name Compose actually creates and warns
+	 * when it already exists — see `InitOnlyExtensions`.
+	 */
+	initOnlyExtensions: InitOnlyExtensions[];
 }
 
 export function launchToCompose(
@@ -710,6 +755,7 @@ export function launchToCompose(
 	const endpoints: Record<string, StateEndpoint> = {};
 	const storageBinds: StorageBind[] = [];
 	const unboundOperatorVolumes: UnboundOperatorVolume[] = [];
+	const initOnlyExtensions: InitOnlyExtensions[] = [];
 
 	// D-50 storage-path keys, indexed once. Only components this generator
 	// actually translates ask the index, so a skipped one's marked volume never
@@ -1039,6 +1085,7 @@ export function launchToCompose(
 				}
 				const backingResult = addBackingService(
 					launch.name,
+					componentName,
 					req,
 					services,
 					volumes,
@@ -1046,6 +1093,7 @@ export function launchToCompose(
 					appliedConfigs,
 					images,
 					warnings,
+					initOnlyExtensions,
 					backingServices,
 				);
 				if (backingResult) {
@@ -1260,6 +1308,7 @@ export function launchToCompose(
 		unsuppliedRequired,
 		storageBinds,
 		unboundOperatorVolumes,
+		initOnlyExtensions,
 	};
 }
 
@@ -1364,6 +1413,7 @@ function resolveEnvVar(
 
 function addBackingService(
 	appName: string,
+	componentName: string,
 	req: NormalizedRequirement,
 	services: Record<string, Record<string, unknown>>,
 	volumes: Record<string, Record<string, unknown>>,
@@ -1371,6 +1421,7 @@ function addBackingService(
 	appliedConfigs: Map<string, string>,
 	images: string[],
 	warnings: string[],
+	initOnlyExtensions: InitOnlyExtensions[],
 	backingServices: Record<string, (name: string) => BackingService>,
 ): { serviceName: string; properties: Record<string, string> } | null {
 	const type = req.type;
@@ -1403,9 +1454,12 @@ function addBackingService(
 
 		// requires.config — honor what we can, surface what we can't (§10.8).
 		let initSql: string | undefined;
+		let initExtensions: string[] | undefined;
 		if (req.config) {
 			if (type === "postgres") {
-				initSql = applyPostgresConfig(req.config, backing, warnings);
+				const applied = applyPostgresConfig(req.config, backing, warnings);
+				initSql = applied?.sql;
+				initExtensions = applied?.sqlNames;
 			} else {
 				for (const key of Object.keys(req.config)) {
 					warnings.push(
@@ -1450,6 +1504,19 @@ function addBackingService(
 			const volName = `${serviceName}-data`;
 			service.volumes = [`${volName}:${backing.dataPath}`];
 			volumes[volName] = {};
+
+			// The init script and the data directory share this volume, so the
+			// script runs only on the run that creates it. Reported for the
+			// caller to check; recorded against the component that created the
+			// service, so a shared service is scoped like `storageBinds` is.
+			if (initExtensions && initExtensions.length > 0) {
+				initOnlyExtensions.push({
+					component: componentName,
+					service: serviceName,
+					volume: volName,
+					extensions: initExtensions,
+				});
+			}
 		}
 
 		services[serviceName] = service;

--- a/providers/docker/src/index.ts
+++ b/providers/docker/src/index.ts
@@ -33,6 +33,7 @@ export {
 	launchToCompose,
 	type ComposeResult,
 	type ComposeOpts,
+	type InitOnlyExtensions,
 	type StorageBind,
 	type UnboundOperatorVolume,
 	type UnsuppliedRequiredVar,

--- a/providers/docker/src/provider.ts
+++ b/providers/docker/src/provider.ts
@@ -30,6 +30,7 @@ import {
 import { allocatePorts } from "./port-allocator.js";
 import {
 	launchToCompose,
+	type InitOnlyExtensions,
 	type StorageBind,
 	type UnsuppliedRequiredVar,
 } from "./compose-generator.js";
@@ -45,6 +46,72 @@ import {
 	type PhaseContext,
 } from "./errors.js";
 import { readdir } from "node:fs/promises";
+
+/**
+ * Reads a docker volume's existence. Injected in tests; defaults to `shell`.
+ */
+export type VolumeProbe = (
+	cmd: string,
+	args: string[],
+) => Promise<{ exitCode: number; stdout: string; stderr: string }>;
+
+const defaultProbe: VolumeProbe = (cmd, args) =>
+	shell(cmd, args, { allowFailure: true, silent: true });
+
+/**
+ * Resolve the volume Compose actually created for a compose-file volume KEY,
+ * or null when none exists.
+ *
+ * Compose scopes every volume it creates to the project, so the bare key from
+ * the compose file matches nothing on the host and a lookup by that name would
+ * report "absent" for a volume that is plainly there. The query goes through
+ * the two labels Compose writes on each volume it creates — the project and
+ * the unscoped key — so the answer holds whatever naming scheme the installed
+ * Compose uses. A docker failure returns null: a warning this provider cannot
+ * ground is worse than none.
+ */
+export async function composeVolumeName(
+	project: string,
+	volumeKey: string,
+	probe: VolumeProbe = defaultProbe,
+): Promise<string | null> {
+	const result = await probe("docker", [
+		"volume",
+		"ls",
+		"--quiet",
+		"--filter",
+		`label=com.docker.compose.project=${project}`,
+		"--filter",
+		`label=com.docker.compose.volume=${volumeKey}`,
+	]);
+	if (result.exitCode !== 0) return null;
+	const name = result.stdout.trim().split("\n")[0]?.trim();
+	return name ? name : null;
+}
+
+/**
+ * The §10 rule 8 warning for `config.extensions` on a postgres service whose
+ * data volume already exists.
+ *
+ * It reports what this provider does — it creates no extension on this run —
+ * and never what the database now contains: the provider does not query the
+ * database, so an extension created by hand earlier is indistinguishable from
+ * one that was never created. Both remedies are named, with the cost of the
+ * destructive one stated.
+ */
+export function initOnlyExtensionsWarning(
+	entry: InitOnlyExtensions,
+	volumeName: string,
+): string {
+	return (
+		`${entry.service}: config.extensions (${entry.extensions.join(", ")}) reaches postgres ` +
+		"through an init script postgres reads only while it initializes an empty data directory. " +
+		`Volume ${volumeName} already exists, so this run creates none of them. ` +
+		"To have this provider create them, run `launchfile down --destroy` then `launchfile up` — " +
+		`that deletes ${entry.service}'s data. To keep the data, run the CREATE EXTENSION ` +
+		"statements against the running database yourself."
+	);
+}
 
 export interface DockerUpOpts {
 	detach?: boolean;
@@ -476,6 +543,28 @@ export async function dockerUp(source: string, opts: DockerUpOpts = {}): Promise
 		// Past the refusal gate — from here the provider starts leaving things on
 		// disk, so the state directory is created here rather than earlier.
 		await ensureStateDir(slug);
+
+		// `config.extensions` reaches postgres through an init script that only
+		// an initializing, empty data directory runs, and this provider keeps
+		// that directory on a named volume `down` preserves. So on a deployment
+		// that has already run, a newly declared extension is never created and
+		// nothing fails — the silent drop §10 rule 8 forbids. The volume's
+		// existence is the trigger, not the database's contents: this provider
+		// runs no SQL of its own here, so a volume that exists but never
+		// initialized costs one advisory line rather than a query. Scoped to
+		// the components actually starting, like the storage checks above.
+		// Skipped on a dry run — that path runs no docker command at all, and
+		// does not even check that docker is installed.
+		if (!opts.dryRun) {
+			const composeProjectName = composeProject(slug);
+			for (const entry of result.initOnlyExtensions) {
+				if (!launching.has(entry.component)) continue;
+				const volumeName = await composeVolumeName(composeProjectName, entry.volume);
+				if (volumeName !== null) {
+					result.warnings.push(initOnlyExtensionsWarning(entry, volumeName));
+				}
+			}
+		}
 
 		// Log warnings; refusals (un-grantable host capabilities, D-44) are
 		// surfaced distinctly — a refusal is user-visible output, not a line


### PR DESCRIPTION
Closes #317.

Postgres `config.extensions` reaches the database through an init script mounted at `/docker-entrypoint-initdb.d/90-launchfile-extensions.sql`. Postgres reads that directory only while it initializes an empty data directory. Since #316 put the data directory on the named volume that `launchfile down` preserves without `--destroy`, an extension added to a deployment that has already run is never created — the image still swaps to `pgvector/pgvector:pg16`, the `CREATE EXTENSION` never runs, and nothing says so. The app finds out on its first query. That is the silent drop `spec/PROVIDERS.md` §10 rule 8 forbids, and this file already honors that rule on two neighbouring branches.

## How the review's bound shape was addressed

| # | Bound shape | Where |
|---|---|---|
| 1 | Detection only; split "idempotent delivery" into its own issue | Nothing here runs SQL. Split filed as **#344** (searched `idempotent`, `extensions postgres`, `CREATE EXTENSION` first — no duplicate) |
| 2 | Check in `provider.ts`, not the generator; append to the warnings list it already carries | `launchToCompose` stays pure and reports `ComposeResult.initOnlyExtensions`; `dockerUp` does the lookup and pushes onto `result.warnings`, the same split `storageBinds` already uses |
| 3 | Resolve the volume name Compose actually creates | `composeVolumeName()` queries `com.docker.compose.project` + `com.docker.compose.volume`, the labels Compose writes on every volume it creates, so the answer holds whatever naming scheme the installed Compose uses. Pinned by a test asserting the resolved name is the project-scoped one and **not** the bare key |
| 4 | Put everything in the warning | Names the service and `config.extensions`, states that postgres creates extensions only while initializing an empty data directory, and gives both remedies — `down --destroy` then `up`, **stating it deletes that service's data**, and running `CREATE EXTENSION` by hand, which does not. It reports what the provider does ("this run creates none of them"), never what the database contains |
| 5 | Trigger on the volume's existence, not the database's contents | The provider issues no query against postgres. A volume that exists but never initialized costs one advisory line |
| 6 | Prove it with a run | Unit tests for both branches, plus the transcript below |
| 7 | Fix the docstring that promises a loud boot failure | `applyPostgresConfig`'s JSDoc now states that both the `CREATE EXTENSION` and the loud failure hold on a first run only, and that the caller checks and warns otherwise |

Scoping follows the storage checks above it: the entry is recorded against the component whose `requires:` entry created the backing service, and a component outside an active `--component` start-set is skipped. Skipped on `--dry-run`, which runs no docker command at all and does not even check that docker is installed.

## Verified live

```
$ launchfile up --yes                 # nginx + requires: postgres, no extensions
  pgext317 is running at http://localhost:12790
$ docker volume ls --filter label=com.docker.compose.project=launchfile-pgext317
launchfile-pgext317_pgext317-postgres-data
   labels=…,com.docker.compose.project=launchfile-pgext317,
          com.docker.compose.volume=pgext317-postgres-data

$ launchfile down
  Containers stopped. Data volumes preserved.

# add   config: { extensions: [pgvector] }   to the requires entry
$ launchfile up --yes
  Warning: pgext317-postgres: config.extensions (vector) reaches postgres through an
  init script postgres reads only while it initializes an empty data directory. Volume
  launchfile-pgext317_pgext317-postgres-data already exists, so this run creates none of
  them. To have this provider create them, run `launchfile down --destroy` then
  `launchfile up` — that deletes pgext317-postgres's data. To keep the data, run the
  CREATE EXTENSION statements against the running database yourself.

$ docker compose … exec -T pgext317-postgres psql -U launchfile -d pgext317 \
    -tAc "select extname from pg_extension order by 1;"
plpgsql                               # the extension is absent — the warning is true
$ docker compose … ps
pgext317-postgres  pgvector/pgvector:pg16   # image swapped, SQL never ran

$ launchfile down --destroy && launchfile up --yes
  (no warning)
$ docker compose … exec -T pgext317-postgres psql … "select extname from pg_extension;"
plpgsql
vector                                # created on a fresh volume
```

Note the volume name: Compose created `launchfile-pgext317_pgext317-postgres-data`, not the compose-file key `pgext317-postgres-data`. A lookup by the bare key would have matched nothing and shipped this as silence.

## Tests

`providers/docker/src/__tests__/pg-extensions-init-only.test.ts` — 14 cases: the generator reports the service/component/SQL names and the compose volume key (and reports nothing for no extensions, a non-postgres type, or names it rejected); `composeVolumeName` queries by both labels, returns the project-scoped name rather than the key, and returns null on no match or a docker failure; the warning carries the service, the field, the rule, both remedies with the destructive one's cost, and no claim about the database's contents.

```
providers/docker: bun run typecheck ✓   bun run test  366 passed (27 files)
packages/launchfile: bun run typecheck ✓  bun run build ✓  bun run test  96 passed
```

No spec change and no decision entry: neither existing rule-8 warning in this file carries one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
