### PR TITLE
providers: the health gate reads which services declare a check, never infers it

### DIFF
--- a/.changeset/docker-health-gate-declared-checks.md
+++ b/.changeset/docker-health-gate-declared-checks.md
@@ -1,0 +1,9 @@
+---
+"@launchfile/docker": patch
+---
+
+Fix `launchfile up` reporting `✓ Health check passed` for a container in a crash loop. The health gate decided "this service declares no health check" from an empty `Health` string in `docker compose ps --format json`, but docker reports that same empty string for a service that *does* declare a check whose result is not yet known — which is what a restarting container reports, in windows of roughly 230ms. A 3s poll landing in one of those windows passed the gate, contradicting SPEC.md § Failure semantics ("a component that never becomes healthy fails the invocation").
+
+The provider generates the compose file, so it already knows which services it gave a `healthcheck:` block. `ComposeResult` now carries that fact as `healthchecks` — every emitted compose service name (backing services included) mapped to whether it declares a check — and the gate reads it instead of guessing. A service that declares a check is healthy only when `Health` is `healthy`; a service that declares none is healthy once it is running; a container matching no generated service is never healthy. No grace window and no debounce: unknown means keep waiting, and the 120s budget is unchanged.
+
+An app whose check genuinely passes, and an app declaring no `health:` at all, behave exactly as before.

--- a/.changeset/docker-health-gate-declared-checks.md
+++ b/.changeset/docker-health-gate-declared-checks.md
@@ -6,4 +6,6 @@ Fix `launchfile up` reporting `✓ Health check passed` for a container in a cra
 
 The provider generates the compose file, so it already knows which services it gave a `healthcheck:` block. `ComposeResult` now carries that fact as `healthchecks` — every emitted compose service name (backing services included) mapped to whether it declares a check — and the gate reads it instead of guessing. A service that declares a check is healthy only when `Health` is `healthy`; a service that declares none is healthy once it is running; a container matching no generated service is never healthy. No grace window and no debounce: unknown means keep waiting, and the 120s budget is unchanged.
 
+The gate names those services in the `docker compose ps` poll. `up -d` leaves the container of a renamed or removed service running as an orphan, and an unscoped poll still reports it under its old service name — a name the gate matches to nothing, so it would wait out the full 120s and then fail naming a component the app no longer has.
+
 An app whose check genuinely passes, and an app declaring no `health:` at all, behave exactly as before.

--- a/providers/docker/src/__tests__/compose-generator.test.ts
+++ b/providers/docker/src/__tests__/compose-generator.test.ts
@@ -1317,3 +1317,59 @@ components:
 		}
 	});
 });
+
+describe("ComposeResult.healthchecks", () => {
+	/**
+	 * The health gate reads this map instead of inferring "declares no check"
+	 * from an empty `Health` string, which docker also reports for a declared
+	 * check that has not been evaluated yet (#325). The map must therefore agree
+	 * with the emitted YAML exactly — for backing services as much as components,
+	 * since compose starts those too.
+	 */
+	function assertAgreesWithYaml(result: ReturnType<typeof launchToCompose>): void {
+		const doc = parse(result.yaml) as {
+			services: Record<string, { healthcheck?: unknown }>;
+		};
+		const expected = Object.fromEntries(
+			Object.entries(doc.services).map(([name, svc]) => [
+				name,
+				svc.healthcheck !== undefined,
+			]),
+		);
+		expect(result.healthchecks).toEqual(expected);
+	}
+
+	it("covers every emitted service, backing services included (ghost)", async () => {
+		const launch = await loadApp("ghost");
+		const result = launchToCompose(launch);
+
+		assertAgreesWithYaml(result);
+		// ghost declares `health:` and pulls in a mysql that ships its own check.
+		expect(result.healthchecks.ghost).toBe(true);
+		const backing = Object.keys(result.healthchecks).filter(
+			(name) => !Object.values(result.services).includes(name),
+		);
+		expect(backing.length).toBeGreaterThan(0);
+		expect(backing.some((name) => result.healthchecks[name])).toBe(true);
+	});
+
+	it("is keyed by compose service name, the same key `docker compose ps` returns", async () => {
+		const launch = await loadApp("ghost");
+		const result = launchToCompose(launch);
+
+		for (const serviceName of Object.values(result.services)) {
+			expect(result.healthchecks).toHaveProperty(serviceName);
+		}
+	});
+
+	it("records false for a component that declares no health check", async () => {
+		const launch = await loadApp("miniflux");
+		const result = launchToCompose(launch);
+
+		assertAgreesWithYaml(result);
+		for (const [name, declared] of Object.entries(result.healthchecks)) {
+			expect(typeof declared).toBe("boolean");
+			expect(result.yaml).toContain(`${name}:`);
+		}
+	});
+});

--- a/providers/docker/src/__tests__/health-gate.test.ts
+++ b/providers/docker/src/__tests__/health-gate.test.ts
@@ -1,23 +1,171 @@
 import { describe, expect, it } from "vitest";
-import { healthFailureMessage, isContainerHealthy } from "../provider.js";
+import { healthFailureMessage, isContainerHealthy, waitForHealth } from "../provider.js";
 
+/**
+ * `Health: ""` from `docker compose ps` is ambiguous: it means "no check
+ * declared" for one service and "check declared, not yet evaluated" for
+ * another. `healthchecks` — the generator's record of which services it wrote a
+ * `healthcheck:` block for — is what tells the two apart.
+ */
 describe("isContainerHealthy", () => {
-	it("accepts a running container that declares no health check", () => {
-		expect(isContainerHealthy({ State: "running", Health: "" })).toBe(true);
+	it("accepts a running container whose service declares no health check", () => {
+		expect(
+			isContainerHealthy({ State: "running", Health: "", Service: "web" }, { web: false }),
+		).toBe(true);
 	});
 
-	it("accepts a running container that passes its check", () => {
-		expect(isContainerHealthy({ State: "running", Health: "healthy" })).toBe(true);
+	it("accepts a running container that passes its declared check", () => {
+		expect(
+			isContainerHealthy({ State: "running", Health: "healthy", Service: "web" }, { web: true }),
+		).toBe(true);
+	});
+
+	it("rejects a declared check that has not been evaluated yet", () => {
+		// The #325 crash-loop window: a restarting container reports running with
+		// an empty Health. Treating that as "declares no check" passed the gate.
+		expect(
+			isContainerHealthy({ State: "running", Health: "", Service: "web" }, { web: true }),
+		).toBe(false);
 	});
 
 	it("rejects a container that is not running, whatever its health says", () => {
-		expect(isContainerHealthy({ State: "exited", Health: "" })).toBe(false);
-		expect(isContainerHealthy({ State: "exited", Health: "healthy" })).toBe(false);
+		expect(
+			isContainerHealthy({ State: "exited", Health: "", Service: "web" }, { web: false }),
+		).toBe(false);
+		expect(
+			isContainerHealthy({ State: "exited", Health: "healthy", Service: "web" }, { web: true }),
+		).toBe(false);
+		expect(
+			isContainerHealthy({ State: "restarting", Health: "", Service: "web" }, { web: true }),
+		).toBe(false);
 	});
 
 	it("rejects a running container that is starting or failing its check", () => {
-		expect(isContainerHealthy({ State: "running", Health: "starting" })).toBe(false);
-		expect(isContainerHealthy({ State: "running", Health: "unhealthy" })).toBe(false);
+		expect(
+			isContainerHealthy({ State: "running", Health: "starting", Service: "web" }, { web: true }),
+		).toBe(false);
+		expect(
+			isContainerHealthy({ State: "running", Health: "unhealthy", Service: "web" }, { web: true }),
+		).toBe(false);
+	});
+
+	it("keys on the compose service name, not the container name", () => {
+		// Pins the keying on both sides: `healthchecks` comes from the generator's
+		// service keys, and `Service` is the same string `ps` returns. A rename on
+		// either side empties the match and this test fails instead of the gate
+		// silently passing.
+		expect(
+			isContainerHealthy(
+				{ State: "running", Health: "", Service: "web", Name: "myapp-web-1" },
+				{ web: false },
+			),
+		).toBe(true);
+		expect(
+			isContainerHealthy(
+				{ State: "running", Health: "", Service: "web", Name: "myapp-web-1" },
+				{ "myapp-web-1": false },
+			),
+		).toBe(false);
+	});
+
+	it("rejects a container it cannot match to a generated service", () => {
+		// The provider wrote both sides. An unmatched name is a gap to report,
+		// never one to absorb into a pass.
+		expect(
+			isContainerHealthy({ State: "running", Health: "", Service: "stranger" }, { web: false }),
+		).toBe(false);
+		expect(
+			isContainerHealthy({ State: "running", Health: "healthy", Service: "stranger" }, { web: true }),
+		).toBe(false);
+		expect(isContainerHealthy({ State: "running", Health: "" }, { web: false })).toBe(false);
+	});
+});
+
+/** `docker compose ps --format json` output for the given rows. */
+function psLines(...rows: Record<string, string>[]): string {
+	return rows.map((r) => JSON.stringify(r)).join("\n");
+}
+
+describe("waitForHealth", () => {
+	const fast = { maxWaitMs: 30, pollIntervalMs: 1 };
+
+	it("fails a healthchecked service stuck at running with an empty Health", async () => {
+		const outcome = await waitForHealth("proj", "/tmp/compose.yaml", { web: true }, {
+			...fast,
+			ps: async () => ({
+				exitCode: 0,
+				stdout: psLines({ State: "running", Health: "", Service: "web", Name: "proj-web-1" }),
+			}),
+		});
+
+		expect(outcome).toEqual({ ok: false, stuck: ["web"] });
+	});
+
+	it("passes a healthchecked service once its check reports healthy", async () => {
+		const outcome = await waitForHealth("proj", "/tmp/compose.yaml", { web: true }, {
+			...fast,
+			ps: async () => ({
+				exitCode: 0,
+				stdout: psLines({ State: "running", Health: "healthy", Service: "web" }),
+			}),
+		});
+
+		expect(outcome).toEqual({ ok: true, stuck: [] });
+	});
+
+	it("passes a running service that declares no check", async () => {
+		const outcome = await waitForHealth("proj", "/tmp/compose.yaml", { web: false }, {
+			...fast,
+			ps: async () => ({
+				exitCode: 0,
+				stdout: psLines({ State: "running", Health: "", Service: "web" }),
+			}),
+		});
+
+		expect(outcome).toEqual({ ok: true, stuck: [] });
+	});
+
+	it("names only the stuck service when a sibling is already healthy", async () => {
+		const outcome = await waitForHealth("proj", "/tmp/compose.yaml", { web: true, db: true }, {
+			...fast,
+			ps: async () => ({
+				exitCode: 0,
+				stdout: psLines(
+					{ State: "running", Health: "healthy", Service: "db" },
+					{ State: "running", Health: "", Service: "web" },
+				),
+			}),
+		});
+
+		expect(outcome).toEqual({ ok: false, stuck: ["web"] });
+	});
+
+	it("reports nothing running when no container ever appears", async () => {
+		const outcome = await waitForHealth("proj", "/tmp/compose.yaml", { web: true }, {
+			...fast,
+			ps: async () => ({ exitCode: 0, stdout: "" }),
+		});
+
+		expect(outcome).toEqual({ ok: false, stuck: [] });
+	});
+
+	it("keeps polling while ps itself fails", async () => {
+		let calls = 0;
+		const outcome = await waitForHealth("proj", "/tmp/compose.yaml", { web: true }, {
+			...fast,
+			ps: async () => {
+				calls += 1;
+				return calls === 1
+					? { exitCode: 1, stdout: "" }
+					: {
+							exitCode: 0,
+							stdout: psLines({ State: "running", Health: "healthy", Service: "web" }),
+						};
+			},
+		});
+
+		expect(outcome).toEqual({ ok: true, stuck: [] });
+		expect(calls).toBeGreaterThan(1);
 	});
 });
 

--- a/providers/docker/src/__tests__/health-gate.test.ts
+++ b/providers/docker/src/__tests__/health-gate.test.ts
@@ -1,5 +1,32 @@
-import { describe, expect, it } from "vitest";
-import { healthFailureMessage, isContainerHealthy, waitForHealth } from "../provider.js";
+import { describe, expect, it, vi } from "vitest";
+
+/** Every argv the provider hands to `shell`, newest last. */
+const shellCalls: string[][] = [];
+
+vi.mock("../shell.js", () => ({
+	shell: async (cmd: string, args: string[]) => {
+		shellCalls.push([cmd, ...args]);
+		return {
+			exitCode: 0,
+			stdout: JSON.stringify({
+				State: "running",
+				Health: "healthy",
+				Name: "proj-api-1",
+				Service: "api",
+			}),
+			stderr: "",
+		};
+	},
+	shellStream: async () => 0,
+	shellOk: async () => true,
+}));
+
+import {
+	healthFailureMessage,
+	healthPsArgs,
+	isContainerHealthy,
+	waitForHealth,
+} from "../provider.js";
 
 /**
  * `Health: ""` from `docker compose ps` is ambiguous: it means "no check
@@ -79,6 +106,51 @@ describe("isContainerHealthy", () => {
 		).toBe(false);
 		expect(isContainerHealthy({ State: "running", Health: "" }, { web: false })).toBe(false);
 	});
+
+	it("does not match a service named after an Object.prototype key", () => {
+		// `healthchecks` is a lookup of generated service names, not a prototype
+		// chain. A container calling itself `toString` matches no generated
+		// service, so it is a stranger like any other.
+		expect(
+			isContainerHealthy({ State: "running", Health: "healthy", Service: "toString" }, { web: true }),
+		).toBe(false);
+		expect(
+			isContainerHealthy({ State: "running", Health: "", Service: "constructor" }, { web: false }),
+		).toBe(false);
+	});
+});
+
+describe("healthPsArgs", () => {
+	it("scopes the poll to the generated services", () => {
+		expect(healthPsArgs("proj", "/tmp/compose.yaml", { web: true, db: false })).toEqual([
+			"compose", "-p", "proj", "-f", "/tmp/compose.yaml", "ps", "--format", "json", "web", "db",
+		]);
+	});
+
+	it("leaves behind the orphan a rename strands", () => {
+		// `up -d` runs without `--remove-orphans`, so the container of a service
+		// renamed `web` -> `api` keeps running and an unscoped `ps` still reports
+		// `Service: "web"`. Unmatched rows fail closed, so an unscoped poll would
+		// spend the whole budget and then name a component the app no longer has.
+		const args = healthPsArgs("proj", "/tmp/compose.yaml", { api: true });
+
+		expect(args).toContain("api");
+		expect(args).not.toContain("web");
+	});
+
+	it("names the services after the format flag, where docker takes them", () => {
+		const args = healthPsArgs("proj", "/tmp/compose.yaml", { web: true });
+
+		expect(args.slice(-3)).toEqual(["--format", "json", "web"]);
+	});
+
+	it("polls bare when the generator emitted no services", () => {
+		// Nothing was generated, so there is nothing the gate can accept: every
+		// row the bare poll returns fails closed anyway.
+		expect(healthPsArgs("proj", "/tmp/compose.yaml", {})).toEqual([
+			"compose", "-p", "proj", "-f", "/tmp/compose.yaml", "ps", "--format", "json",
+		]);
+	});
 });
 
 /** `docker compose ps --format json` output for the given rows. */
@@ -147,6 +219,18 @@ describe("waitForHealth", () => {
 		});
 
 		expect(outcome).toEqual({ ok: false, stuck: [] });
+	});
+
+	it("polls the generated services when no ps is injected", async () => {
+		shellCalls.length = 0;
+
+		const outcome = await waitForHealth("proj", "/tmp/compose.yaml", { api: true }, fast);
+
+		expect(outcome).toEqual({ ok: true, stuck: [] });
+		expect(shellCalls).toHaveLength(1);
+		expect(shellCalls[0]).toEqual([
+			"docker", "compose", "-p", "proj", "-f", "/tmp/compose.yaml", "ps", "--format", "json", "api",
+		]);
 	});
 
 	it("keeps polling while ps itself fails", async () => {

--- a/providers/docker/src/compose-generator.ts
+++ b/providers/docker/src/compose-generator.ts
@@ -661,6 +661,20 @@ export interface ComposeResult {
 	/** Map of component name → generated compose service name (skipped components absent) */
 	services: Record<string, string>;
 	/**
+	 * Every compose service name the generator emitted, mapped to whether that
+	 * service carries a `healthcheck:` block. Backing services (`requires:`)
+	 * are in here alongside components — compose starts them too, so the gate
+	 * has to classify them.
+	 *
+	 * The health gate reads this instead of inferring the fact from `docker
+	 * compose ps`, whose `Health` field is `""` for BOTH "this service declares
+	 * no check" and "this service declares a check that has not been evaluated
+	 * yet" — the second is what a restarting container reports, and reading it
+	 * as the first passes a crash loop (#325). Derived from the services that
+	 * were actually emitted, so it cannot drift from the YAML above it.
+	 */
+	healthchecks: Record<string, boolean>;
+	/**
 	 * `required:` variables that arrived from neither the Launchfile nor
 	 * `opts.operatorEnv` (D-52, PROVIDERS.md §10 rule 8). Their keys are ABSENT
 	 * from the emitted compose — never `""`, never a substitute.
@@ -1257,6 +1271,12 @@ export function launchToCompose(
 		ports,
 		endpoints,
 		services: componentServices,
+		healthchecks: Object.fromEntries(
+			Object.entries(services).map(([name, service]) => [
+				name,
+				service.healthcheck !== undefined,
+			]),
+		),
 		unsuppliedRequired,
 		storageBinds,
 		unboundOperatorVolumes,

--- a/providers/docker/src/provider.ts
+++ b/providers/docker/src/provider.ts
@@ -844,8 +844,10 @@ export interface PsContainer {
  *
  * Fail-closed in both directions: a service that declares a check is healthy
  * only at `healthy`, and a container that matches no generated service at all
- * is never healthy — the provider wrote both sides, so an unmatched name is a
- * gap to report, not to absorb into a pass (the D-51/D-52 posture).
+ * is never healthy. The poll that feeds this is scoped to the generated
+ * services ({@link healthPsArgs}), so an orphan left behind by a rename never
+ * reaches here; a row that still does is a gap to report, not one to absorb
+ * into a pass (the D-51/D-52 posture).
  */
 export function isContainerHealthy(
 	container: PsContainer,
@@ -854,13 +856,45 @@ export function isContainerHealthy(
 	if (container.State !== "running") return false;
 
 	const service = container.Service;
-	if (service === undefined || !(service in healthchecks)) return false;
+	if (service === undefined || !Object.hasOwn(healthchecks, service)) return false;
 
 	return healthchecks[service] ? container.Health === "healthy" : true;
 }
 
 /** One `docker compose ps --format json` poll. Injected by the tests. */
 export type ComposePs = () => Promise<{ exitCode: number; stdout: string }>;
+
+/**
+ * The `docker compose ps` argv for one health poll, scoped to the services the
+ * generator emitted.
+ *
+ * `up -d` runs without `--remove-orphans`, so a container whose service was
+ * renamed or removed keeps running, and an unscoped `ps` still lists it under
+ * its old `Service` name. That name is not a key of `healthchecks`, so the
+ * fail-closed match holds the gate open for the whole budget and then names a
+ * component the app no longer has. Naming the generated services keeps the poll
+ * to what this `up` wrote.
+ *
+ * With no generated services there is nothing the gate can accept, so the bare
+ * poll it returns then costs nothing: every row fails closed either way.
+ */
+export function healthPsArgs(
+	project: string,
+	composeFile: string,
+	healthchecks: Readonly<Record<string, boolean>>,
+): string[] {
+	return [
+		"compose",
+		"-p",
+		project,
+		"-f",
+		composeFile,
+		"ps",
+		"--format",
+		"json",
+		...Object.keys(healthchecks),
+	];
+}
 
 export interface WaitForHealthOpts {
 	/** Total budget. Defaults to {@link HEALTH_TIMEOUT_MS}. */
@@ -883,10 +917,10 @@ export async function waitForHealth(
 	const ps: ComposePs =
 		opts.ps ??
 		(() =>
-			shell(
-				"docker", ["compose", "-p", project, "-f", composeFile, "ps", "--format", "json"],
-				{ allowFailure: true, silent: true },
-			));
+			shell("docker", healthPsArgs(project, composeFile, healthchecks), {
+				allowFailure: true,
+				silent: true,
+			}));
 	const start = Date.now();
 	let stuck: string[] = [];
 

--- a/providers/docker/src/provider.ts
+++ b/providers/docker/src/provider.ts
@@ -641,7 +641,7 @@ export async function dockerUp(source: string, opts: DockerUpOpts = {}): Promise
 		// the deployment on this path so `status`/`logs`/`down` reach them.
 		await inPhase("health", withLogs(), () =>
 			withSpan("up:health", { project }, async () => {
-				const health = await waitForHealth(project, composeFile);
+				const health = await waitForHealth(project, composeFile, result.healthchecks);
 				if (!health.ok) {
 					const message = healthFailureMessage(
 						health.stuck,
@@ -821,22 +821,72 @@ export function healthFailureMessage(
 		: `no container was running after ${seconds}s`;
 }
 
-/** A container is healthy when it is running and either passes or declares no check. */
-export function isContainerHealthy(container: { State: string; Health: string }): boolean {
-	const declaresNoCheck = container.Health === "";
-	return (
-		container.State === "running" &&
-		(container.Health === "healthy" || declaresNoCheck)
-	);
+/** A row of `docker compose ps --format json`, as the health gate reads it. */
+export interface PsContainer {
+	State: string;
+	Health: string;
+	Name?: string;
+	Service?: string;
 }
 
-async function waitForHealth(
+/**
+ * Whether one `docker compose ps` row counts as healthy, given the generator's
+ * record of which services it wrote a `healthcheck:` block for
+ * (`ComposeResult.healthchecks`, keyed by compose service name — the same
+ * string `ps` returns as `Service`).
+ *
+ * The row's `Health` field cannot answer this on its own: docker reports `""`
+ * both for a service that declares no check and for a checked container whose
+ * check has not been evaluated yet. A crash-looping container sits in the
+ * second state for ~230ms windows, and any poll landing in one used to pass the
+ * gate (#325). So the declared-check fact comes from the generator, and `Health`
+ * only ever answers the narrower question "has this declared check passed".
+ *
+ * Fail-closed in both directions: a service that declares a check is healthy
+ * only at `healthy`, and a container that matches no generated service at all
+ * is never healthy — the provider wrote both sides, so an unmatched name is a
+ * gap to report, not to absorb into a pass (the D-51/D-52 posture).
+ */
+export function isContainerHealthy(
+	container: PsContainer,
+	healthchecks: Readonly<Record<string, boolean>>,
+): boolean {
+	if (container.State !== "running") return false;
+
+	const service = container.Service;
+	if (service === undefined || !(service in healthchecks)) return false;
+
+	return healthchecks[service] ? container.Health === "healthy" : true;
+}
+
+/** One `docker compose ps --format json` poll. Injected by the tests. */
+export type ComposePs = () => Promise<{ exitCode: number; stdout: string }>;
+
+export interface WaitForHealthOpts {
+	/** Total budget. Defaults to {@link HEALTH_TIMEOUT_MS}. */
+	maxWaitMs?: number;
+	/** Gap between polls. Defaults to 3s. */
+	pollIntervalMs?: number;
+	/** How to read container status. Defaults to `docker compose ps`. */
+	ps?: ComposePs;
+}
+
+export async function waitForHealth(
 	project: string,
 	composeFile: string,
+	healthchecks: Readonly<Record<string, boolean>>,
+	opts: WaitForHealthOpts = {},
 ): Promise<HealthOutcome> {
 	const log = getLogger();
-	const maxWait = HEALTH_TIMEOUT_MS;
-	const pollInterval = 3_000;
+	const maxWait = opts.maxWaitMs ?? HEALTH_TIMEOUT_MS;
+	const pollInterval = opts.pollIntervalMs ?? 3_000;
+	const ps: ComposePs =
+		opts.ps ??
+		(() =>
+			shell(
+				"docker", ["compose", "-p", project, "-f", composeFile, "ps", "--format", "json"],
+				{ allowFailure: true, silent: true },
+			));
 	const start = Date.now();
 	let stuck: string[] = [];
 
@@ -844,10 +894,7 @@ async function waitForHealth(
 		const elapsed = Date.now() - start;
 		log.trace({ elapsed, project }, "health poll");
 
-		const result = await shell(
-			"docker", ["compose", "-p", project, "-f", composeFile, "ps", "--format", "json"],
-			{ allowFailure: true, silent: true },
-		);
+		const result = await ps();
 
 		if (result.exitCode !== 0) {
 			await new Promise((r) => setTimeout(r, pollInterval));
@@ -861,10 +908,10 @@ async function waitForHealth(
 
 		for (const line of lines) {
 			try {
-				const container = JSON.parse(line) as { State: string; Health: string; Name: string; Service: string };
+				const container = JSON.parse(line) as PsContainer;
 				hasContainers = true;
-				if (!isContainerHealthy(container)) {
-					unhealthy.push(container.Service || container.Name);
+				if (!isContainerHealthy(container, healthchecks)) {
+					unhealthy.push(container.Service || container.Name || "(unnamed container)");
 				}
 			} catch {
 				// Skip unparseable lines


### PR DESCRIPTION
Closes #325

`launchfile up` printed `✓ Health check passed` for a container in a crash loop. `isContainerHealthy` decided "this service declares no health check" from `container.Health === ""`, but `docker compose ps --format json` reports that same empty string for a service that *does* declare a check whose result is not yet known. The gate polls every 3s over a 120s budget, so any poll landing in one of those windows returned `{ ok: true }` — contradicting [`spec/SPEC.md` § Failure semantics](https://github.com/launchfile/launchfile/blob/main/spec/SPEC.md), which says a component that never becomes healthy fails the invocation ([D-48] gives the disposition).

## How the verdict's bound shape was addressed

**1. Pass the declared-healthcheck fact in; never infer it from `Health`.** `ComposeResult` now carries `healthchecks`: every emitted compose service name mapped to whether it got a `healthcheck:` block. `waitForHealth` takes it from the call site in `dockerUp`.

One deliberate departure from the verdict's suggested insertion point. The verdict named `compose-generator.ts:1144-1147` — the component `healthcheck:` write. Populating there would have missed `requires:` **backing services**, which ship their own healthchecks (mysql, postgres, redis), are started by the same `up`, and appear in the same `ps` output. Classifying those as "declares no check" would have left the identical bug for every app with a backing service. The map is instead derived from the emitted `services` object at the return, which is the same fact for components, additionally correct for backing services, and — being read off what was actually serialized — cannot drift from the YAML. The verdict's own alternative ("re-reading the generated compose file also works") is the same reading, without the second file read.

**2. Keyed on the compose service key.** `healthchecks` is keyed by compose service name, the same string `ps` returns as `Service` and the same key `ComposeResult.services` maps components to. Two tests pin it: one asserts the container `Name` (`myapp-web-1`) is *not* accepted as a key, one asserts every value of `result.services` appears in `result.healthchecks`. A rename on either side fails loudly instead of silently emptying the set.

**3. Unknown means keep waiting, never pass.** A service that declares a check is healthy only at `Health === "healthy"`. No debounce, no grace window; the 120s budget is unchanged.

**4. Fail closed on an unmatched service.** A container whose `Service` matches no generated service is never healthy, and its name goes into the stuck list. The provider wrote both sides, so an unmatched name is a gap to report rather than absorb into a pass — the posture of [D-51] and [D-52].

**5. Replaced the test that asserted the defect.** `isContainerHealthy({State:"running", Health:""})` → `true` is now two cases, one per meaning of the empty string. The `restarting` case is kept. `waitForHealth` is exported and accepts an injected `ps` plus a shortened budget, so the crash-loop case is a unit test rather than a two-minute one: a healthchecked service stuck at `running` with an empty `Health` now ends as `{ ok: false, stuck: ["web"] }`.

**6. Observed runs.** Below.

**7. Stayed inside the docker provider.** `catalog/test/src/test-app.ts` is untouched.

## Observed runs — Docker 29.7.2, macOS

Three real `up` invocations through `dockerUp`, each torn down with `down --destroy`.

**The crash loop now fails the gate.** An alpine app declaring `health: /healthz` whose start command is `sh -c 'echo booting; sleep 1; exit 1'`, under the generator's default `restart: unless-stopped`:

```
  ↓ Pulling alpine:3.20... done (2s)
  ↓ Starting services...
  ! component(s) gh325-crashloop did not become healthy within 120s
    Containers are left running. Inspect them with: launchfile status / launchfile logs
RESULT: up FAILED — component(s) gh325-crashloop did not become healthy within 120s
```

The failure record carries `"phase": "health"`, `"disposition": "failed-invocation"`, and the container's own repeated `booting` output.

**Two runs that stay green.** An app whose declared check genuinely passes, and an app declaring no `health:` at all — both print `✓ Health check passed` and exit 0.

**The ambiguity itself, sampled.** #325's load-bearing claim was that `docker compose ps` really does report `Health: ""` transiently for a container that *does* declare a healthcheck — the one thing the issue review could not confirm from this repository. Sampling `docker compose ps --format json` every 150ms across the crash loop, 188 rows:

| `State` | `Health` | rows |
|--------------|--------------|------|
| `restarting` | `""`         | 143  |
| `running`    | `"starting"` | 36   |
| `running`    | `""`         | **6**|
| `restarting` | `"starting"` | 3    |

```
t=   2.40s  State='running'     Health='starting'
t=   2.55s  State='running'     Health=''
t=   2.70s  State='running'     Health='starting'
```

Six of 188 rows — about 3% of polls, and the generated compose for that service carries a `healthcheck:` block. Replaying all 188 rows through both predicates: the old one calls this crash loop healthy **6 times**; the new one, **never**.

## Two claims from the issue body that are not repeated here

Per the verdict: `no-fabrication-guard.test.ts` does not cover health classification, and glance's `health_check_passed: true` predates its `health:` field and was written by `docker compose up -d --wait`, not by this code path.

## Tests

`bun run typecheck` and `bun run test` green in every affected package: sdk 425/425, providers/docker **364/364**, providers/macos-dev 205/205, providers/aws 55/55, packages/launchfile 96/96. `bun test` in `providers/docker` is refused by the repo's own runner guard, which directs to `bun run test` (vitest) — the runner CI uses. Biome diagnostics are byte-identical to `main` (53 errors / 124 warnings, all pre-existing; CI does not run provider lint).

Changeset: `patch` on `@launchfile/docker`.

[D-48]: https://github.com/launchfile/launchfile/blob/main/spec/DESIGN.md#d-48-per-stage-failure-semantics-and-one-duration-grammar-zero-new-fields
[D-51]: https://github.com/launchfile/launchfile/blob/main/spec/DESIGN.md#d-51-unexecuted-schedule-is-reported-loudly-not-silently-accepted
[D-52]: https://github.com/launchfile/launchfile/blob/main/spec/DESIGN.md#d-52-a-required-environment-variable-is-operator-supplied--providers-must-not-fabricate-one

🤖 Generated with [Claude Code](https://claude.com/claude-code)
