### PR TITLE
providers: run macos-dev source prepare on demand (D-38)

### DIFF
--- a/.changeset/macos-dev-prepare-on-demand.md
+++ b/.changeset/macos-dev-prepare-on-demand.md
@@ -1,0 +1,5 @@
+---
+"@launchfile/macos-dev": minor
+---
+
+Run the source-mode prepare command (`install ?? build`) on demand instead of on every `up`, as D-38 requires. The only gate was `--no-build`, an opt-out a person had to remember, so every `up` reinstalled dependencies. `up` now fingerprints the prepare inputs — the command string plus the dependency manifests and lockfiles in the directory the command runs in — and records the fingerprint of each component's last successful run under `prepared` in `.launchfile/state.json`. A component whose fingerprint is unchanged is skipped and reports `Prepare up to date`; a first launch, an edited lockfile or manifest, or a changed `install`/`build` command re-runs it. Components sharing a working directory and command share one prepare, so it runs once per `up`. A failed prepare records nothing and is retried on the next `up`, and `--no-build` still skips the slot entirely. Dependency files nested below the working directory (a monorepo's per-workspace manifests) do not move the fingerprint. State files written by earlier versions carry no record, so the first `up` after upgrading prepares every component once.

--- a/providers/macos-dev/CLAUDE.md
+++ b/providers/macos-dev/CLAUDE.md
@@ -10,6 +10,7 @@ A Launchfile provider that runs apps natively on macOS for local development. Us
 
 - **Source-first** — ignores `image:`, uses `runtime:` + native package managers
 - **Source-mode commands** — runs from source: `install ?? build` for prepare, `dev` over `start` for run (D-38); `release`/`bootstrap`/`seed`/`test` are mode-invariant. Commands run natively with user privileges, so this provider is for local, trusted sources
+- **Prepare on demand** — the prepare command runs on first launch and whenever its inputs change (the command itself, or a dependency manifest/lockfile in its working directory), never on every `up` (D-38). `prepare-fingerprint.ts` computes the signal; `state.prepared` records it
 - **Brew-first** — shared database services, app-specific databases namespaced by app name
 - **Supports skip by default** — use `--with-optional` for optional resources
 
@@ -42,7 +43,8 @@ This package is a library consumed by the unified `launchfile` CLI (`packages/la
 - `resources/` — Brew-based provisioners (postgres, redis, mysql, sqlite)
 - `runtimes/` — Version manager integrations (fnm, pyenv, rbenv)
 - `process-manager.ts` — Multi-component startup with topological sort and health waits
-- `state.ts` — Persists secrets, ports, and credentials in project-local `.launchfile/state.json`
+- `state.ts` — Persists secrets, ports, credentials, and prepare fingerprints in project-local `.launchfile/state.json`
+- `prepare-fingerprint.ts` — Digests the prepare inputs so `install ?? build` runs on demand (D-38)
 
 ## Dependencies
 

--- a/providers/macos-dev/src/__tests__/prepare-on-demand.test.ts
+++ b/providers/macos-dev/src/__tests__/prepare-on-demand.test.ts
@@ -1,0 +1,334 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readLaunch } from "@launchfile/sdk";
+import { beforeEach, describe, expect, it } from "vitest";
+import { prepareFingerprint } from "../prepare-fingerprint.js";
+import { runSourcePrepare, type SourcePrepareContext } from "../provider.js";
+import { initState, type LaunchState } from "../state.js";
+
+async function tempProject(): Promise<string> {
+	return mkdtemp(join(tmpdir(), "lf-prepare-"));
+}
+
+describe("prepareFingerprint", () => {
+	let dir: string;
+
+	beforeEach(async () => {
+		dir = await tempProject();
+		return async () => {
+			await rm(dir, { recursive: true, force: true });
+		};
+	});
+
+	it("is stable across calls when nothing changed", async () => {
+		await writeFile(
+			join(dir, "package.json"),
+			'{"dependencies":{"a":"1.0.0"}}',
+		);
+		const first = await prepareFingerprint(dir, "bun install");
+		const second = await prepareFingerprint(dir, "bun install");
+		expect(second).toBe(first);
+	});
+
+	it("changes when a lockfile's contents change", async () => {
+		await writeFile(join(dir, "bun.lock"), "a@1.0.0");
+		const before = await prepareFingerprint(dir, "bun install");
+		await writeFile(join(dir, "bun.lock"), "a@2.0.0");
+		expect(await prepareFingerprint(dir, "bun install")).not.toBe(before);
+	});
+
+	it("changes when a manifest changes with no lockfile present", async () => {
+		await writeFile(join(dir, "package.json"), '{"dependencies":{}}');
+		const before = await prepareFingerprint(dir, "npm install");
+		await writeFile(
+			join(dir, "package.json"),
+			'{"dependencies":{"b":"1.0.0"}}',
+		);
+		expect(await prepareFingerprint(dir, "npm install")).not.toBe(before);
+	});
+
+	it("changes when a dependency file appears", async () => {
+		const before = await prepareFingerprint(dir, "bundle install");
+		await writeFile(join(dir, "Gemfile.lock"), "rails");
+		expect(await prepareFingerprint(dir, "bundle install")).not.toBe(before);
+	});
+
+	it("changes when the prepare command changes", async () => {
+		await writeFile(join(dir, "package.json"), "{}");
+		const before = await prepareFingerprint(dir, "bun install");
+		expect(await prepareFingerprint(dir, "bun install --production")).not.toBe(
+			before,
+		);
+	});
+
+	it("ignores files that are not dependency inputs", async () => {
+		await writeFile(join(dir, "package.json"), "{}");
+		const before = await prepareFingerprint(dir, "bun install");
+		await writeFile(join(dir, "README.md"), "# hello");
+		expect(await prepareFingerprint(dir, "bun install")).toBe(before);
+	});
+
+	it("returns a digest for a directory that does not exist", async () => {
+		const missing = join(dir, "nope");
+		expect(await prepareFingerprint(missing, "bun install")).toMatch(
+			/^[0-9a-f]{16}$/,
+		);
+	});
+});
+
+/** Collects the commands a prepare run would have executed. */
+function recorder() {
+	const commands: string[] = [];
+	const run: NonNullable<SourcePrepareContext["run"]> = async (command) => {
+		commands.push(command);
+		return undefined;
+	};
+	return { commands, run };
+}
+
+const SINGLE = `name: demo
+components:
+  web:
+    commands:
+      install: bun install
+      dev: bun run dev
+`;
+
+describe("runSourcePrepare (D-38 on demand)", () => {
+	let dir: string;
+	let state: LaunchState;
+
+	beforeEach(async () => {
+		dir = await tempProject();
+		state = initState("demo", SINGLE);
+		await writeFile(join(dir, "bun.lock"), "a@1.0.0");
+		return async () => {
+			await rm(dir, { recursive: true, force: true });
+		};
+	});
+
+	async function prepare(
+		yaml: string,
+		rec: ReturnType<typeof recorder>,
+	): Promise<void> {
+		await runSourcePrepare(readLaunch(yaml), {
+			projectDir: dir,
+			state,
+			envs: {},
+			run: rec.run,
+			save: async () => {},
+		});
+	}
+
+	it("runs on first launch and records the fingerprint", async () => {
+		const rec = recorder();
+		await prepare(SINGLE, rec);
+		expect(rec.commands).toEqual(["bun install"]);
+		expect(state.prepared?.web).toMatch(/^[0-9a-f]{16}$/);
+	});
+
+	it("does not run again when nothing changed", async () => {
+		await prepare(SINGLE, recorder());
+		const second = recorder();
+		await prepare(SINGLE, second);
+		expect(second.commands).toEqual([]);
+	});
+
+	it("runs again when the lockfile changes", async () => {
+		await prepare(SINGLE, recorder());
+		await writeFile(join(dir, "bun.lock"), "a@2.0.0");
+		const second = recorder();
+		await prepare(SINGLE, second);
+		expect(second.commands).toEqual(["bun install"]);
+	});
+
+	it("runs again when the declared command changes", async () => {
+		await prepare(SINGLE, recorder());
+		const changed = SINGLE.replace(
+			"install: bun install",
+			"install: bun install --frozen-lockfile",
+		);
+		const second = recorder();
+		await prepare(changed, second);
+		expect(second.commands).toEqual(["bun install --frozen-lockfile"]);
+	});
+
+	it("falls back to `build` where no `install` is declared (install ?? build)", async () => {
+		const buildOnly = `name: demo
+components:
+  web:
+    commands:
+      build: make deps
+      dev: bun run dev
+`;
+		const rec = recorder();
+		await prepare(buildOnly, rec);
+		expect(rec.commands).toEqual(["make deps"]);
+	});
+
+	it("uses the package-manager fallback where a component declares neither", async () => {
+		const bare = `name: demo
+components:
+  web:
+    commands:
+      dev: bun run dev
+`;
+		const rec = recorder();
+		await runSourcePrepare(readLaunch(bare), {
+			projectDir: dir,
+			state,
+			envs: {},
+			fallbackCommand: "bun install",
+			run: rec.run,
+			save: async () => {},
+		});
+		expect(rec.commands).toEqual(["bun install"]);
+	});
+
+	it("skips a component with no prepare command and no fallback", async () => {
+		const bare = `name: demo
+components:
+  web:
+    commands:
+      dev: bun run dev
+`;
+		const rec = recorder();
+		await prepare(bare, rec);
+		expect(rec.commands).toEqual([]);
+		expect(state.prepared).toEqual({});
+	});
+
+	it("runs a shared prepare once on first launch", async () => {
+		const shared = `name: demo
+components:
+  web:
+    commands:
+      install: bun install
+      dev: bun run dev
+  worker:
+    commands:
+      install: bun install
+      dev: bun run worker
+`;
+		const rec = recorder();
+		await prepare(shared, rec);
+		expect(rec.commands).toEqual(["bun install"]);
+		expect(state.prepared?.web).toBe(state.prepared?.worker);
+	});
+
+	it("prepares each component separately when their source directories differ", async () => {
+		await mkdir(join(dir, "api"), { recursive: true });
+		await writeFile(join(dir, "api", "bun.lock"), "a@1.0.0");
+		const twoDirs = `name: demo
+components:
+  web:
+    commands:
+      install: bun install
+      dev: bun run dev
+  api:
+    source: api
+    commands:
+      install: bun install
+      dev: bun run api
+`;
+		const rec = recorder();
+		await prepare(twoDirs, rec);
+		expect(rec.commands).toEqual(["bun install", "bun install"]);
+	});
+
+	it("records nothing for a command that fails, so the next launch retries", async () => {
+		const failing: SourcePrepareContext["run"] = async () => {
+			throw new Error("install failed");
+		};
+		await expect(
+			runSourcePrepare(readLaunch(SINGLE), {
+				projectDir: dir,
+				state,
+				envs: {},
+				run: failing,
+				save: async () => {},
+			}),
+		).rejects.toThrow("install failed");
+		expect(state.prepared).toEqual({});
+
+		const retry = recorder();
+		await prepare(SINGLE, retry);
+		expect(retry.commands).toEqual(["bun install"]);
+	});
+
+	it("persists after each successful component so a later failure keeps the record", async () => {
+		await mkdir(join(dir, "api"), { recursive: true });
+		const twoComponents = `name: demo
+components:
+  web:
+    commands:
+      install: bun install
+      dev: bun run dev
+  api:
+    source: api
+    commands:
+      install: cargo build
+      dev: bun run api
+`;
+		const saved: LaunchState[] = [];
+		const run: SourcePrepareContext["run"] = async (command) => {
+			if (command === "cargo build") throw new Error("boom");
+			return undefined;
+		};
+		await expect(
+			runSourcePrepare(readLaunch(twoComponents), {
+				projectDir: dir,
+				state,
+				envs: {},
+				run,
+				save: async (_dir, s) => {
+					saved.push(structuredClone(s));
+				},
+			}),
+		).rejects.toThrow("boom");
+		expect(saved).toHaveLength(1);
+		expect(Object.keys(saved[0]!.prepared ?? {})).toEqual(["web"]);
+	});
+
+	it("passes the component's resolved env to the command", async () => {
+		const seen: (Record<string, string> | undefined)[] = [];
+		const run: SourcePrepareContext["run"] = async (_command, opts) => {
+			seen.push(opts.env);
+			return undefined;
+		};
+		await runSourcePrepare(readLaunch(SINGLE), {
+			projectDir: dir,
+			state,
+			envs: { web: { NODE_ENV: "development" } },
+			run,
+			save: async () => {},
+		});
+		expect(seen).toEqual([{ NODE_ENV: "development" }]);
+	});
+
+	it("honors a declared prepare timeout", async () => {
+		const withTimeout = `name: demo
+components:
+  web:
+    commands:
+      install:
+        command: bun install
+        timeout: 30s
+      dev: bun run dev
+`;
+		const seen: (number | undefined)[] = [];
+		const run: SourcePrepareContext["run"] = async (_command, opts) => {
+			seen.push(opts.timeout);
+			return undefined;
+		};
+		await runSourcePrepare(readLaunch(withTimeout), {
+			projectDir: dir,
+			state,
+			envs: {},
+			run,
+			save: async () => {},
+		});
+		expect(seen).toEqual([30_000]);
+	});
+});

--- a/providers/macos-dev/src/lockfile-detect.ts
+++ b/providers/macos-dev/src/lockfile-detect.ts
@@ -25,6 +25,17 @@ const LOCKFILE_ORDER: PackageManager[] = [
 	{ name: "uv", installCommand: "uv sync", lockfile: "uv.lock" },
 ];
 
+/**
+ * Every lockfile name this provider knows, deduplicated. Dependency-change
+ * detection (D-38 on-demand prepare) reads them all rather than only the one
+ * `detectPackageManager` selects: a polyglot component can carry more than one,
+ * and priority order decides which install command to run, not which files
+ * count as dependency inputs.
+ */
+export function lockfileNames(): string[] {
+	return [...new Set(LOCKFILE_ORDER.map((pm) => pm.lockfile))];
+}
+
 async function fileExists(path: string): Promise<boolean> {
 	try {
 		await access(path);

--- a/providers/macos-dev/src/prepare-fingerprint.ts
+++ b/providers/macos-dev/src/prepare-fingerprint.ts
@@ -1,0 +1,68 @@
+/**
+ * Dependency fingerprinting for the source-mode `prepare` slot (D-38).
+ *
+ * D-38 requires prepare (`install ?? build`) to run "on demand (first launch or
+ * a detected dependency change), never on every `dev`". The detection is a
+ * fingerprint of the prepare inputs: the command string plus the contents of
+ * every dependency manifest and lockfile in the directory the command runs in.
+ * A run records its fingerprint in state; a later `up` that computes the same
+ * fingerprint has nothing to install.
+ *
+ * Scope: files in the prepare working directory only. Dependency files nested
+ * deeper (a monorepo's per-workspace manifests) do not move the fingerprint, so
+ * editing one alone does not trigger a reinstall.
+ */
+
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { lockfileNames } from "./lockfile-detect.js";
+
+/**
+ * Dependency manifests — the hand-edited half of the pair. They are read
+ * alongside lockfiles so a project that commits no lockfile still gets change
+ * detection, and so an edited manifest counts as a change before the install
+ * that would regenerate the lockfile has run.
+ */
+const MANIFEST_FILES = [
+	"package.json",
+	"Gemfile",
+	"go.mod",
+	"Cargo.toml",
+	"pyproject.toml",
+	"Pipfile",
+	"setup.py",
+	"composer.json",
+] as const;
+
+/** Every file whose content is a prepare input, deduplicated and ordered. */
+function dependencyFiles(): string[] {
+	return [...new Set<string>([...lockfileNames(), ...MANIFEST_FILES])].sort();
+}
+
+/**
+ * Fingerprint the inputs of one component's prepare run.
+ *
+ * The command string is part of the digest, so editing `install:`/`build:` in
+ * the Launchfile re-runs prepare even when no dependency file moved. A missing
+ * file contributes nothing to the digest, so creating or deleting one changes it.
+ */
+export async function prepareFingerprint(
+	dir: string,
+	command: string,
+): Promise<string> {
+	const hash = createHash("sha256");
+	hash.update(`command ${command} `);
+	for (const name of dependencyFiles()) {
+		let content: Buffer;
+		try {
+			content = await readFile(join(dir, name));
+		} catch {
+			continue;
+		}
+		hash.update(`file ${name} `);
+		hash.update(createHash("sha256").update(content).digest("hex"));
+		hash.update(" ");
+	}
+	return hash.digest("hex").slice(0, 16);
+}

--- a/providers/macos-dev/src/provider.ts
+++ b/providers/macos-dev/src/provider.ts
@@ -34,7 +34,14 @@ import {
 	httpsOriginSatisfied,
 	httpsOriginShortfall,
 } from "./https-origin.js";
-import { loadState, initState, saveState, ensureDirs, withRecordedDbIndexes } from "./state.js";
+import {
+	loadState,
+	initState,
+	saveState,
+	ensureDirs,
+	withRecordedDbIndexes,
+	type LaunchState,
+} from "./state.js";
 import {
 	declaredUses,
 	registerResource,
@@ -56,6 +63,7 @@ import {
 import { allocatePorts } from "./port-allocator.js";
 import { getRuntimeInstaller } from "./runtimes/index.js";
 import { detectPackageManager } from "./lockfile-detect.js";
+import { prepareFingerprint } from "./prepare-fingerprint.js";
 import { provisionStorage, storagePaths } from "./storage.js";
 import { ProcessManager } from "./process-manager.js";
 import { stopRecordedProcesses } from "./process-stopper.js";
@@ -432,6 +440,84 @@ export function applyResourceUseRefusals(
 		Object.entries(launch.components).filter(([n]) => !refused.has(n)),
 	);
 	return Object.keys(launch.components).length === 0 ? "none-left" : "ok";
+}
+
+/** What {@link runSourcePrepare} needs from the surrounding `up`. */
+export interface SourcePrepareContext {
+	projectDir: string;
+	/** Mutated in place: successful runs are recorded under `state.prepared`. */
+	state: LaunchState;
+	/** Resolved environment per component, as `prepare` should see it. */
+	envs: Record<string, Record<string, string>>;
+	/** Package-manager install command used where a component declares none. */
+	fallbackCommand?: string;
+	/** Prefix progress lines with the component name (multi-component apps). */
+	labelComponents?: boolean;
+	/** Runs one command. Injected so tests can observe without a real shell. */
+	run?: (command: string, opts: { cwd: string; env?: Record<string, string>; timeout?: number }) => Promise<unknown>;
+	/** Persists state after each successful prepare. */
+	save?: (projectDir: string, state: LaunchState) => Promise<void>;
+}
+
+/**
+ * Run the source-mode prepare slot (`install ?? build`, D-38) for every
+ * component that declares one, **on demand**: on first launch, and afterwards
+ * only when the prepare inputs changed.
+ *
+ * The demand signal is {@link prepareFingerprint} — the command plus the
+ * dependency manifests and lockfiles in its working directory. `state.prepared`
+ * holds the fingerprint of each component's last successful run, so an
+ * unchanged component is skipped rather than reinstalled on every `up`.
+ *
+ * Components resolving to the same working directory and command share one
+ * prepare, so it runs once per `up` (D-38) even on a first launch, when neither
+ * has a recorded fingerprint yet.
+ *
+ * A failing command throws, which fails the launch (SPEC.md § Failure
+ * semantics): the prepare slot fails the invocation. Nothing is recorded for
+ * it, so the next `up` retries.
+ */
+export async function runSourcePrepare(
+	launch: NormalizedLaunch,
+	ctx: SourcePrepareContext,
+): Promise<void> {
+	const run = ctx.run ?? shellScript;
+	const save = ctx.save ?? saveState;
+	const prepared = (ctx.state.prepared ??= {});
+	const ranThisUp = new Set<string>();
+
+	for (const [name, component] of Object.entries(launch.components)) {
+		const prepare = resolveSourcePrepareCommand(component);
+		const command = prepare?.command ?? ctx.fallbackCommand;
+		if (!command) continue;
+
+		const label = ctx.labelComponents ? ` [${name}]` : "";
+		const sourceDir = join(component.source ?? component.build?.context ?? ".");
+		const cwd = join(ctx.projectDir, sourceDir);
+		// Identifies a shared prepare: same directory, same command.
+		const sharedKey = `${sourceDir}\u0000${command}`;
+		const fingerprint = await prepareFingerprint(cwd, command);
+
+		if (prepared[name] === fingerprint || ranThisUp.has(sharedKey)) {
+			prepared[name] = fingerprint;
+			console.log(`  \u2713 Prepare up to date${label} (no dependency change)`);
+			continue;
+		}
+
+		console.log(`  \u2193 Preparing${label}...`);
+		await run(command, {
+			cwd,
+			env: ctx.envs[name],
+			// Installs/compiles routinely exceed the 2-minute shell default;
+			// honor a declared timeout, else allow 10 minutes.
+			timeout: declaredTimeout(prepare?.timeout, `prepare [${name}]`) ?? 600_000,
+		});
+		ranThisUp.add(sharedKey);
+		// Recorded as each command succeeds: a later component can fail the
+		// launch, and that must not discard the record of work already done.
+		prepared[name] = fingerprint;
+		await save(ctx.projectDir, ctx.state);
+	}
 }
 
 export async function launchUp(opts: LaunchUpOpts = {}): Promise<void> {
@@ -969,22 +1055,17 @@ export async function launchUp(opts: LaunchUpOpts = {}): Promise<void> {
 		return;
 	}
 
-	// 14. Run source-mode prepare \u2014 `install ?? build` (D-38), on demand
+	// 14. Run source-mode prepare \u2014 `install ?? build` (D-38), on demand.
+	// `--no-build` stays the explicit opt-out; it records nothing, since nothing
+	// ran, so a later `up` without it still prepares.
 	if (!opts.noBuild) {
-		for (const [name, component] of Object.entries(launch.components)) {
-			const prepare = resolveSourcePrepareCommand(component);
-			const cmd = prepare?.command ?? pm?.installCommand;
-			if (cmd) {
-				console.log(`  \u2193 Preparing${componentNames.length > 1 ? ` [${name}]` : ""}...`);
-				await shellScript(cmd, {
-					cwd: join(projectDir, component.source ?? component.build?.context ?? "."),
-					env: allEnvs[name],
-					// Installs/compiles routinely exceed the 2-minute shell default;
-					// honor a declared timeout, else allow 10 minutes.
-					timeout: declaredTimeout(prepare?.timeout, `prepare [${name}]`) ?? 600_000,
-				});
-			}
-		}
+		await runSourcePrepare(launch, {
+			projectDir,
+			state,
+			envs: allEnvs,
+			fallbackCommand: pm?.installCommand,
+			labelComponents: componentNames.length > 1,
+		});
 	}
 
 	// 15. Run release commands (migrations) \u2014 mode-invariant (D-38)

--- a/providers/macos-dev/src/state.ts
+++ b/providers/macos-dev/src/state.ts
@@ -137,6 +137,19 @@ export interface LaunchState {
 	 * answers.
 	 */
 	appUrl?: string;
+	/**
+	 * Fingerprint of the prepare inputs (`install ?? build` command plus the
+	 * dependency manifests and lockfiles in its working directory) at the last
+	 * successful prepare, keyed by component name. It is what makes prepare run
+	 * on demand rather than on every `up` (D-38): a component whose current
+	 * fingerprint matches its recorded one has nothing to install.
+	 *
+	 * An entry is written only after its command exits zero, so a failed prepare
+	 * is retried on the next `up`. Optional for backward compatibility: a state
+	 * file written before this existed has no entries, so the next `up` prepares
+	 * every component once and records them.
+	 */
+	prepared?: Record<string, string>;
 }
 
 const STATE_DIR = ".launchfile";

--- a/spec/PROVIDERS.md
+++ b/spec/PROVIDERS.md
@@ -216,12 +216,12 @@ local watcher ← emit ← diff() ← fs change ────┘
 - **`up` opts:** `withOptional`, `noBuild`, `detach`, `dryRun`, `projectDir`.
 - **Resources (native, via Homebrew services):** `postgres`, `mysql`, `redis`, `sqlite`.
 - **Runtimes:** `bun`, `node`, `python`, `ruby`.
-- **Prepare-on-change:** `lockfile-detect` decides when to (re)install — `prepare` is not re-run on every `up`.
+- **Prepare-on-change:** `prepare` runs on demand, not on every `up` — a fingerprint of the prepare command plus the dependency manifests and lockfiles in its working directory, recorded per component in `LaunchState.prepared`; a first launch or a changed fingerprint re-runs it.
 - **Process management:** components are spawned detached; `pid`/`pgid`/`startedAt`/`command` are recorded so `down` from another shell can signal the whole group, guarded against pid reuse.
 - **Also:** health checks, secret generation, persistent storage, env writing.
 - **`env`:** prints a component's resolved environment (§7) — the read surface §8 generalizes.
 - **Storage:** resolves `$storage.<name>.path` to `.launchfile/storage/<component>/<name>` on the host (D-39).
-- **State:** `LaunchState` at `<projectDir>/.launchfile/state.json`, keyed by Launchfile **content hash**; holds `resources`, `secrets`, `ports`, `processes`.
+- **State:** `LaunchState` at `<projectDir>/.launchfile/state.json`, keyed by Launchfile **content hash**; holds `resources`, `secrets`, `ports`, `processes`, `prepared`.
 - **Selection:** narrows `components` to the selected set's downward `depends_on` closure (`selectionClosure`) after the prereq gate, so every phase honors it.
 
 ### Mode coverage today


### PR DESCRIPTION
Closes #251.

## The bound shape

The steward's verdict on #251 settled this as an implementation bug with no governance decision to make: the requirement is already on the record twice, and the code does not meet it. It named three things a fix must do.

**1. Implement D-38's on-demand behaviour — first launch or a detected dependency change, persisted in state.**

`providers/macos-dev/src/provider.ts` gated the prepare loop only on `!opts.noBuild`, so every `up` reinstalled dependencies. The demand signal is now a fingerprint of the prepare inputs:

- the resolved prepare command string (`install ?? build`, or the detected package manager's install command), plus
- the contents of every dependency manifest and lockfile in the directory the command runs in.

`state.prepared` (new, optional, in `.launchfile/state.json`) holds the fingerprint of each component's last successful run. An unchanged component is skipped and reports `Prepare up to date`. A first launch, an edited lockfile or manifest, or a changed `install`/`build` command moves the fingerprint and re-runs prepare.

**2. Correct the stale comment that already claimed the behaviour.** The comment at the loop now describes what the code does, and the new `runSourcePrepare` doc comment states the rule and its limits.

**3. How the change is detected was left to the PR to decide and defend.** The choice and its cost:

- **Lockfiles and manifests, both.** Lockfile names come from `lockfile-detect`'s existing table (all of them, not only the one that wins priority — a polyglot component can carry several). Manifests are read alongside, so a project that commits no lockfile still gets detection, and an edited `package.json` counts as a change *before* the install that would regenerate the lockfile.
- **The command string is in the digest**, so editing `install:` re-prepares even when no dependency file moved.
- **Content, not mtime.** A checkout, a `git stash`, or a touched file does not force a reinstall; a real edit does.
- **Scope is the prepare working directory only.** Dependency files nested deeper — a monorepo's per-workspace manifests — do not move the fingerprint. Documented in the module, in `CLAUDE.md`, and in the changeset.
- **A shared prepare runs once**, as D-38 requires: components resolving to the same working directory and command share one run, including on a first launch when neither has a recorded fingerprint yet.
- **Recorded per component as each command succeeds.** A later component can fail the launch, and that must not discard the record of work already done. A failed command records nothing, so the next `up` retries it.
- **`--no-build` is unchanged** — still the explicit skip, and it records nothing, so a later `up` without it prepares.
- **Backward compatible.** State files written before this have no `prepared` entries, so the first `up` after upgrading prepares every component once and records it.

Deliberately out of scope: a force-prepare flag. D-38 asks for detection, not a new knob; if one is wanted later it is an additive follow-up.

## Also in this PR

- `spec/PROVIDERS.md`'s macos-dev summary credited `lockfile-detect` with the prepare-on-change decision. That module only picks an install command from lockfile presence. The line now names the real mechanism, and `prepared` joins the listed state fields.
- A changeset (`@launchfile/macos-dev`, minor — observable behaviour changes).
- `www-dev` needed no change: `learn/lifecycle-commands` and the examples pages already documented `install` as running "on demand: first launch, or when dependencies change". The docs were ahead of the implementation; this closes the gap.

Three commits, one top-level directory each: `providers:`, `spec:`, `chore:`.

## Verification

**Tests — all green.**

| Package | Command | Result |
|---------------------------|-------------------------------|-------------------|
| `providers/macos-dev` | `bun run typecheck` | clean |
| `providers/macos-dev` | `bun run test` (vitest) | 225/225 passed (22 files) |
| `providers/macos-dev` | `bun run build` | clean |
| `providers/docker` | `bun run typecheck && build` | clean |
| `packages/launchfile` | `bun run typecheck && build` | clean |
| `packages/launchfile` | `bun run test` | 96/96 passed |
| `sdk` | `bun run typecheck` | clean |

20 of those 225 are new, in `src/__tests__/prepare-on-demand.test.ts`: fingerprint stability, lockfile change, manifest change with no lockfile, a dependency file appearing, command change, a non-dependency file being ignored, a missing directory; then the loop itself — runs on first launch and records, skips when unchanged, re-runs on a lockfile change, re-runs on a command change, `install ?? build` fallback, package-manager fallback, no command at all, shared prepare runs once, separate source directories prepare separately, a failure records nothing and is retried, a partial failure keeps the earlier component's record, env pass-through, and a declared `timeout` honoured.

**Live check — `up` run three times on a sample app.** The Launchfile's prepare command appends a timestamp to `prepare.log`, so the file is a run counter.

1. **First `up`** — prepare ran. `prepare.log`: 1 line. `.launchfile/state.json` gained `"prepared": { "default": "9a9d6f3788cb0d01" }`.
2. **Second `up`, nothing changed** — output: `✓ Prepare up to date (no dependency change)`. `prepare.log`: still 1 line. This is the behaviour #251 asked for.
3. **Third `up`, after editing `bun.lock`** — output: `↓ Preparing...` followed by the command. `prepare.log`: 2 lines.

The app started and `launch down` stopped it cleanly on each cycle.

## Note for the reviewer

The fingerprint reads the working directory only. A monorepo component whose real dependency files live in nested workspace directories will not re-prepare when only those change — the command string and the top-level manifest still cover the common cases, and D-38 leaves the detection method to the provider. It is called out in the module doc comment rather than left to be discovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
