### PR TITLE
www-dev: teach requires[].config on the adding-a-database lesson

### DIFF
--- a/www-dev/src/pages/learn/adding-a-database.astro
+++ b/www-dev/src/pages/learn/adding-a-database.astro
@@ -110,7 +110,11 @@ health: /health`,
 ]} />
 
 <p>
-  The docker provider maps known package names to the SQL name <code>CREATE EXTENSION</code> expects (<code>vector</code>, not <code>pgvector</code>) and swaps in a Postgres image that ships it. The macos-dev provider does no such mapping — it drops your string straight into <code>CREATE EXTENSION</code> and, if that fails, continues silently, so an unrecognized name produces no error and no extension. On docker, extensions are only created the first time a database's data directory initializes, so adding <code>config.extensions</code> to an app that's already deployed does nothing and warns you of nothing yet (tracked in <a href="https://github.com/launchfile/launchfile/issues/317">#317</a>). See the spec's <a href="https://launchfile.org/spec/requires/#resource-configuration">Resource configuration</a> section for the full key list, and Lesson 8, <a href="/learn/expressions-and-resources/">Expressions &amp; Resource Configuration</a>, for naming, versioning, and config together.
+  The docker provider maps known package names to the SQL name <code>CREATE EXTENSION</code> expects (<code>vector</code>, not <code>pgvector</code>) and swaps in a Postgres image that ships it. The macos-dev provider does no such mapping — it drops your string straight into <code>CREATE EXTENSION</code> and, if that fails, continues silently, so an unrecognized name produces no error and no extension.
+</p>
+
+<p>
+  On docker, extensions are only created the first time a database's data directory initializes. Add <code>config.extensions</code> to an app that's already deployed, and the provider warns instead of applying it — naming the service and <code>config.extensions</code>, and pointing you to two remedies: run <code>launchfile down --destroy</code> then <code>launchfile up</code> to recreate the data (and the extensions) from scratch, or run the <code>CREATE EXTENSION</code> statements against the running database yourself to keep the data. See the spec's <a href="https://launchfile.org/spec/requires/">Resource configuration</a> section for the full key list, and Lesson 8, <a href="/learn/expressions-and-resources/">Expressions &amp; Resource Configuration</a>, for naming, versioning, and config together.
 </p>
 
 <h2 id="expressions">How expressions work</h2>

--- a/www-dev/src/pages/learn/adding-a-database.astro
+++ b/www-dev/src/pages/learn/adding-a-database.astro
@@ -22,6 +22,7 @@ const minifluxYaml = minifluxYamlRaw.replace(/^#.*\n/gm, "").trim();
     "How requires declares resource dependencies",
     "Shorthand vs expanded syntax for requires",
     "How a declared database gets provisioned and wired in automatically",
+    "Passing provisioning hints like Postgres extensions with config",
     "Adding a health check endpoint",
   ]}
   nextLesson={{ title: "Env Vars & Secrets", description: "Configure your app with defaults, required values, and generated secrets.", href: "/learn/env-and-secrets/" }}
@@ -90,6 +91,28 @@ health: /health`,
   after={{ title: "Expanded", yaml: "requires:\n  - type: postgres" }}
 />
 
+<h2 id="config">Provisioning hints with config</h2>
+
+<p>
+  A <code>requires</code> entry also takes a <GlossaryTip term="config" definition="Provisioning hints passed straight to whatever provisions the resource. Keys and their meaning are resource-type-specific.">config</GlossaryTip> map, which passes provisioning hints straight to whatever provisions the resource — for Postgres, the one you'll reach for most is <code>extensions</code>, the list of Postgres extensions the database should have installed.
+</p>
+
+<CodeBuildUp steps={[
+  {
+    yaml: `requires:
+  - type: postgres
+    config:
+      extensions: [vector]
+    set_env:
+      DATABASE_URL: $url`,
+    note: "Declare the extensions your app needs under <code>config</code>. How — or whether — a provider honors them is provider-specific.",
+  },
+]} />
+
+<p>
+  The docker provider maps known package names to the SQL name <code>CREATE EXTENSION</code> expects (<code>vector</code>, not <code>pgvector</code>) and swaps in a Postgres image that ships it. The macos-dev provider does no such mapping — it drops your string straight into <code>CREATE EXTENSION</code> and, if that fails, continues silently, so an unrecognized name produces no error and no extension. On docker, extensions are only created the first time a database's data directory initializes, so adding <code>config.extensions</code> to an app that's already deployed does nothing and warns you of nothing yet (tracked in <a href="https://github.com/launchfile/launchfile/issues/317">#317</a>). See the spec's <a href="https://launchfile.org/spec/requires/#resource-configuration">Resource configuration</a> section for the full key list, and Lesson 8, <a href="/learn/expressions-and-resources/">Expressions &amp; Resource Configuration</a>, for naming, versioning, and config together.
+</p>
+
 <h2 id="expressions">How expressions work</h2>
 
 <Callout type="info" title="Resource expressions">
@@ -140,6 +163,7 @@ health: /health`,
     <li><code>requires</code> declares resource dependencies — they're provisioned automatically.</li>
     <li>Use <code>set_env</code> with <code>$url</code>, <code>$host</code>, <code>$port</code>, etc. to wire connection details into your app.</li>
     <li>Shorthand (<code>[postgres]</code>) and expanded syntax (<code>- type: postgres</code>) are equivalent.</li>
+    <li><code>config</code> passes provider-specific provisioning hints, like Postgres <code>extensions</code> — how it's honored differs by provider.</li>
     <li>Add <code>health</code> so your app's readiness can be verified after deployment.</li>
   </ul>
 </div>


### PR DESCRIPTION
Closes #272.

## What changed

`www-dev/src/pages/learn/adding-a-database.astro` (Lesson 2) taught `requires` and `set_env` but never `config` — the field for provisioning hints like Postgres extensions, even though the docker provider has honored it since #268. Added one new section (`<h2 id="config">`), placed right after the existing `set_env` build-up material and before "How expressions work":

- One YAML example declaring `config: { extensions: [vector] }` — using the SQL extension name `vector`, not the package name `pgvector`. The `spec/SPEC.md` / Lesson 8 example still uses `pgvector`; that separate spelling mismatch is tracked in #269 and this PR does not touch it or link it.
- One sentence on how the docker provider honors it: maps known package names to the SQL name and swaps in an image that ships the extension.
- One sentence on how the macos-dev provider honors it: no mapping, drops the string straight into `CREATE EXTENSION`, and continues silently if that fails.
- One paragraph on the docker first-run caveat: extensions are only created when the data directory first initializes; on a later run the docker provider warns, naming the service and `config.extensions`, and points to the two remedies (`launchfile down --destroy` then `launchfile up`, or running the `CREATE EXTENSION` statements yourself). This describes the warning PR #349 shipped (merged 2026-09-11, closing #317). The page links no issue numbers.
- A pointer to the spec's Resource configuration section (`https://launchfile.org/spec/requires/`, no fragment — www-org emits no heading ids until #398 lands) and a cross-link to Lesson 8 for the full treatment.

Also added one `learningGoals` bullet and one "Key takeaways" bullet for `config`, matching how every other topic on this page is already listed in both places — no other file touched.

Commits: `d6968c5` adds the section; `da01818` rewrites the caveat after #349 merged, so the page describes present docker behavior.

## How the review's bound shape was addressed

Per the steward's ACCEPT verdict on #272: edited only this one file, no spec/provider/Lesson-8 changes, no new `D-*` entry, one short section (YAML block + prose) placed after the `set_env` material, `vector` used in the example (not `pgvector`), docker and macos-dev described as separate sentences (never "the providers" as one behavior), the docker first-run caveat carried, and no implication that every provider applies extensions (only docker and macos-dev are named as acting on it).

## Verification

```
$ cd www-shared && bun install --frozen-lockfile   # CI installs this first; the site build imports satteri from here
$ cd www-dev && bun install --frozen-lockfile
$ bun run typecheck   # astro check
Result (30 files): 0 errors, 0 warnings, 0 hints

$ bun run build       # astro build && pagefind --site dist/client
26 page(s) built
```

OBSERVED at `da01818`: grepped the built `dist/client/learn/adding-a-database/index.html` and confirmed the `<h2 id="config">` section, the YAML block, the rewritten caveat text, the spec link (no fragment) and the Lesson-8 link render; the string `#317` no longer appears anywhere in the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
