### PR TITLE
providers: retrofit chmod on .launchfile state dirs (CWE-276, #252)

### DIFF
--- a/.changeset/macos-env-dir-mode-retrofit.md
+++ b/.changeset/macos-env-dir-mode-retrofit.md
@@ -1,0 +1,5 @@
+---
+"@launchfile/macos-dev": patch
+---
+
+Fix `.launchfile/` state directories (`env`, `storage`, `tmp`, `logs`, `data`) staying world-readable when the directory already existed (CWE-276). `ensureDirs` passed `mode: 0o700` to `mkdir`, but `mkdir`'s mode only applies when it creates the directory — a directory left at a looser mode by an earlier Launchfile version, a permissive umask, or a manual `mkdir` stayed at that mode forever. `ensureDirs` now `chmod`s each directory unconditionally after `mkdir`, mirroring the retrofit already shipped in `packages/launchfile/src/state/errors.ts`. Also adds the mode to the two other `.launchfile/env` `mkdir` call sites for consistency (issue #252).

--- a/providers/macos-dev/src/__tests__/operator-storage.test.ts
+++ b/providers/macos-dev/src/__tests__/operator-storage.test.ts
@@ -17,6 +17,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	chmodSync,
 	existsSync,
 	mkdirSync,
 	mkdtempSync,
@@ -44,6 +45,9 @@ vi.mock("node:fs/promises", () => ({
 	},
 	mkdir: async (path: string, opts?: { recursive?: boolean; mode?: number }) => {
 		mkdirSync(path, opts);
+	},
+	chmod: async (path: string, mode: number) => {
+		chmodSync(path, mode);
 	},
 }));
 

--- a/providers/macos-dev/src/__tests__/provider-required-env.test.ts
+++ b/providers/macos-dev/src/__tests__/provider-required-env.test.ts
@@ -26,7 +26,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -50,6 +50,9 @@ vi.mock("node:fs/promises", () => ({
 	},
 	mkdir: async (path: string, opts?: { recursive?: boolean; mode?: number }) => {
 		mkdirSync(path, opts);
+	},
+	chmod: async (path: string, mode: number) => {
+		chmodSync(path, mode);
 	},
 }));
 

--- a/providers/macos-dev/src/__tests__/state.test.ts
+++ b/providers/macos-dev/src/__tests__/state.test.ts
@@ -1,8 +1,8 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it, expect, afterEach } from "vitest";
-import { initState, hashLaunchfile, loadState, saveState, type LaunchState } from "../state.js";
+import { initState, hashLaunchfile, loadState, saveState, ensureDirs, type LaunchState } from "../state.js";
 import { clearRegisteredSecrets, redactSecrets, REDACTED } from "../redact.js";
 
 describe("initState", () => {
@@ -137,6 +137,38 @@ describe("state persistence of env-level generator values (D-49, #186)", () => {
 			clearRegisteredSecrets();
 			await loadState(dir);
 			expect(redactSecrets(`token=${value}`)).toBe(`token=${REDACTED}`);
+		});
+	});
+});
+
+describe("ensureDirs (issue #252, CWE-276)", () => {
+	async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+		const dir = await mkdtemp(join(tmpdir(), "launchfile-state-"));
+		try {
+			return await fn(dir);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	}
+
+	it("tightens a pre-existing .launchfile/env left at 0o755 to 0o700", async () => {
+		await withTempDir(async (dir) => {
+			const envDir = join(dir, ".launchfile", "env");
+			await mkdir(envDir, { recursive: true, mode: 0o755 });
+
+			await ensureDirs(dir);
+
+			expect((await stat(envDir)).mode & 0o777).toBe(0o700);
+		});
+	});
+
+	it("creates all five state dirs at 0o700", async () => {
+		await withTempDir(async (dir) => {
+			await ensureDirs(dir);
+
+			for (const d of ["storage", "tmp", "logs", "data", "env"]) {
+				expect((await stat(join(dir, ".launchfile", d))).mode & 0o777).toBe(0o700);
+			}
 		});
 	});
 });

--- a/providers/macos-dev/src/env-writer.ts
+++ b/providers/macos-dev/src/env-writer.ts
@@ -335,7 +335,7 @@ export async function writeAllEnvFiles(
 			await writeEnvFile(join(projectDir, ".env.local"), env);
 		} else {
 			const envDir = join(projectDir, ".launchfile", "env");
-			await mkdir(envDir, { recursive: true });
+			await mkdir(envDir, { recursive: true, mode: 0o700 });
 			await writeEnvFile(join(envDir, `${name}.env`), env);
 		}
 	}

--- a/providers/macos-dev/src/provider.ts
+++ b/providers/macos-dev/src/provider.ts
@@ -559,7 +559,7 @@ export async function launchUp(opts: LaunchUpOpts = {}): Promise<void> {
 			console.log(`  \u2193 Wiring environment variables... done (${Object.keys(env).length} vars)`);
 		} else {
 			const { mkdir } = await import("node:fs/promises");
-			await mkdir(join(projectDir, ".launchfile", "env"), { recursive: true });
+			await mkdir(join(projectDir, ".launchfile", "env"), { recursive: true, mode: 0o700 });
 			await writeEnvFile(join(projectDir, ".launchfile", "env", `${name}.env`), env);
 			console.log(`  \u2193 Wiring ${name} environment... done (${Object.keys(env).length} vars)`);
 		}

--- a/providers/macos-dev/src/state.ts
+++ b/providers/macos-dev/src/state.ts
@@ -5,7 +5,7 @@
  * so credentials and ports are stable across restarts.
  */
 
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { readFile, writeFile, mkdir, chmod } from "node:fs/promises";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
 import { registerSecrets } from "./redact.js";
@@ -144,9 +144,16 @@ export async function saveState(projectDir: string, state: LaunchState): Promise
 /** Ensure .launchfile directories exist */
 export async function ensureDirs(projectDir: string): Promise<void> {
 	const dirs = ["storage", "tmp", "logs", "data", "env"];
-	// Security: restrict permissions — these dirs contain secrets, logs, env files
+	// Security: these dirs hold secrets, logs, and env files. mkdir applies the
+	// mode only when it creates the directory, so chmod unconditionally — a dir
+	// left by an earlier version or a looser umask must not stay world-readable
+	// (CWE-276). Mirrors packages/launchfile/src/state/errors.ts.
 	await Promise.all(
-		dirs.map((d) => mkdir(join(projectDir, STATE_DIR, d), { recursive: true, mode: 0o700 })),
+		dirs.map(async (d) => {
+			const dir = join(projectDir, STATE_DIR, d);
+			await mkdir(dir, { recursive: true, mode: 0o700 });
+			await chmod(dir, 0o700);
+		}),
 	);
 	// Safety net: write a .gitignore inside .launchfile/ so secrets aren't
 	// accidentally committed even if the project's .gitignore doesn't exclude it.


### PR DESCRIPTION
Closes #252

## What the steward verdict found

The issue's original diagnosis named two `mkdir` calls missing `mode: 0o700`
(`provider.ts`, `env-writer.ts`). The steward's verdict on #252 (ACCEPT)
found both of those calls are no-ops on the real leak path:
`ensureDirs` (`providers/macos-dev/src/state.ts`) already creates
`.launchfile/env` at `mode: 0o700` and runs before either named call, and
`writeAllEnvFiles` (the function containing the `env-writer.ts` call) is
dead code — exported but never imported or called anywhere in the tree.

The real gap: `mkdir`'s `mode` option only applies when `mkdir` actually
creates the directory. A `.launchfile/env` (or `storage`/`tmp`/`logs`/`data`)
left at a looser mode by an earlier Launchfile version, a permissive umask,
or a manual `mkdir` stays that way forever — `ensureDirs` never fixes it.
Files inside are already written `0o600`, so the exposure is the directory
listing, not file contents.

## What this PR does (the verdict's bound shape)

1. **`providers/macos-dev/src/state.ts`** — `ensureDirs` now `chmod`s each of
   the five state directories unconditionally after `mkdir`, mirroring the
   retrofit already shipped in `packages/launchfile/src/state/errors.ts`
   (`ensureErrorsDir`).
2. **`providers/macos-dev/src/provider.ts:562`** — adds `mode: 0o700` to the
   originally-flagged `mkdir`. It's a no-op today (`ensureDirs` runs first
   on the `up` path), but stops the omission reading as deliberate.
3. **`providers/macos-dev/src/env-writer.ts:338`** — adds `mode: 0o700` to
   the second flagged `mkdir`, inside `writeAllEnvFiles`. That function is
   unreachable dead code (no callers in the tree) — this is consistency,
   not a live fix.
4. **Test** — `providers/macos-dev/src/__tests__/state.test.ts` gets a new
   `describe("ensureDirs (issue #252, CWE-276)")` block: one test
   pre-creates `.launchfile/env` at `0o755` and asserts `ensureDirs` tightens
   it to `0o700`, one asserts all five dirs land at `0o700` on a fresh
   `ensureDirs` call.
5. Two existing test files (`provider-required-env.test.ts`,
   `operator-storage.test.ts`) mock `node:fs/promises` without a `chmod`
   export; both call `launchUp`, which now reaches the new `chmod`. Added a
   `chmod` mock backed by `chmodSync`, consistent with how the rest of that
   mock proxies to the real `fs` confined to each test's temp dir.

**Scope fence (per the verdict):** three files + one test, nothing else. Two
other directory-creation sites with the same gap
(`providers/macos-dev/src/resources/sqlite.ts:25`,
`packages/launchfile/src/state/index.ts:60,72`) and `writeAllEnvFiles` being
dead code are explicitly out of scope — the verdict asked for them to be
filed separately, citing #252.

## Verification

- **`bun run typecheck`** (macos-dev): clean.
- **`bun run test`** (macos-dev, vitest): 207/207 passed, including the 2 new
  `ensureDirs` tests.
- **`bun test`** (macos-dev): correctly refused by this repo's `bun test`
  guard, pointing at `bun run test` — confirms no runner divergence to
  check here.
- **`bun run typecheck` + `bun run test`** (`packages/launchfile`): typecheck
  clean; 88/96 tests pass. The 8 failures (`validate-host-capabilities.test.ts`,
  `cli-args.test.ts`) are pre-existing — reproduced identically on unmodified
  `main` at the same base commit (`093983b`) in a separate worktree, unrelated
  to this change.
- **Live behavioral check (OBSERVED):** pre-created `.launchfile/env` at
  `0o755` in a temp project dir, called `ensureDirs` directly, and confirmed
  the mode changed from `755` to `700` — the exact leak scenario the issue
  describes.
- **Lint** (`bun run lint`, macos-dev): pre-existing failures exist elsewhere
  in the package (`storage.ts` formatting, unrelated); none in any file this
  PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
