### PR TITLE
packages: operator spelling of the publication channel — `launchfile up --url <public-url>` (#295)

### DIFF
--- a/.changeset/cli-up-url-flag.md
+++ b/.changeset/cli-up-url-flag.md
@@ -1,0 +1,16 @@
+---
+"launchfile": minor
+---
+
+`launchfile up --url <public-url>` — the operator spelling of D-58's
+publication channel
+
+An operator running behind their own Caddy, nginx, or tunnel supplies the
+public URL of the app's primary endpoint on the command line, and `$app.*`
+resolves from it instead of the provider's own routing answer. The flag reaches
+`appUrl` on both providers, so `up`, `up --native`, and `dev` all take it.
+
+The value is passed through untouched: the SDK's `normalizeAppUrl` stays the
+only implementation of validation and normalization, and a refused value stops
+the deploy with the provider's message — never a degraded or guessed `$app.*`.
+Omit the flag and behavior is unchanged.

--- a/packages/launchfile/src/__tests__/cli-args.test.ts
+++ b/packages/launchfile/src/__tests__/cli-args.test.ts
@@ -46,6 +46,13 @@ describe("getPositional (#248)", () => {
 		expect(getPositional(args, 1)).toBe("ghost");
 	});
 
+	it("skips the --url value so a public URL is never the up target (D-58)", () => {
+		const args = ["up", "--url", "https://x.example.com"];
+		expect(getPositional(args, 0)).toBe("up");
+		expect(getPositional(args, 1)).toBeUndefined();
+		expect(getPositional(["up", "--url", "https://x.example.com", "ghost"], 1)).toBe("ghost");
+	});
+
 	it("skips --storage values so a pair is never the up target (D-50)", () => {
 		const args = ["up", "--storage", "music=/srv/music", "--storage", "books=/srv/books"];
 		expect(getPositional(args, 0)).toBe("up");

--- a/packages/launchfile/src/__tests__/up-url.test.ts
+++ b/packages/launchfile/src/__tests__/up-url.test.ts
@@ -1,0 +1,185 @@
+/**
+ * The D-58 `--url` channel at the command layer (#295): the operator's
+ * publication URL reaches either provider's `appUrl` option untouched, and a
+ * refused value reaches the operator as a message rather than a stack.
+ *
+ * Directories are injected temp paths — nothing touches the real
+ * ~/.launchfile and nothing talks to docker.
+ */
+
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { DockerUpOpts, DockerUpResult } from "@launchfile/docker";
+import { InvalidAppUrlError } from "@launchfile/sdk";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { handleUp } from "../commands/up.js";
+
+let indexDir: string;
+let recordDir: string;
+let projectDir: string;
+
+let output: string[];
+let restore: (() => void) | null = null;
+
+beforeEach(async () => {
+	indexDir = await mkdtemp(join(tmpdir(), "lf-url-index-"));
+	recordDir = await mkdtemp(join(tmpdir(), "lf-url-records-"));
+	projectDir = await mkdtemp(join(tmpdir(), "lf-url-project-"));
+	await writeFile(join(projectDir, "Launchfile"), "name: notes\n");
+
+	output = [];
+	const log = console.log;
+	const err = console.error;
+	console.log = (...args: unknown[]) => output.push(args.join(" "));
+	console.error = (...args: unknown[]) => output.push(args.join(" "));
+	restore = () => {
+		console.log = log;
+		console.error = err;
+	};
+});
+
+afterEach(() => {
+	restore?.();
+	restore = null;
+});
+
+function fakeUp(calls: DockerUpOpts[]) {
+	return async (
+		_source: string,
+		opts: DockerUpOpts,
+	): Promise<DockerUpResult> => {
+		calls.push(opts);
+		return { slug: "notes", appName: "notes", sourceType: "local" };
+	};
+}
+
+describe("up --url reaches the docker provider (D-58)", () => {
+	it("passes the value through untouched — normalization is the provider's", async () => {
+		const calls: DockerUpOpts[] = [];
+		await handleUp(
+			projectDir,
+			{ url: "https://notes.example.com/" },
+			{ up: fakeUp(calls), indexDir, recordDir },
+		);
+		expect(calls).toHaveLength(1);
+		// Trailing slash intact: `normalizeAppUrl` drops it, not the CLI.
+		expect(calls[0]!.appUrl).toBe("https://notes.example.com/");
+	});
+
+	it("passes no URL when --url is absent, so a recorded one is preserved (D-49)", async () => {
+		const calls: DockerUpOpts[] = [];
+		await handleUp(projectDir, {}, { up: fakeUp(calls), indexDir, recordDir });
+		expect(calls[0]!.appUrl).toBeUndefined();
+	});
+
+	it("carries a second, different URL through so the provider can replace it", async () => {
+		const calls: DockerUpOpts[] = [];
+		const deps = { up: fakeUp(calls), indexDir, recordDir };
+		await handleUp(projectDir, { url: "https://notes.example.com" }, deps);
+		await handleUp(projectDir, {}, deps);
+		await handleUp(projectDir, { url: "https://wiki.example.com" }, deps);
+		expect(calls.map((c) => c.appUrl)).toEqual([
+			"https://notes.example.com",
+			undefined,
+			"https://wiki.example.com",
+		]);
+	});
+});
+
+describe("up --url reaches the macOS provider (D-58)", () => {
+	it("threads the value into the native provider's appUrl channel", async () => {
+		const calls: { appUrl?: string }[] = [];
+		await handleUp(
+			projectDir,
+			{ native: true, url: "https://notes.example.com" },
+			{
+				importMacos: async () =>
+					({
+						launchUp: async (opts: { appUrl?: string }) => {
+							calls.push(opts);
+						},
+					}) as unknown as typeof import("@launchfile/macos-dev"),
+				indexDir,
+				recordDir,
+			},
+		);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]!.appUrl).toBe("https://notes.example.com");
+	});
+});
+
+describe("a refused publication URL reaches the operator (D-58 rule 3)", () => {
+	/**
+	 * The provider refuses; the command prints the message and exits non-zero.
+	 * Without the catch this lands as an unhandled rejection with a stack,
+	 * burying the one instruction the operator needs.
+	 */
+	async function expectRefusalPrinted(
+		flags: { native?: boolean; url: string },
+		err: Error,
+	): Promise<string> {
+		const exit = process.exit;
+		let exited: number | undefined;
+		process.exit = (code?: number) => {
+			exited = code;
+			throw new Error("exited");
+		};
+		try {
+			await expect(
+				handleUp(projectDir, flags, {
+					up: async () => {
+						throw err;
+					},
+					importMacos: async () =>
+						({
+							launchUp: async () => {
+								throw err;
+							},
+						}) as unknown as typeof import("@launchfile/macos-dev"),
+					indexDir,
+					recordDir,
+				}),
+			).rejects.toThrow("exited");
+		} finally {
+			process.exit = exit;
+		}
+		expect(exited).toBe(1);
+		return output.join("\n");
+	}
+
+	it("prints the docker refusal with no stack", async () => {
+		const printed = await expectRefusalPrinted(
+			{ url: "notes.example.com" },
+			new InvalidAppUrlError(
+				"notes.example.com",
+				"not a parseable absolute URL",
+			),
+		);
+		expect(printed).toContain("Invalid appUrl");
+		expect(printed).toContain("absolute http:// or https:// URL");
+	});
+
+	it("prints the macOS refusal with no stack", async () => {
+		const printed = await expectRefusalPrinted(
+			{ native: true, url: "ftp://notes.example.com" },
+			new InvalidAppUrlError(
+				"ftp://notes.example.com",
+				'scheme "ftp" is not http or https',
+			),
+		);
+		expect(printed).toContain("Invalid appUrl");
+	});
+
+	it("never echoes userinfo from the refused value (D-18)", async () => {
+		const printed = await expectRefusalPrinted(
+			{ url: "https://admin:hunter2@notes.example.com" },
+			new InvalidAppUrlError(
+				"https://admin:hunter2@notes.example.com",
+				"userinfo is not allowed",
+			),
+		);
+		expect(printed).not.toContain("hunter2");
+		expect(printed).toContain("***@notes.example.com");
+	});
+});

--- a/packages/launchfile/src/cli-args.ts
+++ b/packages/launchfile/src/cli-args.ts
@@ -14,6 +14,7 @@ export const VALUE_FLAGS: ReadonlySet<string> = new Set([
 	"component",
 	"schema-path",
 	"storage",
+	"url",
 ]);
 
 export function hasFlag(args: readonly string[], flag: string): boolean {

--- a/packages/launchfile/src/cli.ts
+++ b/packages/launchfile/src/cli.ts
@@ -61,6 +61,26 @@ function getNameFlag(): string | undefined {
 	return value;
 }
 
+/**
+ * The D-58 publication URL, or undefined when --url was not given. The value
+ * is passed to the provider untouched — normalization and refusal belong to
+ * `normalizeAppUrl`, one implementation for every provider. A `--url` with no
+ * value is an error rather than a silent omission: the provider would resolve
+ * `$app.*` from its own routing answer, which is exactly the wrong public
+ * address the flag exists to correct.
+ */
+function getUrlFlag(): string | undefined {
+	if (!argsFlagPresent(args, "url")) return undefined;
+	const value = getFlagValue("url");
+	if (!value || value.startsWith("-")) {
+		console.error(
+			"--url requires a value, e.g. --url https://notes.example.com",
+		);
+		process.exit(1);
+	}
+	return value;
+}
+
 /** The D-50 `--storage` volume-to-path map, or undefined when the flag is absent. */
 const storageFlag = (): Record<string, string> | undefined => {
 	const values = argsGetFlagValues(args, "storage");
@@ -103,6 +123,10 @@ Options:
                     supply its content; the provider binds it there instead of
                     creating an empty volume. Repeat per volume; spell the key
                     <component>.<volume> where the volume name is ambiguous
+  --url <public-url>
+                   Public URL the app is reached at when a reverse proxy,
+                    tunnel, or edge in front of it owns routing — $app.* then
+                    resolves from it instead of the local address (with up, dev)
   --component <n>  Limit bootstrap to a single component
   --reveal         (bootstrap) Print captures marked \`sensitive\` instead of
                     masking them — they never reach logs or state either way
@@ -118,6 +142,8 @@ Environment:
 Examples:
   launchfile up ghost                Run Ghost from the catalog
   launchfile up                      Run the app in the current directory
+  launchfile up --url https://notes.example.com
+                                     Run it behind your own proxy at that URL
   launchfile diagnose                Explain the last failed launch
   launchfile diagnose --json         The same record, for a script
   launchfile down --destroy          Stop and remove everything
@@ -145,6 +171,7 @@ async function main(): Promise<void> {
 				dryRun: hasFlag("dry-run"),
 				name: getNameFlag(),
 				storage: storageFlag(),
+				url: getUrlFlag(),
 			});
 			break;
 
@@ -158,6 +185,7 @@ async function main(): Promise<void> {
 				dryRun: hasFlag("dry-run"),
 				name: getNameFlag(),
 				storage: storageFlag(),
+				url: getUrlFlag(),
 			});
 			break;
 

--- a/packages/launchfile/src/commands/up.ts
+++ b/packages/launchfile/src/commands/up.ts
@@ -12,6 +12,7 @@ import {
 } from "@launchfile/docker";
 // The two D-50 refusals come from the SDK, so one catch covers both providers.
 import {
+	InvalidAppUrlError,
 	isLaunchError,
 	type LaunchPhase,
 	MissingOperatorStoragePathError,
@@ -46,6 +47,14 @@ export interface UpFlags {
 	 * parsed Launchfile.
 	 */
 	storage?: Record<string, string>;
+	/**
+	 * The public URL the app is reached at when routing is owned upstream of
+	 * the provider — a reverse proxy, tunnel, or edge (D-58). Passed to the
+	 * provider raw: `normalizeAppUrl` in the SDK is the only implementation of
+	 * validation and normalization, and `deriveAppUrlProperties` the only
+	 * implementation of what `$app.*` becomes.
+	 */
+	url?: string;
 }
 
 /**
@@ -153,17 +162,22 @@ export async function handleUp(
 						dryRun: flags.dryRun,
 						name: flags.name,
 						storage: flags.storage,
+						appUrl: flags.url,
 					}),
 				recordDir,
 			);
 		} catch (err) {
-			// An unsupplied `required:` variable (D-52) or an unbound/absent
-			// operator storage path (D-50) is an operator's problem to fix, not a
-			// bug — it gets the provider's own message, not a stack trace.
+			// An unsupplied `required:` variable (D-52), an unbound/absent
+			// operator storage path (D-50), or a malformed publication URL
+			// (D-58) is an operator's problem to fix, not a bug — it gets the
+			// provider's own message, not a stack trace. The URL refusal masks
+			// any userinfo in its own message (D-18), so the raw value the
+			// operator typed is never echoed here.
 			if (
 				err instanceof UnsuppliedRequiredEnvError ||
 				err instanceof UnboundOperatorStorageError ||
-				err instanceof MissingOperatorStoragePathError
+				err instanceof MissingOperatorStoragePathError ||
+				err instanceof InvalidAppUrlError
 			) {
 				console.error(`\n${err.message}`);
 				process.exit(1);
@@ -247,15 +261,18 @@ export async function handleUp(
 						dryRun: flags.dryRun,
 						detach: flags.detach,
 						storage: flags.storage,
+						appUrl: flags.url,
 					}),
 				recordDir,
 			);
 		} catch (err) {
-			// Same two D-50 refusals the docker branch prints: an operator's
-			// problem to fix, so it gets the provider's message, not a trace.
+			// The same operator-fixable refusals the docker branch prints — the
+			// two D-50 storage ones and D-58's malformed publication URL: the
+			// operator gets the provider's message, not a trace.
 			if (
 				err instanceof UnboundOperatorStorageError ||
-				err instanceof MissingOperatorStoragePathError
+				err instanceof MissingOperatorStoragePathError ||
+				err instanceof InvalidAppUrlError
 			) {
 				console.error(`\n${err.message}`);
 				process.exit(1);

--- a/packages/launchfile/src/macos-dev.d.ts
+++ b/packages/launchfile/src/macos-dev.d.ts
@@ -15,6 +15,12 @@ declare module "@launchfile/macos-dev" {
 		noBuild?: boolean;
 		/** Host paths for `content: operator` volumes (D-50 rule 1). */
 		storage?: Record<string, string>;
+		/**
+		 * The public URL of the app's primary endpoint when routing is owned
+		 * upstream of this provider (D-58). Raw as the operator typed it — the
+		 * provider normalizes or refuses it.
+		 */
+		appUrl?: string;
 	}): Promise<void>;
 
 	export function launchDown(opts?: {

--- a/www-dev/src/pages/learn/env-and-secrets.astro
+++ b/www-dev/src/pages/learn/env-and-secrets.astro
@@ -124,6 +124,9 @@ const fireflyYaml = fireflyYamlRaw.replace(/^#.*\n/gm, "").trim();
   CMD_DOMAIN: $app.authority    # public host[:port], port omitted when default
   CMD_PROTOCOL_USESSL: $app.tls # "true" or "false" — for literal SSL on/off flags</code></pre>
   <p><code>$app.authority</code>, <code>$app.scheme</code>, and <code>$app.tls</code> are all derived from <code>$app.url</code>, so any provider that can resolve the URL can resolve the pieces. Reach for them only when the app genuinely needs the address split — <code>$app.url</code> stays the default.</p>
+  <p>The provider answers <code>$app.url</code> with the address it routes to — <code>http://localhost:8080</code> and the like. When something in front of it owns routing — your own Caddy, nginx, or a tunnel — that is no longer the address anyone reaches the app at, so tell the provider the public one:</p>
+  <pre><code>launchfile up --url https://notes.example.com</code></pre>
+  <p>Every <code>$app.*</code> property then resolves from that URL: HedgeDoc's <code>CMD_DOMAIN</code> becomes <code>notes.example.com</code> and <code>CMD_PROTOCOL_USESSL</code> becomes <code>true</code>. Leave the flag off and nothing changes — the provider's own routing answer stands. A value that is not an absolute <code>http</code>/<code>https</code> URL stops the deploy before anything starts, rather than deploying the app against a guessed address.</p>
 </Callout>
 
 <h2 id="in-the-wild">In the wild</h2>


### PR DESCRIPTION
Closes #295.

**Open this PR with `--base chore/gov-macos-app-url`.** It stacks on the
macos-dev publication-channel branch (#294) — that branch is what makes the
`--url` value reachable on the native path instead of refused.

`launchfile up --url https://notes.example.com` is the operator spelling of the
channel D-58 ratified. The flag reaches `appUrl` on both providers, so `up`,
`up --native`, and `dev` all take it, and `$app.*` resolves from the supplied
URL instead of the provider's own `http://localhost:<port>`.

## How the verdict's bound shape is met

| # | Requirement | Where |
|---|-------------|-------|
| 1 | Value passed through untouched — no parsing, trimming, or defaulting in the CLI | `commands/up.ts` hands `flags.url` straight to `appUrl`; a test asserts a trailing slash survives the CLI, since dropping it is `normalizeAppUrl`'s job |
| 2 | One table entry, no parser change | `cli-args.ts`: `"url"` added to `VALUE_FLAGS`, one line — no other parser edit (#352 adds `components` on the same line neighbourhood) |
| 3 | Never ignore `--url` on the macOS path | **Superseded by the base branch, not skipped.** The verdict required a refusal *because* macos-dev had no channel (#294). That channel landed on `chore/gov-macos-app-url`, which this branch stacks on, so the flag is wired through to `LaunchUpOpts.appUrl` — the flag is still never silently dropped, and the operator now gets the address they asked for rather than an error. If #294's branch is dropped, this PR must go back to the refusal. |
| 4 | No credentials echoed on refusal | The CLI prints `InvalidAppUrlError.message`, never the raw argument; the error masks userinfo in its own constructor (D-18). Test + live transcript below. |
| 5 | Four tests | (a) `cli-args.test.ts` — `up --url https://x.example.com` is not read as the deploy target; (b) the value arrives as `DockerUpOpts.appUrl`; (c) the macOS path receives it as `LaunchUpOpts.appUrl` (the shape (c) takes now the channel exists), plus refusal tests for both providers and a no-userinfo-echo test; (d) omission passes `undefined` so the provider's recorded value stands, and a different value is carried through to replace it — the preservation/replacement rule itself is the provider's, tested in `provider-app-url.test.ts` |
| 6 | Show it running once | Transcript below |
| 7 | Docs in the "URL in pieces" callout | `www-dev/src/pages/learn/env-and-secrets.astro` — the callout at the old lines 120-127, not the provenance one above it |

Scope is unchanged otherwise: `up`/`dev` only, one URL for the primary endpoint,
no schema, parser, or resolver change, no new decision entry (D-58 covers it).
AWS stays in #304.

## Verification

Tests, in the worktree:

- `packages/launchfile`: `bun run typecheck` clean, `bun run build` clean, `bun run test` — 11 files, 104 tests, all passing (7 of them new in `up-url.test.ts`, 1 new in `cli-args.test.ts`). `bun test` is refused by the package's guard, which points at `bun run test`.
- `sdk` 440/440, `providers/docker` 343/343, `providers/macos-dev` 217/217 — the stacked base is green under this change.
- `www-dev`: `bun run build` succeeds and the rendered page contains the new copy.

Live, with the built `dist/cli.js` under a sandboxed `HOME` (nothing touched the
real `~/.launchfile`), against a HedgeDoc-shaped Launchfile whose env is
`PUBLIC_URL: $app.url`, `CMD_DOMAIN: $app.authority`,
`CMD_PROTOCOL_USESSL: $app.tls`:

```
$ launchfile up --dry-run                      # no --url: the provider's own answer
      PUBLIC_URL: http://localhost:3000
      CMD_DOMAIN: localhost:3000
      CMD_PROTOCOL_USESSL: "false"

$ launchfile up --url https://notes.example.com --dry-run
      PUBLIC_URL: https://notes.example.com
      CMD_DOMAIN: notes.example.com
      CMD_PROTOCOL_USESSL: "true"
exit 0; a second identical run also exits 0

$ launchfile up --url notes.example.com --dry-run
Invalid appUrl "notes.example.com": not a parseable absolute URL.
The publication URL must be an absolute http:// or https:// URL with no userinfo,
query, or fragment (e.g. https://notes.example.com). Refusing to derive $app.* from
it — a degraded or guessed value would configure the app with a wrong public
address (D-35).
exit 1

$ launchfile up --url https://admin:hunter2@notes.example.com --dry-run
Invalid appUrl "https://***@notes.example.com": userinfo is not allowed.
exit 1                                          # the password is not in the output

$ launchfile up --url --dry-run
--url requires a value, e.g. --url https://notes.example.com
exit 1
```

The native path, same binary, a source-runnable Launchfile:

```
$ launchfile dev --url https://notes.example.com --dry-run
# .launchfile/state.json  ->  "appUrl": "https://notes.example.com"

$ launchfile dev --dry-run                      # omitted: recorded value kept (D-49)
# .launchfile/state.json  ->  "appUrl": "https://notes.example.com"

$ launchfile dev --url https://wiki.example.com --dry-run
# .launchfile/state.json  ->  "appUrl": "https://wiki.example.com"
```

Two notes for the reviewer:

- `dev` takes the flag as well as `up`. `dev` reaches the same `handleUp`, so the
  alternative was accepting `--url` there and dropping it — the silent-drop
  failure the verdict rules out. Both native entry points now carry it to the
  same channel.
- `packages/launchfile/src/macos-dev.d.ts` is a hand-maintained ambient
  declaration that shadows the package's own types, so `appUrl` had to be added
  there too. It is narrower than `LaunchUpOpts` by design and nothing checks the
  two against each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Rebase addendum (2026-09-11)

Rebased onto the new #354 head `1123da3` (`git rebase --onto chore/gov-macos-app-url cdd1aee`). Head `8f41b9e` → `927a211`. Three commits kept; base stays `chore/gov-macos-app-url`.

### Conflicts

None. This PR touches `packages/launchfile`, `www-dev/src/pages/learn/env-and-secrets.astro`, and its changeset; neither #354's rebase nor `main` (D-60/D-61/D-62, #474) changed those paths. The hand-maintained `packages/launchfile/src/macos-dev.d.ts` gained only `appUrl?`, which matches `LaunchUpOpts.appUrl` in `providers/macos-dev/src/provider.ts`.

Pre-existing drift, not introduced here and not changed: the `.d.ts` omits `components?` that `LaunchUpOpts` on `main` declares (issue #320).

### Verification (rebased head, clean worktree, SDK + both providers rebuilt first)

| Suite                 | main | now |
|-----------------------|------|-----|
| `packages/launchfile` | 105  | 113 |

Typecheck + build green. `www-dev`: `astro check` — 30 files, 0 errors, 0 warnings, 0 hints.
