### PR TITLE
chore: one required CI context — a ci-required aggregator, plus a lint that keeps its needs list complete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,10 +253,11 @@ jobs:
               + glob.glob('.github/workflows/*.yaml')
           )
           failed = []
+          parsed = {}
           for f in files:
               try:
                   with open(f) as fh:
-                      yaml.safe_load(fh)
+                      parsed[f] = yaml.safe_load(fh)
                   print(f'  ok  {f}')
               except yaml.YAMLError as e:
                   failed.append((f, str(e)))
@@ -265,4 +266,75 @@ jobs:
               print(f'\n{len(failed)} workflow file(s) failed YAML validation', file=sys.stderr)
               sys.exit(1)
           print(f'\n{len(files)} workflow file(s) parsed cleanly')
+
+          # ci-required is the only CI context the `Protect main` ruleset
+          # requires, and it gates exactly what it waits on. A job missing from
+          # its `needs:` list runs, reports, and blocks nothing. Assert the list
+          # names every other job in ci.yml, in both directions.
+          ci = parsed.get('.github/workflows/ci.yml') or {}
+          jobs = ci.get('jobs') or {}
+          if 'ci-required' not in jobs:
+              print('::error::ci.yml has no ci-required job', file=sys.stderr)
+              sys.exit(1)
+          needs = (jobs['ci-required'] or {}).get('needs') or []
+          if isinstance(needs, str):
+              needs = [needs]
+          expected = set(jobs) - {'ci-required'}
+          missing = sorted(expected - set(needs))
+          extra = sorted(set(needs) - expected)
+          for j in missing:
+              print(
+                  f"::error::ci.yml job '{j}' is missing from ci-required's "
+                  'needs: — it would gate nothing',
+                  file=sys.stderr,
+              )
+          for j in extra:
+              print(
+                  f"::error::ci-required needs '{j}', which is not a job in "
+                  'ci.yml',
+                  file=sys.stderr,
+              )
+          if missing or extra:
+              sys.exit(1)
+          print(f'ci-required waits on all {len(expected)} other ci.yml jobs')
           PY
+
+  # The single required status check on the `Protect main` ruleset. A ruleset
+  # matches a required check by its rendered name, so requiring the jobs
+  # directly makes merge policy track matrix membership: add a matrix entry and
+  # it reports a name nothing requires, remove one and a required name never
+  # reports at all. This job's name never changes, so the ruleset needs one
+  # context and this workflow decides what "CI passed" means. The workflow-lint
+  # job asserts the needs: list below names every other job here.
+  ci-required:
+    name: CI required
+    needs:
+      - sdk
+      - providers
+      - aws-terraform-validate
+      - cli
+      - catalog
+      - websites
+      - spec-citations
+      - workflow-lint
+    # Without always() this job is skipped the moment anything it needs fails,
+    # and a skipped required check never reports — the merge box would wait for
+    # a result that is not coming.
+    if: always()
+    runs-on: ubuntu-latest
+    # Reads no code, calls no API.
+    permissions: {}
+    steps:
+      - name: Fail unless every CI job succeeded
+        env:
+          # Through env, not interpolated into the script body. A result is one
+          # of success / failure / cancelled / skipped.
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          echo "upstream job results: $RESULTS"
+          for result in $RESULTS; do
+            if [ "$result" != "success" ]; then
+              echo "::error::A required CI job reported '$result' (expected success)."
+              exit 1
+            fi
+          done


### PR DESCRIPTION
Closes #309.

**Base: `chore/gov-catalog-ci` (PR #350), not `main`.** The aggregator's `needs:` list must name the `catalog` job, which only exists on that branch. Open this PR with `--base chore/gov-catalog-ci`; it becomes a `main` PR once #350 lands.

## What changed

One file, `.github/workflows/ci.yml`:

1. A new `ci-required` job (`name: CI required`) with `if: always()`, `permissions: {}`, and `needs:` naming **all eight** other jobs — `sdk`, `providers`, `aws-terraform-validate`, `cli`, `catalog`, `websites`, `spec-citations`, `workflow-lint`.
2. Its one step reads `${{ join(needs.*.result, ' ') }}` through `env: RESULTS` and fails unless **every** result is exactly `success`. A job result is one of `success` / `failure` / `cancelled` / `skipped`; the gate denies by default rather than allowing values it was not written against.
3. `workflow-lint` now keeps the parsed workflow documents and compares `ci.yml`'s job names (minus `ci-required`) against `ci-required`'s `needs:` list, failing on a difference in either direction.

## How the verdict's six points were addressed

| Verdict point | Where |
|---|---|
| 1. Wait on every job, including `spec-citations` | `needs:` names all eight jobs; `catalog` (from #350) is in the list too |
| 2. Fail unless every result is exactly `success` | The loop compares each result to `success`; `skipped` and `cancelled` both fail |
| 3. `workflow-lint` asserts the list covers every job | Coverage check added inside the existing `yaml.safe_load` step, both directions |
| 4. Land the job first, then edit the ruleset | Operator step, below — not in this PR |
| 5. Show the failure path failing | Verification, below |
| 6. Rewrite the Conformance section | Conformance, below — the issue's P-13 claim was wrong |

## Operator step after merge — do not do it before

`Protect main` (ruleset 14841674) currently requires `steward/review` plus five CI contexts by name — `SDK`, `CLI`, `Workflow Lint`, `AWS provider — terraform validate`, `Spec Citations` — read from the live ruleset while preparing this PR. **Do not touch the ruleset until this job has reported once on `main`** — a required context that has never reported stays pending and blocks every merge. After it reports, replace those five contexts with the single context `CI required`. Keep `steward/review` required. Leave "require branches to be up to date before merging" off. The swap is reversible in one step: put the five names back.

## Verification (OBSERVED)

- `actionlint .github/workflows/ci.yml` on the change and on its base produce **identical** output — one pre-existing `SC2034` warning at line 202 in the `websites` job. The change adds no new finding.
- The `workflow-lint` script, extracted verbatim from `ci.yml` and run against this worktree: `6 workflow file(s) parsed cleanly` / `ci-required waits on all 8 other ci.yml jobs`, exit 0.
- The coverage check fails closed in all three shapes, each on a mutated copy of the workflow tree:
  - a job added but not listed → exit 1, `::error::ci.yml job 'brand-new-gate' is missing from ci-required's needs: — it would gate nothing`
  - `needs:` naming a job that does not exist → exit 1, `::error::ci-required needs 'ghost-job', which is not a job in ci.yml`
  - `ci-required` renamed away → exit 1, `::error::ci.yml has no ci-required job`
- The gate's deny branch, running the step's script verbatim under `bash` with `RESULTS` set by hand (verdict point 5 — "run the loop over a `skipped` value"):

  | `RESULTS` | exit | output |
  |---|---|---|
  | all `success` | 0 | — |
  | one `failure` | 1 | `::error::A required CI job reported 'failure' (expected success).` |
  | one `skipped` | 1 | `::error::A required CI job reported 'skipped' (expected success).` |
  | one `cancelled` | 1 | `::error::A required CI job reported 'cancelled' (expected success).` |

  A real failing GitHub run could not be produced ahead of this PR: `ci.yml` triggers on `pull_request` and on `push` to `main` only, so a scratch branch alone runs nothing. This PR's own run exercises the success path.

## Conformance

**No design principle applies.** `governance/GOVERNANCE.md` scopes P-1…P-14 to the Launchfile format — fields, schema, parser behavior. This changes a workflow file and a branch-protection ruleset; no Launchfile field, schema, or parser is touched. The issue cited P-13 as "fail loudly"; P-13 is *Additive extensibility*, and that citation is withdrawn. Precedent, as the steward's verdict on #309 cites it: #310, and #299 / PR #302.

**The "3+ real catalog apps" motivation requirement does not apply.** No catalog app motivates a CI job. The motivation is the repo's own merge policy.

**No decision entry.** This binds no `D-*`: it changes no format behavior a Launchfile author or provider implementer could observe.

**No changeset.** No published package (`sdk`, `packages/launchfile`, `providers/*`) changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
