### PR TITLE
providers(macos-dev): anchor the allocated host port on the exposed endpoint, not provides[0]

### DIFF
--- a/.changeset/macos-dev-exposed-port-anchor.md
+++ b/.changeset/macos-dev-exposed-port-anchor.md
@@ -1,0 +1,9 @@
+---
+"@launchfile/macos-dev": minor
+---
+
+Anchor the allocated host port on the component's first `exposed: true` endpoint, falling back to `provides[0]`.
+
+`allocatePorts` read `component.provides?.[0]?.port` with no check on `exposed`, while `computeAppProperties` picked the component to publish by `p.exposed === true`. Two rules, one number. For `provides: [{port: 9000}, {port: 8080, exposed: true}]` the docker provider reported `8080` and macos-dev reported `9000` for the same file — the P-5 divergence, and it moved `$app.*`, `$components.<name>.*`, and the `PORT` the spawned process binds together, since this provider keeps one port per component.
+
+No shipped catalog app moves: the four apps with more than one `provides` entry mark every entry `exposed: true`. The parameter type widens to `Array<{ port: number; exposed?: boolean }>`.

--- a/providers/macos-dev/package.json
+++ b/providers/macos-dev/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.10",
+    "@launchfile/docker": "^0.7.1",
     "@types/bun": "^1.3.11",
     "@types/semver": "^7.7.1",
     "typescript": "^7.0.2",

--- a/providers/macos-dev/src/__tests__/cross-provider-app-url.test.ts
+++ b/providers/macos-dev/src/__tests__/cross-provider-app-url.test.ts
@@ -23,7 +23,8 @@ import {
 import { allocatePorts } from "../port-allocator.js";
 
 // The first entry is internal, the second is the public one. Reading provides[0]
-// answers 9000 here; reading the exposed endpoint answers 8080.
+// answers 39000 here; reading the exposed endpoint answers 38080. Both sit above
+// the registered-port range, so the allocator finds them free on any machine.
 const TWO_ENDPOINT_FIXTURE = `
 version: launch/v1
 name: cross-provider-fixture
@@ -33,10 +34,10 @@ components:
     provides:
       - name: internal
         protocol: http
-        port: 9000
+        port: 39000
       - name: public
         protocol: http
-        port: 8080
+        port: 38080
         exposed: true
 `;
 
@@ -44,16 +45,18 @@ describe("$app.* agrees across providers (P-5, D-27)", () => {
 	it("docker and macos-dev name the same port for the same file", async () => {
 		const launch = readLaunch(TWO_ENDPOINT_FIXTURE);
 
-		// macos-dev: pin the allocation so the comparison is about the anchor
-		// rule, not about whether 8080 happens to be free on this machine.
-		const ports = await allocatePorts(launch.components, launch.name, { web: 8080 });
+		// macos-dev: no saved port, so the allocator runs the anchor rule this
+		// test exists for. A saved port takes the reuse branch above it, and the
+		// comparison would then hold whichever endpoint the anchor picked.
+		const ports = await allocatePorts(launch.components, launch.name);
 		const macos = computeAppProperties(launch, ports);
 
-		// docker: same file, its own routing strategy, no orchestrator appUrl.
-		const docker = dockerAppProperties(launch, { web: 8080 });
+		// docker: same file, no host-port map, so its number comes from the
+		// declared exposed endpoint rather than from what macos-dev allocated.
+		const docker = dockerAppProperties(launch, undefined);
 
-		expect(macos.port).toBe(8080);
-		expect(docker.port).toBe(8080);
+		expect(docker.port).toBe(38080);
+		expect(macos.port).toBe(38080);
 		expect(macos.url).toBe(docker.url);
 		expect(macos.authority).toBe(docker.authority);
 	});

--- a/providers/macos-dev/src/__tests__/cross-provider-app-url.test.ts
+++ b/providers/macos-dev/src/__tests__/cross-provider-app-url.test.ts
@@ -1,0 +1,79 @@
+/**
+ * `$app.*` must name the same public port on every provider that runs the same
+ * Launchfile (P-5). Both reference providers answer it from the first
+ * `exposed: true` endpoint (D-27) — docker in `app-url.ts`, macos-dev through
+ * the port it allocates — and nothing asserted that the two agree.
+ *
+ * The macos-dev half runs the real path: `allocatePorts` → `computeAppProperties`
+ * → `buildResolverContext` → `writeAllEnvFiles`, so the resolved `$app.url` is
+ * compared against the `PORT` the spawned process would actually bind.
+ */
+
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readLaunch, resolveExpression } from "@launchfile/sdk";
+import { describe, expect, it } from "vitest";
+import { computeAppProperties as dockerAppProperties } from "../../../docker/src/app-url.js";
+import {
+	buildResolverContext,
+	computeAppProperties,
+	writeAllEnvFiles,
+} from "../env-writer.js";
+import { allocatePorts } from "../port-allocator.js";
+
+// The first entry is internal, the second is the public one. Reading provides[0]
+// answers 9000 here; reading the exposed endpoint answers 8080.
+const TWO_ENDPOINT_FIXTURE = `
+version: launch/v1
+name: cross-provider-fixture
+components:
+  web:
+    image: web-like
+    provides:
+      - name: internal
+        protocol: http
+        port: 9000
+      - name: public
+        protocol: http
+        port: 8080
+        exposed: true
+`;
+
+describe("$app.* agrees across providers (P-5, D-27)", () => {
+	it("docker and macos-dev name the same port for the same file", async () => {
+		const launch = readLaunch(TWO_ENDPOINT_FIXTURE);
+
+		// macos-dev: pin the allocation so the comparison is about the anchor
+		// rule, not about whether 8080 happens to be free on this machine.
+		const ports = await allocatePorts(launch.components, launch.name, { web: 8080 });
+		const macos = computeAppProperties(launch, ports);
+
+		// docker: same file, its own routing strategy, no orchestrator appUrl.
+		const docker = dockerAppProperties(launch, { web: 8080 });
+
+		expect(macos.port).toBe(8080);
+		expect(docker.port).toBe(8080);
+		expect(macos.url).toBe(docker.url);
+		expect(macos.authority).toBe(docker.authority);
+	});
+
+	it("resolves $app.url to the port the process is told to bind", async () => {
+		const launch = readLaunch(TWO_ENDPOINT_FIXTURE);
+		const ports = await allocatePorts(launch.components, launch.name);
+		const app = computeAppProperties(launch, ports);
+		const context = buildResolverContext({}, ports, {}, app);
+
+		const projectDir = await mkdtemp(join(tmpdir(), "cross-provider-"));
+		const envs = await writeAllEnvFiles(launch, context, {}, ports, projectDir, {});
+
+		const resolvedPort = new URL(resolveExpression("$app.url", context)).port;
+		// The allocator may move off 8080 when it is taken, but $app.url and the
+		// process's own PORT must move together — they are one number.
+		expect(resolvedPort).toBe(String(ports.web));
+		expect(envs.web?.PORT).toBe(String(ports.web));
+
+		const written = await readFile(join(projectDir, ".launchfile", "env", "web.env"), "utf8");
+		expect(written).toContain(`PORT=${ports.web}`);
+	});
+});

--- a/providers/macos-dev/src/__tests__/port-allocator.test.ts
+++ b/providers/macos-dev/src/__tests__/port-allocator.test.ts
@@ -1,5 +1,20 @@
 import { describe, it, expect } from "vitest";
+import { createServer } from "node:net";
 import { allocatePort, allocatePorts } from "../port-allocator.js";
+
+/** Hold a real listener on `port` for the duration of `fn`. */
+async function occupying<T>(port: number, fn: () => Promise<T>): Promise<T> {
+	const server = createServer();
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(port, "127.0.0.1", resolve);
+	});
+	try {
+		return await fn();
+	} finally {
+		await new Promise<void>((resolve) => server.close(() => resolve()));
+	}
+}
 
 describe("allocatePort", () => {
 	it("returns a port in the expected range", async () => {
@@ -55,5 +70,46 @@ describe("allocatePorts", () => {
 		const saved = { api: 9876 };
 		const ports = await allocatePorts(components, "test-app", saved);
 		expect(ports.api).toBe(9876);
+	});
+});
+
+describe("allocatePorts — the exposed endpoint anchors the port (D-27, P-5)", () => {
+	it("allocates the first exposed: true entry, not provides[0]", async () => {
+		const components = {
+			api: {
+				provides: [
+					{ port: 9000 },
+					{ port: 8080, exposed: true },
+				],
+			},
+		};
+		const ports = await allocatePorts(components, "anchor-test");
+		expect(ports.api).toBe(8080);
+	});
+
+	it("keeps provides[0] when nothing is exposed", async () => {
+		const components = {
+			worker: { provides: [{ port: 9000 }] },
+		};
+		const ports = await allocatePorts(components, "anchor-test");
+		expect(ports.worker).toBe(9000);
+	});
+
+	it("falls through to the deterministic allocator when the anchor port is taken", async () => {
+		const components = {
+			api: {
+				provides: [
+					{ port: 9000 },
+					{ port: 8080, exposed: true },
+				],
+			},
+		};
+		const ports = await occupying(8080, () => allocatePorts(components, "anchor-test"));
+		// Not the anchor (taken), and not provides[0] either — the anchor being
+		// unavailable does not hand the port back to the internal endpoint.
+		expect(ports.api).not.toBe(8080);
+		expect(ports.api).not.toBe(9000);
+		expect(ports.api).toBeGreaterThanOrEqual(10_000);
+		expect(ports.api).toBeLessThan(20_000);
 	});
 });

--- a/providers/macos-dev/src/port-allocator.ts
+++ b/providers/macos-dev/src/port-allocator.ts
@@ -63,7 +63,7 @@ export async function allocatePort(
  * Returns a map of component name → port.
  */
 export async function allocatePorts(
-	components: Record<string, { provides?: Array<{ port: number }> }>,
+	components: Record<string, { provides?: Array<{ port: number; exposed?: boolean }> }>,
 	appName: string,
 	savedPorts?: Record<string, number>,
 ): Promise<Record<string, number>> {
@@ -79,8 +79,24 @@ export async function allocatePorts(
 			continue;
 		}
 
-		// Use the component's declared port if free
-		const declaredPort = component.provides?.[0]?.port;
+		// Use the component's declared port if free.
+		//
+		// D-27: only an `exposed: true` endpoint is reachable from outside the
+		// host, so it anchors the single port this provider allocates. Fully
+		// internal components keep provides[0]. The docker provider answers
+		// $app.* by this same rule (app-url.ts), and this line is what makes the
+		// two agree on a file whose first entry is not the exposed one.
+		//
+		// Residual: this provider runs one host process per component and
+		// allocates it one port, so a component declaring several endpoints
+		// collapses to the anchor — every non-anchor endpoint is unallocated
+		// here. The allocated port also need not equal any declared port: when
+		// the preferred one is taken, the fall-through below picks a
+		// deterministic free port instead. See #276 for what that costs
+		// `$components.<name>.<endpoint>.*` on this provider.
+		const declaredPort = (
+			component.provides?.find((p) => p.exposed === true) ?? component.provides?.[0]
+		)?.port;
 		if (declaredPort && !allocated.has(declaredPort) && (await isPortFree(declaredPort))) {
 			result[name] = declaredPort;
 			allocated.add(declaredPort);

--- a/providers/macos-dev/tsconfig.build.json
+++ b/providers/macos-dev/tsconfig.build.json
@@ -1,4 +1,11 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // rootDir governs the emitted dist/ layout, so it lives with the build.
+    // The typecheck program also holds src/__tests__, and the cross-provider
+    // $app.* agreement test reads the docker provider's source — under a
+    // rootDir that is an error, for a file nothing is emitted from.
+    "rootDir": "src"
+  },
   "exclude": ["src/**/__tests__/**"]
 }

--- a/providers/macos-dev/tsconfig.json
+++ b/providers/macos-dev/tsconfig.json
@@ -7,10 +7,13 @@
     "noUnusedLocals": true,
     "noUncheckedIndexedAccess": true,
     "isolatedModules": true,
+    // The typecheck program also holds src/__tests__, and the cross-provider
+    // $app.* agreement test reads the docker provider's source. Emit layout is
+    // not decided here — tsconfig.build.json pins rootDir to src/.
+    "rootDir": "..",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "rootDir": "src",
     "outDir": "dist",
     "types": ["@types/bun", "vitest/globals"],
     "skipLibCheck": true


### PR DESCRIPTION
Closes #277

## What this does

`providers/macos-dev/src/port-allocator.ts` read `component.provides?.[0]?.port` with no check on `exposed`, while `env-writer.ts` picked the component to publish by `p.exposed === true`. Two rules, one number. For `provides: [{port: 9000}, {port: 8080, exposed: true}]` the docker provider answered `8080` and macos-dev answered `9000` for the same file.

## How the verdict's bound shape was addressed

| Verdict item | Where |
|---|---|
| 1. Anchor on the first `exposed: true` entry, falling back to `provides[0]` | `port-allocator.ts` — the patch as written in the verdict |
| 2. Widen the parameter type to carry `exposed` | `allocatePorts(components: Record<string, { provides?: Array<{ port: number; exposed?: boolean }> }>, …)` |
| 3. Keep the three consumers on one port | no second port map; `$app.*`, `$components.<name>.*`, and `PORT` all move together |
| 4. Change nothing in `providers/docker/` | the diff touches `providers/macos-dev/` and `.changeset/` only |
| 5. Record the residual in a code comment at the anchor | the collapse to one port, the fall-through port that matches no declared port, and the link to #276 |
| 6. Three allocator cases plus two composed tests | see **Tests** |
| 7. Show the path running | see **Verification** |

## Verification

**Live, the real path** — `allocatePorts` → `computeAppProperties` → `buildResolverContext` → `writeAllEnvFiles` on the two-endpoint fixture, reading back the env file it wrote:

```
allocated port        : 8080
macos-dev $app.url    : http://localhost:8080
docker    $app.url    : http://localhost:8080
process PORT (env)    : 8080
--- /var/folders/…/gov277-jJQwik/.launchfile/env/web.env ---
# Generated by launch up — do not edit manually
PORT=8080
```

**The same fixture on `origin/main`**, run against the pre-change allocator:

```
origin/main allocated port: 9000
```

That is the divergence: macos-dev bound `9000` where docker published `8080`, and `$app.url` named a port nothing outside the host could reach.

**The cross-provider agreement test fails on the unfixed allocator.** With `origin/main`'s `port-allocator.ts` copied over this head's, `src/__tests__/cross-provider-app-url.test.ts` fails:

```
AssertionError: expected 39000 to be 38080
 ❯ src/__tests__/cross-provider-app-url.test.ts:59:22
```

Neither side is handed the number: macos-dev runs with no saved port, so the anchor rule decides it, and docker runs with no host-port map, so it answers from the declared exposed endpoint. The fixture uses `39000`/`38080`, above the registered range, so a busy `8080` cannot make the test flaky.

**Tests** (`bun run typecheck` + `bun run build` + `bun run test`, in CI's build order):

| Package | Result |
|---|---|
| `providers/macos-dev` | 210 passed (22 files) — +5 new |
| `providers/docker` | 352 passed (26 files) — untouched, no drift |
| `providers/aws` | 55 passed (3 files) |
| `packages/launchfile` | 96 passed (10 files) |

New: `[{port: 9000}, {port: 8080, exposed: true}]` allocates `8080`; `[{port: 9000}]` with nothing exposed still allocates `9000`; an occupied `8080` (a real listener held for the assertion) falls through to the deterministic allocator and **not** back to `9000`. Plus `cross-provider-app-url.test.ts`: the composed run above, and docker's and macos-dev's `$app.*` agreeing on the two-endpoint fixture. No cross-provider agreement test existed before.

## What a reviewer should know

- **`@launchfile/docker` is a declared devDependency of `providers/macos-dev`.** The cross-provider test imports `../../../docker/src/app-url.js`, so macos-dev's typecheck reads docker's source; the declaration puts that in the dependency graph rather than leaving it to on-disk adjacency. `bun install --frozen-lockfile` resolves it to the workspace with no lockfile change.
- **`rootDir` moves from `tsconfig.json` to `tsconfig.build.json`.** The cross-provider test necessarily reads `providers/docker/src/app-url.ts`, which `tsc --noEmit` rejects under a `rootDir` of `src/`. `rootDir` governs the emitted `dist/` layout, so it belongs with the build config. Verified: the tsconfig split changes no emitted layout — both trees carry the same 120 files at the same paths. (The only `dist/` differences are the four files carrying the fix itself: `port-allocator.js`, its map, and its declarations.)
- **No catalog app moves.** The four apps with more than one `provides` entry (`gitea`, `mailpit`, `openclaw`, `opengist`) mark every entry `exposed: true`, so their anchor is unchanged. Worth doing at 0% catalog impact because nothing else would catch a regression here.
- **No decision entry is owed** — [D-27] already decides the rule being applied — and no documentation site changes.
- **Relationship to #276**: that is an open *issue*, not a PR. It makes `$components.<name>.<endpoint>.*` resolve and is deliberately independent of this change: it touches `env-writer.ts`, this one touches `port-allocator.ts`. There is nothing to conflict with yet — recheck when #276 opens a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
