### PR TITLE
chore: one catalog CI job — the harness suite plus static Launchfile validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,47 @@ jobs:
       - name: Verify dist/cli.js exists
         run: test -f packages/launchfile/dist/cli.js || (echo "dist/cli.js missing!" && exit 1)
 
+  # The catalog's own gate, in two halves that share one checkout.
+  #
+  # `catalog/test` is a Vitest suite for the Launchfile → compose harness, and
+  # `validate-catalog` is static analysis of every catalog Launchfile — schema
+  # plus the image-reference policy in catalog/CONTRIBUTING.md. Neither pulls an
+  # image or starts a container; the docker-compose runs stay local.
+  #
+  # No `needs:` edge. Jobs share no filesystem, so `needs:` would reuse nothing
+  # and only add queue latency — the same reasoning the aws-terraform-validate
+  # job records above. This job builds the SDK and the Docker provider itself:
+  # catalog/test's harness imports providers/docker/src/app-url.ts, which
+  # imports the bare package @launchfile/sdk and resolves only to sdk/dist.
+  catalog:
+    name: Catalog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The two WARNING checks only look at Launchfiles this change adds or
+          # edits, so the base commit has to be in history to diff against.
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - name: Build SDK and Docker provider (local dependencies)
+        run: |
+          cd sdk && bun install --frozen-lockfile && bun run build
+          cd ../providers/docker && bun install --frozen-lockfile && bun run build
+      - run: cd catalog/test && bun install --frozen-lockfile
+      # Vitest strips types instead of checking them, and this harness reaches
+      # into sdk/src and providers/docker/src by relative path — without a
+      # typecheck a cross-package signature change breaks silently.
+      - run: cd catalog/test && bun run typecheck
+      # `bun run test`, never `bun test`: catalog/test/bunfig.toml preloads a
+      # guard that exits 1 when Bun's built-in runner is used instead of Vitest.
+      - run: cd catalog/test && bun run test
+      - name: Validate catalog Launchfiles and image references
+        env:
+          # The PR's merge base on a pull_request; the previous main tip on a
+          # push. Read through env, not interpolated into the script body.
+          CATALOG_DIFF_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: cd catalog/test && bun run validate-catalog
+
   websites:
     name: "Website (${{ matrix.site }})"
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,8 +99,15 @@ Providers (build SDK first, then typecheck → build → test)
   ↓
 CLI package (build SDK + providers first, then typecheck → build → test)
   ↓
+Catalog (build SDK + providers/docker first, then typecheck → test → validate-catalog)
+  ↓
 Websites (need Node >= 22 for Astro 6, need wrangler.toml with pinned compat_date)
 ```
+
+`catalog/test` is not a workspace member, so it carries its own committed
+`bun.lock` (like `smoke-tests/`) and installs `--frozen-lockfile`. Its suite runs
+under Vitest via `bun run test` — `bun test` hits the guard in
+`catalog/test/scripts/test-guard.ts` and exits 1.
 
 ### Websites — Astro + Cloudflare
 
@@ -124,4 +131,7 @@ cd providers/macos-dev && bun run build && bun test
 
 # CLI package
 cd packages/launchfile && bun run typecheck && bun run build && bun test
+
+# Catalog harness + static catalog validation
+cd catalog/test && bun run typecheck && bun run test && bun run validate-catalog
 ```

--- a/catalog/CONTRIBUTING.md
+++ b/catalog/CONTRIBUTING.md
@@ -102,6 +102,23 @@ Rung 2 freezes an app the same way, which is exactly why it ranks below rung 1 a
 applies only where upstream maintains no channel to follow. A digest freezes every
 entry, including the ones upstream still patches.
 
+### What CI checks
+
+The `Catalog` job runs `catalog/test`'s `validate-catalog` script over every
+`catalog/{apps,drafts}/*/Launchfile` — static analysis only, nothing is pulled or run.
+
+| Check                                                  | Severity  | Scope                             |
+|--------------------------------------------------------|-----------|-----------------------------------|
+| Parses against the SDK's schema (`sdk/src/schema.ts`)  | **error** | Every catalog Launchfile          |
+| `image:` carries a tag — a bare reference is rejected  | **error** | Every catalog Launchfile          |
+| `image:` pins by `@sha256` digest — rejected           | **error** | Every catalog Launchfile          |
+| `:latest` with no trailing `#` rationale comment       | warning   | Launchfiles your PR adds or edits |
+| `image:` disagrees with a tag `metadata.yaml` measured | warning   | Launchfiles your PR adds or edits |
+
+The warnings are scoped to what you touch because the grandfather clause above is
+real: the entries already on `:latest` are not a backlog this job reopens on every
+run. Run the same checks locally with `cd catalog/test && bun run validate-catalog`.
+
 ## Updating an Existing App
 
 If an app's configuration changes (new env vars, different ports, etc.), update the Launchfile and note what changed in the PR description.

--- a/catalog/test/.gitignore
+++ b/catalog/test/.gitignore
@@ -1,3 +1,2 @@
 node_modules/
 .tmp/
-bun.lock

--- a/catalog/test/README.md
+++ b/catalog/test/README.md
@@ -19,7 +19,26 @@ bun run src/test-app.ts memos --keep
 
 # Test all apps in a tier
 bun run src/test-all.ts --tier 0
+
+# Static checks only — schema + image-reference policy, nothing pulled or run
+bun run validate-catalog
+
+# The unit suite (Vitest — `bun test` is blocked by scripts/test-guard.ts)
+bun run typecheck && bun run test
 ```
+
+## Static validation
+
+`src/validate-catalog.ts` reads every `catalog/{apps,drafts}/*/Launchfile`, parses it
+with the SDK's `readLaunch` — the Zod schema in `sdk/src/schema.ts`, not the published
+JSON Schema, which nothing yet asserts agrees with it (issue #179) — and applies the
+image-reference policy in
+[`catalog/CONTRIBUTING.md`](../CONTRIBUTING.md#image-references). A missing tag or an
+`@sha256` digest is an error anywhere in the catalog; the `:latest`-without-rationale
+and `metadata.yaml`-drift checks are warnings, and only apply to Launchfiles the change
+under review touches. Set `CATALOG_DIFF_BASE=<sha>` to name the base to diff against —
+CI sets it from the pull request; with it unset, no file counts as changed and the
+warnings are not evaluated.
 
 ## Tiers
 

--- a/catalog/test/bun.lock
+++ b/catalog/test/bun.lock
@@ -1,0 +1,214 @@
+{
+  "lockfileVersion": 2,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@launchfile/catalog-test",
+      "dependencies": {
+        "playwright": "^1.59.1",
+        "yaml": "^2.8.3",
+        "zod": "^4.3.6",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.11",
+        "typescript": "^7.0.2",
+        "vitest": "^4.1.3",
+      },
+    },
+  },
+  "packages": {
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.6.0", "", {}, "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.149.0", "", {}, "sha512-Efcc+iF0j3Bf67YjEqIqWXbX5XddXoK/Mw4K1/JuXwRCZ8N16VR7iT23nlCc9XrveFVh/E5Rqs2StT0V8v9LdA=="],
+
+    "@rolldown/binding-android-arm-eabi": ["@rolldown/binding-android-arm-eabi@1.2.8", "", { "os": "android", "cpu": "arm" }, "sha512-tN5aztYkKCte4i5SIrrz5yK/HMjEuCqCSCJa418jOV8tZ1cBY3YF2otxB1ktPxzsLA1BeTqwapK0bfjxNvHJVw=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.8", "", { "os": "android", "cpu": "arm64" }, "sha512-dIYTWl9XprMUiQFoc55KUyk/oS8SKYH3zFl0LTR7RT0Xj4hgSVyuJcroH8JUu8RcpF8fTB6E0aOwCkZoYPcDSQ=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.2.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-PCSDQGXD2IyTEFrcgPyBM8jJuGmrbCMuoIOXdbEGVemruKACXoLQJrb+A45Z0L5t1RQkdfJprAYPkikbh7dzdA=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.2.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-Uk7lRsGhPFHVX/sAUC6D5H9Ol30dFHd6iquokll2th3LpdJ3F5CzQB+7DHn0Ri2mG+U7k2zXiPHDrwZenXhwSA=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.2.8", "", { "os": "freebsd", "cpu": "x64" }, "sha512-DjszaTEVogPqA5bYzsEeqDCQxbcp2fexQwKcRspYji2yzR68fCf+e4fx6kBSRDwX5/brZaHw/hWS9+A/+/w9sQ=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.2.8", "", { "os": "linux", "cpu": "arm" }, "sha512-zmwa7FTmdzB6aaEEuuls18H6Ap5JmJPSoPTuXixeJZV6tG40SyLkApQtz1g8ptZtiEKqj9OM0oNLPh1AgvE31Q=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.2.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-KdYQDPHwJVnbFwdTGMgxsI9SqblBlz6STGM+w1We/d5B8OWWidYH0MwkU/uA1wM5fIpO2MkOVxXrNzzuZhw9ew=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.2.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-jFJTifHnNPY+yzOoNZQfSIysrVyXzEQPhPnOUjmD1bcQGHH6s7c8cViKWar8YplQImE5N9JRqMCLrM2CdxOrZA=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.2.8", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FhiOziBDWPBjbcmRzfLyIJnaP7AVMFXT7YCXPjXxj7wKU3vx24RjrCNN/zjvVa+N2vVoHJwCoUBvsrN/DG3zIA=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.2.8", "", { "os": "linux", "cpu": "s390x" }, "sha512-WnHfADMzOV2Y55wlx1hzzQnar/wDt/VdvWSD99r18Mz9ylNieIGOkRx3UV21h7m/eJvjySYJkO26VvGNFkwsIQ=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.2.8", "", { "os": "linux", "cpu": "x64" }, "sha512-H9tRr5ibfXFVLxbPOseVewewFpl28zcEdjRDt2FTUZU7odxP0gEv1ki4/kGmcGOh78oRwZuuQllGLZ9zTJp84g=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.2.8", "", { "os": "linux", "cpu": "x64" }, "sha512-UefiqfM3D6IVNlZ8tSGs9+Ejjud2T+oxO0IHADU45Y+lyEjD2dVFyZHbkfX0LUb5Zugo/oIv1eCO/KVYhgYJYA=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.2.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-xWBkPOF1Q9k/Gv1nQXnVdLxKu74jXppuOM4Z3mnypVUJJJwLsMl7hNJGRAUJoG8A5MgOI1ACKM+wBFxSJzKy4A=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.2.8", "", { "os": "win32", "cpu": "x64" }, "sha512-uz2ZvfgXbxqNwijjjbxrnvALwpyODDcgc1T1N8N3rf/DXKQmaFwmB4LX4yyjggpwN2obdQLb2rgirX5ffCWYng=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@types/bun": ["@types/bun@1.4.2", "", { "dependencies": { "bun-types": "1.4.2" } }, "sha512-GimotNn7+ZV0uVArItBbriZsR1oNf0+WTzPkdcFrzShI7k2norL0uzEaJT8T33dWr7O/c9ZDuAFQrctKCi72oQ=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/node": ["@types/node@26.5.0", "", { "dependencies": { "undici-types": "~8.9.0" } }, "sha512-dVSGpriSoCgz8WnDNTuSSuSv1PC/ALXihO4ulRZt7Md8k9mlbdin3lGOcDE8SnWOgf513ByWlXd7BK4azmyg/A=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+
+    "@vitest/expect": ["@vitest/expect@4.1.11", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.11", "@vitest/utils": "4.1.11", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.11", "", { "dependencies": { "@vitest/spy": "4.1.11", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.11", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.11", "", { "dependencies": { "@vitest/utils": "4.1.11", "pathe": "^2.0.3" } }, "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.11", "", { "dependencies": { "@vitest/pretty-format": "4.1.11", "@vitest/utils": "4.1.11", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.11", "", {}, "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.11", "", { "dependencies": { "@vitest/pretty-format": "4.1.11", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "bun-types": ["bun-types@1.4.2", "", { "dependencies": { "@types/node": "*" } }, "sha512-bxV1FgK7yBIzjRe5zBozIM4Bem11ZJcCXSrjWRG3YWLt8yFDePu4cLjpebO8OvPeIE9trbyPF4fuj3Cia4Fj3w=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "es-module-lexer": ["es-module-lexer@2.3.2", "", {}, "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "lightningcss": ["lightningcss@1.33.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.33.0", "lightningcss-darwin-arm64": "1.33.0", "lightningcss-darwin-x64": "1.33.0", "lightningcss-freebsd-x64": "1.33.0", "lightningcss-linux-arm-gnueabihf": "1.33.0", "lightningcss-linux-arm64-gnu": "1.33.0", "lightningcss-linux-arm64-musl": "1.33.0", "lightningcss-linux-x64-gnu": "1.33.0", "lightningcss-linux-x64-musl": "1.33.0", "lightningcss-win32-arm64-msvc": "1.33.0", "lightningcss-win32-x64-msvc": "1.33.0" } }, "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.33.0", "", { "os": "android", "cpu": "arm64" }, "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.33.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.33.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.33.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.33.0", "", { "os": "linux", "cpu": "arm" }, "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.33.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.33.0", "", { "os": "win32", "cpu": "x64" }, "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
+
+    "obug": ["obug@2.2.1", "", {}, "sha512-XrsrhT5sybtKI6wakr2SPOlGZWWYbUXZ7a0jT8/QOeAPau+1X/bSegNe5YR75oJmEZQbKningirmGOEJCIk61Q=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.7", "", {}, "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA=="],
+
+    "playwright": ["playwright@1.63.0", "", { "dependencies": { "playwright-core": "1.63.0" }, "bin": { "playwright": "cli.js" } }, "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg=="],
+
+    "playwright-core": ["playwright-core@1.63.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg=="],
+
+    "postcss": ["postcss@8.5.28", "", { "dependencies": { "nanoid": "^3.3.18", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A=="],
+
+    "rolldown": ["rolldown@1.2.8", "", { "dependencies": { "@oxc-project/types": "=0.149.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm-eabi": "1.2.8", "@rolldown/binding-android-arm64": "1.2.8", "@rolldown/binding-darwin-arm64": "1.2.8", "@rolldown/binding-darwin-x64": "1.2.8", "@rolldown/binding-freebsd-x64": "1.2.8", "@rolldown/binding-linux-arm-gnueabihf": "1.2.8", "@rolldown/binding-linux-arm64-gnu": "1.2.8", "@rolldown/binding-linux-arm64-musl": "1.2.8", "@rolldown/binding-linux-ppc64-gnu": "1.2.8", "@rolldown/binding-linux-s390x-gnu": "1.2.8", "@rolldown/binding-linux-x64-gnu": "1.2.8", "@rolldown/binding-linux-x64-musl": "1.2.8", "@rolldown/binding-openharmony-arm64": "1.2.8", "@rolldown/binding-win32-arm64-msvc": "1.2.8", "@rolldown/binding-win32-x64-msvc": "1.2.8" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-Z67nTmhZe7anqnM/EjI392w5i/ANUinjip7QYsOyN37oayduxt3ksdX0hf5OOamkAd53BiIHfbfSzfUmzKFQqQ=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.3.1", "", {}, "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.1", "", {}, "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw=="],
+
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+
+    "undici-types": ["undici-types@8.9.0", "", {}, "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg=="],
+
+    "vite": ["vite@8.2.2", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.26", "rolldown": "~1.2.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0 || ^0.5.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q=="],
+
+    "vitest": ["vitest@4.1.11", "", { "dependencies": { "@vitest/expect": "4.1.11", "@vitest/mocker": "4.1.11", "@vitest/pretty-format": "4.1.11", "@vitest/runner": "4.1.11", "@vitest/snapshot": "4.1.11", "@vitest/spy": "4.1.11", "@vitest/utils": "4.1.11", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.11", "@vitest/browser-preview": "4.1.11", "@vitest/browser-webdriverio": "4.1.11", "@vitest/coverage-istanbul": "4.1.11", "@vitest/coverage-v8": "4.1.11", "@vitest/ui": "4.1.11", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "zod": ["zod@4.5.4", "", {}, "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA=="],
+  }
+}

--- a/catalog/test/package.json
+++ b/catalog/test/package.json
@@ -7,7 +7,9 @@
     "test-app": "bun run src/test-app.ts",
     "test-all": "bun run src/test-all.ts",
     "portability-lint-counts": "bun run src/portability-lint-counts.ts",
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "validate-catalog": "bun run src/validate-catalog.ts"
   },
   "dependencies": {
     "playwright": "^1.59.1",

--- a/catalog/test/src/validate-catalog.test.ts
+++ b/catalog/test/src/validate-catalog.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import {
+	collectImageLines,
+	lintImageReferences,
+	metadataImageNames,
+	parseImageRef,
+} from "./validate-catalog.ts";
+
+function lint(text: string, opts: { changed?: boolean; metadataText?: string } = {}) {
+	return lintImageReferences({
+		file: "catalog/apps/example/Launchfile",
+		text,
+		app: "example",
+		metadataText: opts.metadataText,
+		changed: opts.changed ?? true,
+	});
+}
+
+describe("parseImageRef", () => {
+	it("reads the tag after the last slash", () => {
+		expect(parseImageRef("ghost:5-alpine")).toEqual({
+			kind: "tagged",
+			name: "ghost",
+			tag: "5-alpine",
+		});
+	});
+
+	it("treats a registry port as part of the name, not a tag", () => {
+		expect(parseImageRef("registry.example:5000/app")).toEqual({
+			kind: "bare",
+			name: "registry.example:5000/app",
+		});
+	});
+
+	it("reads a tag on an image behind a ported registry", () => {
+		expect(parseImageRef("registry.example:5000/app:1.2")).toEqual({
+			kind: "tagged",
+			name: "registry.example:5000/app",
+			tag: "1.2",
+		});
+	});
+
+	it("recognizes a digest reference", () => {
+		expect(parseImageRef("ghost@sha256:abc123").kind).toBe("digest");
+	});
+});
+
+describe("collectImageLines", () => {
+	it("finds component images as well as the top-level one", () => {
+		const lines = collectImageLines(
+			["image: app:1", "components:", "  web:", "    image: web:2"].join("\n"),
+		);
+		expect(lines.map((l) => l.ref)).toEqual(["app:1", "web:2"]);
+		expect(lines.map((l) => l.line)).toEqual([1, 4]);
+	});
+
+	it("splits the trailing rationale comment off the reference", () => {
+		const [line] = collectImageLines("image: app:latest  # upstream publishes no versioned tag");
+		expect(line?.ref).toBe("app:latest");
+		expect(line?.rationale).toBe("upstream publishes no versioned tag");
+	});
+
+	it("keeps a `#` inside a quoted reference", () => {
+		const [line] = collectImageLines('image: "app:1#odd"');
+		expect(line?.ref).toBe("app:1#odd");
+		expect(line?.rationale).toBeUndefined();
+	});
+});
+
+describe("lintImageReferences — errors", () => {
+	it("rejects a bare reference whether or not the file changed", () => {
+		for (const changed of [true, false]) {
+			const findings = lint("image: example/app", { changed });
+			expect(findings).toHaveLength(1);
+			expect(findings[0]?.severity).toBe("error");
+			expect(findings[0]?.message).toContain("carries no tag");
+		}
+	});
+
+	it("rejects an @sha256 digest, which catalog policy forbids", () => {
+		const findings = lint("image: example/app@sha256:deadbeef", { changed: false });
+		expect(findings).toHaveLength(1);
+		expect(findings[0]?.severity).toBe("error");
+		expect(findings[0]?.message).toContain("digest");
+	});
+
+	it("accepts a tagged reference", () => {
+		expect(lint("image: ghost:5-alpine")).toEqual([]);
+	});
+});
+
+describe("lintImageReferences — :latest warning", () => {
+	it("warns on an unannotated :latest in a changed file", () => {
+		const findings = lint("image: example/app:latest");
+		expect(findings).toHaveLength(1);
+		expect(findings[0]?.severity).toBe("warning");
+		expect(findings[0]?.line).toBe(1);
+	});
+
+	it("stays silent when the file is not part of the change", () => {
+		expect(lint("image: example/app:latest", { changed: false })).toEqual([]);
+	});
+
+	it("stays silent when the line states why", () => {
+		expect(lint("image: example/app:latest  # upstream publishes no versioned tag")).toEqual([]);
+	});
+});
+
+describe("lintImageReferences — metadata drift warning", () => {
+	const metadata = ["images:", "  - name: example/app:1.0", "    size_mb: 10"].join("\n");
+
+	it("warns when metadata records another tag of the same repository", () => {
+		const findings = lint("image: example/app:2.0", { metadataText: metadata });
+		expect(findings).toHaveLength(1);
+		expect(findings[0]?.severity).toBe("warning");
+		expect(findings[0]?.message).toContain("measurements are stale");
+		expect(findings[0]?.message).toContain("bun run src/test-app.ts example");
+	});
+
+	it("stays silent when the tags agree", () => {
+		expect(lint("image: example/app:1.0", { metadataText: metadata })).toEqual([]);
+	});
+
+	it("stays silent for a repository metadata never measured", () => {
+		expect(lint("image: other/app:1.0", { metadataText: metadata })).toEqual([]);
+	});
+
+	it("stays silent when the file is not part of the change", () => {
+		expect(lint("image: example/app:2.0", { metadataText: metadata, changed: false })).toEqual(
+			[],
+		);
+	});
+});
+
+describe("metadataImageNames", () => {
+	it("returns an empty list for metadata with no images block", () => {
+		expect(metadataImageNames("category: CMS\n")).toEqual([]);
+	});
+});

--- a/catalog/test/src/validate-catalog.ts
+++ b/catalog/test/src/validate-catalog.ts
@@ -1,0 +1,334 @@
+#!/usr/bin/env bun
+/**
+ * Static validation for every catalog Launchfile — schema plus image-reference
+ * policy. Analysis only: nothing is pulled, built, or run.
+ *
+ * "Schema" here is the SDK's Zod schema (`sdk/src/schema.ts`), which is what
+ * `readLaunch` checks — not the published JSON Schema at
+ * `spec/schema/launchfile.schema.json`. The two are maintained separately and
+ * nothing asserts they agree (issue #179).
+ *
+ * Two severities:
+ *
+ *   ERROR   — fails CI. A bare `image: example/app` (silently `:latest`), or an
+ *             `@sha256` digest, which `catalog/CONTRIBUTING.md` forbids because
+ *             the catalog has no mechanism to re-pin one.
+ *   WARNING — reported, never fatal. Scoped to the Launchfiles a change adds or
+ *             edits, because `catalog/CONTRIBUTING.md` grandfathers the entries
+ *             already on `:latest` and runs no sweep. A whole-catalog warning
+ *             that never clears teaches reviewers to skip this job's output.
+ *
+ * Usage:
+ *   bun run src/validate-catalog.ts                    # ERRORs only
+ *   CATALOG_DIFF_BASE=<sha> bun run src/validate-catalog.ts   # + WARNINGs on changed files
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { parse } from "yaml";
+import { readLaunch } from "../../../sdk/src/reader.ts";
+
+export type Severity = "error" | "warning";
+
+export interface Finding {
+	severity: Severity;
+	/** Repo-relative path of the file the finding is about. */
+	file: string;
+	/** 1-based line number in that file, where the finding has one. */
+	line?: number;
+	message: string;
+}
+
+/** One `image:` line as written, before any schema normalization. */
+export interface ImageLine {
+	/** 1-based line number. */
+	line: number;
+	/** The reference exactly as written, comment and quotes stripped. */
+	ref: string;
+	/** A trailing `# …` comment on the same line — the documented `:latest` rationale marker. */
+	rationale: string | undefined;
+}
+
+/**
+ * Pull `image:` lines out of the raw YAML text rather than the parsed document.
+ * The rationale marker is a trailing comment, and both the YAML parser and the
+ * SDK schema drop comments.
+ */
+export function collectImageLines(text: string): ImageLine[] {
+	const out: ImageLine[] = [];
+	const lines = text.split("\n");
+	for (let i = 0; i < lines.length; i++) {
+		const raw = lines[i] ?? "";
+		const match = /^\s*image:\s*(.+)$/.exec(raw);
+		if (!match) continue;
+		let value = (match[1] ?? "").trim();
+		let rationale: string | undefined;
+		// A `#` inside a quoted reference is not a comment; catalog entries never
+		// quote, but the check stays correct if one does.
+		const quoted = /^(['"])(.*?)\1\s*(?:#\s*(.*))?$/.exec(value);
+		if (quoted) {
+			rationale = quoted[3]?.trim() || undefined;
+			value = quoted[2] ?? "";
+		} else {
+			const hash = value.indexOf("#");
+			if (hash !== -1) {
+				rationale = value.slice(hash + 1).trim() || undefined;
+				value = value.slice(0, hash).trim();
+			}
+		}
+		if (!value) continue;
+		out.push({ line: i + 1, ref: value, rationale });
+	}
+	return out;
+}
+
+export type ImageRefKind = "bare" | "tagged" | "digest";
+
+export interface ParsedImageRef {
+	kind: ImageRefKind;
+	/** The repository part, registry and namespace included. */
+	name: string;
+	/** The tag, for a `tagged` reference. */
+	tag?: string;
+}
+
+/**
+ * Split a reference into repository and tag. A `:` only introduces a tag when it
+ * comes after the last `/` — otherwise it is a registry port
+ * (`registry.example:5000/app`).
+ */
+export function parseImageRef(ref: string): ParsedImageRef {
+	if (ref.includes("@")) {
+		return { kind: "digest", name: ref.slice(0, ref.indexOf("@")) };
+	}
+	const lastSlash = ref.lastIndexOf("/");
+	const lastColon = ref.lastIndexOf(":");
+	if (lastColon > lastSlash) {
+		return { kind: "tagged", name: ref.slice(0, lastColon), tag: ref.slice(lastColon + 1) };
+	}
+	return { kind: "bare", name: ref };
+}
+
+/** The `images[].name` entries a tested app's `metadata.yaml` records, if it has one. */
+export function metadataImageNames(metadataText: string): string[] {
+	const doc = parse(metadataText) as unknown;
+	if (!doc || typeof doc !== "object") return [];
+	const images = (doc as { images?: unknown }).images;
+	if (!Array.isArray(images)) return [];
+	const names: string[] = [];
+	for (const entry of images) {
+		if (entry && typeof entry === "object") {
+			const name = (entry as { name?: unknown }).name;
+			if (typeof name === "string") names.push(name);
+		}
+	}
+	return names;
+}
+
+export interface LintInput {
+	/** Repo-relative path of the Launchfile. */
+	file: string;
+	/** Raw Launchfile text. */
+	text: string;
+	/** App slug, for the re-test command in the drift warning. */
+	app: string;
+	/** Raw `metadata.yaml` text, where the app has one. */
+	metadataText?: string;
+	/** Whether this change adds or edits this Launchfile. Gates the WARNINGs. */
+	changed: boolean;
+}
+
+/**
+ * Image-reference policy for one Launchfile. Schema validation is separate —
+ * see {@link validateCatalog}.
+ */
+export function lintImageReferences(input: LintInput): Finding[] {
+	const findings: Finding[] = [];
+	const metadataNames = input.metadataText ? metadataImageNames(input.metadataText) : undefined;
+
+	for (const image of collectImageLines(input.text)) {
+		const parsed = parseImageRef(image.ref);
+
+		if (parsed.kind === "bare") {
+			findings.push({
+				severity: "error",
+				file: input.file,
+				line: image.line,
+				message:
+					`\`image: ${image.ref}\` carries no tag. A bare reference silently means ` +
+					"`:latest` and hides the choice from review — write the tag out " +
+					"(catalog/CONTRIBUTING.md § Image references).",
+			});
+			continue;
+		}
+
+		if (parsed.kind === "digest") {
+			findings.push({
+				severity: "error",
+				file: input.file,
+				line: image.line,
+				message:
+					`\`image: ${image.ref}\` pins by digest. catalog/CONTRIBUTING.md: "Do not pin ` +
+					'by `@sha256` digest" — this catalog has no mechanism to re-pin one, so a ' +
+					"digest nobody refreshes is a permanently unpatched image. Use a tag.",
+			});
+			continue;
+		}
+
+		if (!input.changed) continue;
+
+		if (parsed.tag === "latest" && !image.rationale) {
+			findings.push({
+				severity: "warning",
+				file: input.file,
+				line: image.line,
+				message:
+					`\`image: ${image.ref}\` takes \`:latest\` with no stated reason. Prefer the ` +
+					"narrowest stable tag upstream maintains; where it publishes nothing " +
+					"narrower, say so on the line: " +
+					`\`image: ${image.ref}  # upstream publishes no versioned tag\`.`,
+			});
+		}
+
+		// Drift is only unambiguous when metadata records the SAME repository under
+		// a different tag. A repository metadata does not mention at all is more
+		// often an image the harness never measured than a stale record.
+		const recorded = (metadataNames ?? []).filter(
+			(name) => parseImageRef(name).name === parsed.name,
+		);
+		if (recorded.length > 0 && !recorded.includes(image.ref)) {
+			findings.push({
+				severity: "warning",
+				file: input.file,
+				line: image.line,
+				message:
+					`metadata.yaml records measurements for ${recorded.join(", ")}; the Launchfile ` +
+					`now declares ${image.ref}. The measurements are stale — re-run ` +
+					`\`bun run src/test-app.ts ${input.app}\` from catalog/test to refresh them. ` +
+					"Do not hand-edit the `images:` block; the next test run overwrites it.",
+			});
+		}
+	}
+
+	return findings;
+}
+
+/** One catalog entry on disk. */
+interface CatalogEntry {
+	app: string;
+	/** Repo-relative path of the Launchfile. */
+	file: string;
+	launchfilePath: string;
+	metadataPath: string;
+}
+
+function discoverEntries(repoRoot: string): CatalogEntry[] {
+	const entries: CatalogEntry[] = [];
+	for (const tier of ["apps", "drafts"]) {
+		const dir = join(repoRoot, "catalog", tier);
+		if (!existsSync(dir)) continue;
+		for (const app of readdirSync(dir, { withFileTypes: true })) {
+			if (!app.isDirectory()) continue;
+			const launchfilePath = join(dir, app.name, "Launchfile");
+			if (!existsSync(launchfilePath)) continue;
+			entries.push({
+				app: app.name,
+				file: `catalog/${tier}/${app.name}/Launchfile`,
+				launchfilePath,
+				metadataPath: join(dir, app.name, "metadata.yaml"),
+			});
+		}
+	}
+	return entries.sort((a, b) => a.file.localeCompare(b.file));
+}
+
+/**
+ * Repo-relative paths this change adds or edits, from `git diff` against `base`.
+ * An empty set (no base, or a base this clone cannot resolve) scopes the
+ * WARNING checks to nothing, which is the safe direction: they never fail CI.
+ */
+export function changedPaths(repoRoot: string, base: string | undefined): Set<string> {
+	if (!base || /^0+$/.test(base)) return new Set();
+	try {
+		// Array args, never a shell string: `base` comes from the workflow context.
+		const out = execFileSync("git", ["diff", "--name-only", `${base}...HEAD`], {
+			cwd: repoRoot,
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		return new Set(out.split("\n").filter(Boolean));
+	} catch {
+		process.stderr.write(
+			`  note: cannot diff against ${base} — image-policy warnings are scoped to nothing\n`,
+		);
+		return new Set();
+	}
+}
+
+export interface ValidationReport {
+	files: number;
+	findings: Finding[];
+}
+
+export function validateCatalog(repoRoot: string, changed: Set<string>): ValidationReport {
+	const findings: Finding[] = [];
+	const entries = discoverEntries(repoRoot);
+
+	for (const entry of entries) {
+		const text = readFileSync(entry.launchfilePath, "utf8");
+
+		try {
+			readLaunch(text);
+		} catch (err) {
+			findings.push({
+				severity: "error",
+				file: entry.file,
+				message: `does not satisfy the Launchfile schema: ${
+					err instanceof Error ? err.message : String(err)
+				}`,
+			});
+			// The image lint reads raw lines, so it still applies to a file the
+			// schema rejects — a contributor gets every problem in one run.
+		}
+
+		findings.push(
+			...lintImageReferences({
+				file: entry.file,
+				text,
+				app: entry.app,
+				metadataText: existsSync(entry.metadataPath)
+					? readFileSync(entry.metadataPath, "utf8")
+					: undefined,
+				changed: changed.has(entry.file),
+			}),
+		);
+	}
+
+	return { files: entries.length, findings };
+}
+
+function main(): void {
+	const repoRoot = resolve(import.meta.dirname, "../../..");
+	const changed = changedPaths(repoRoot, process.env.CATALOG_DIFF_BASE);
+	const { files, findings } = validateCatalog(repoRoot, changed);
+
+	const errors = findings.filter((f) => f.severity === "error");
+	const warnings = findings.filter((f) => f.severity === "warning");
+
+	for (const finding of findings) {
+		const where = finding.line ? `${finding.file}:${finding.line}` : finding.file;
+		const stream = finding.severity === "error" ? process.stderr : process.stdout;
+		stream.write(`${finding.severity.toUpperCase()}  ${where}\n    ${finding.message}\n\n`);
+	}
+
+	process.stdout.write(
+		`${files} catalog Launchfile(s) validated — ` +
+			`${errors.length} error(s), ${warnings.length} warning(s)` +
+			`${changed.size === 0 ? " (no changed files; warnings not evaluated)" : ""}\n`,
+	);
+
+	if (errors.length > 0) process.exit(1);
+}
+
+if (import.meta.main) main();

--- a/catalog/test/tsconfig.json
+++ b/catalog/test/tsconfig.json
@@ -8,6 +8,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "types": ["bun", "vitest/globals"],
     "forceConsistentCasingInFileNames": true,
     "allowImportingTsExtensions": true,
     "paths": {


### PR DESCRIPTION
Closes #235
Closes #321

Both issues asked for a catalog CI job, and both verdicts said whichever landed
first should create the single `catalog` job while the other extends it. This is
that one job, plus the two things it needs to exist: a static catalog validator,
and a `catalog/test` that CI can actually install and typecheck.

Two commits, one directory each:

- `catalog:` — `src/validate-catalog.ts` + its tests, a `typecheck` script, the
  `types` entry `tsconfig.json` was missing, a committed `bun.lock`, and the
  CONTRIBUTING/README documentation.
- `chore:` — the `catalog` job in `.github/workflows/ci.yml` and `CLAUDE.md`'s
  CI build order and pre-push lists.

No principle applies. `governance/GOVERNANCE.md:63` says P-1 through P-14 govern
the Launchfile format, not project process, and this changes neither a field, a
schema, nor a parser. No published package changes behavior, so there is no
changeset. `catalog/CONTRIBUTING.md` is the rule this enforces; [D-50] is the
rule the guarded harness implements, and this does not alter it.

## How #321's verdict is addressed

| # | Bound shape | Where |
|---|-------------|-------|
| 1 | Build the SDK and `providers/docker` in-job | `ci.yml` — "Build SDK and Docker provider (local dependencies)" |
| 2 | Commit `catalog/test/bun.lock` | tracked; `bun.lock` removed from `catalog/test/.gitignore` |
| 3 | `bun run test`, never `bun test` | `ci.yml`, with the guard's reason in a comment |
| 4 | Add a `typecheck` script and run it before the tests | `package.json`; `tsconfig.json` gains `types: ["bun", "vitest/globals"]`, without which `tsc` cannot resolve `node:*` and reports nothing |
| 5 | No `needs:` edge | none declared; the reasoning is in the job comment |
| 6 | Able to fail the merge box | no `continue-on-error`, no skip condition, actions pinned to the SHAs already in `ci.yml`, no `permissions:` escalation, no Playwright step |
| 7 | Name the follow-through | below, plus `CLAUDE.md` |

## How #235's verdict is addressed

| # | Bound shape | Where |
|---|-------------|-------|
| 1 | Exactly one job, named `catalog` | `ci.yml` — job id `catalog`, display name `Catalog` |
| 2 | Describe the validator accurately | the check is the SDK's Zod schema (`sdk/src/schema.ts`) via `readLaunch`, not `spec/schema/launchfile.schema.json` — stated in the script header, the README, and the CONTRIBUTING table. The gap that nothing asserts the two agree is **already tracked as #179** ("the SDK's zod parser is more permissive than the published JSON Schema"), so filing another issue would duplicate it |
| 3 | Validate `drafts/` too, and prove it | 113 files validated, 41 of them drafts — output below |
| 4 | Scope both WARNING checks to changed Launchfiles | `CATALOG_DIFF_BASE` names the base to diff against; with nothing changed, the warnings are not evaluated |
| 5 | Reject an `@sha256` digest | ERROR, alongside the missing-tag case |
| 6 | `image_tag_rationale:` top level, or drop it | dropped. The only marker is the trailing `#` comment already documented at `catalog/CONTRIBUTING.md` — it lives in the Launchfile, so `test-app.ts`'s `metadata.yaml` round-trip cannot delete it |
| 7 | Word the drift warning as a stale measurement | the warning names what `metadata.yaml` recorded, says the measurements are stale, and sends the contributor to `bun run src/test-app.ts <app>`; it explicitly says not to hand-edit the `images:` block |

## Verified locally

Every command below was run in a clean worktree off `main`.

**All 113 catalog Launchfiles parse — including the 41 drafts that were never validated anywhere:**

```
$ cd catalog/test && bun run validate-catalog
113 catalog Launchfile(s) validated — 0 error(s), 0 warning(s) (no changed files; warnings not evaluated)
```

**The suite and the typecheck:**

```
$ bun run typecheck        # tsc --noEmit, clean
$ bun run test             # Test Files 3 passed (3) · Tests 51 passed (51)
```

51 = the 33 tests #321 is about, plus 18 for the new validator.

**`bun test` still hits the guard** (which is why the job runs `bun run test`):

```
$ bun test
  bun test is not the test runner for catalog/test.
    use:  bun run test        (vitest run)
```

**The failure paths, on throwaway commits that were rolled back before pushing.**
A green run only proves the success path, so each check was made to fire:

```
# :latest and metadata drift, on a changed file — warnings, exit 0
WARNING  catalog/apps/ghost/Launchfile:8
    `image: ghost:latest` takes `:latest` with no stated reason. …
WARNING  catalog/apps/ghost/Launchfile:8
    metadata.yaml records measurements for ghost:5-alpine; the Launchfile now
    declares ghost:latest. The measurements are stale — re-run
    `bun run src/test-app.ts ghost` from catalog/test to refresh them. …
113 catalog Launchfile(s) validated — 0 error(s), 2 warning(s)   → exit 0

# bare reference and digest — errors, exit 1
ERROR  catalog/apps/ghost/Launchfile:8
    `image: ghost` carries no tag. …
ERROR  catalog/apps/memos/Launchfile:8
    `image: neosmemo/memos@sha256:0123456789abcdef` pins by digest. …
113 catalog Launchfile(s) validated — 2 error(s), 0 warning(s)   → exit 1

# a Launchfile that does not parse — error, exit 1
ERROR  catalog/drafts/adguard-home/Launchfile
    does not satisfy the Launchfile schema: Map keys must be unique at line 23 …
```

Scoping was checked in both directions: with everything treated as changed the
job would print **112** `:latest` warnings and **0** drift warnings, which is the
count `catalog/CONTRIBUTING.md`'s grandfather clause exists to keep out of every
run. Scoped to a change, day one is silent.

## Follow-through outside this diff

- **The check is advisory until an operator adds `Catalog` to the `Protect main`
  required-checks list.** That is a repo setting, not a file. #309 proposes a
  `ci-required` aggregator that would fold this job in instead; neither blocks
  the other.
- The schema-drift gap in #235's second correction is tracked in #179.

[D-50]: https://github.com/launchfile/launchfile/blob/main/spec/DESIGN.md#d-50-storagenamecontent-operator--operator-supplied-volume-content-bound-by-the-orchestrator-or-refused

🤖 Generated with [Claude Code](https://claude.com/claude-code)
