### PR TITLE
providers: document the health-gate budget and what up leaves behind

### DIFF
--- a/providers/docker/CLAUDE.md
+++ b/providers/docker/CLAUDE.md
@@ -16,14 +16,17 @@ A Launchfile provider that runs apps via Docker Compose. Generates a docker-comp
 
 ## Timeout defaults (PROVIDERS.md §10.10)
 
-Budgets applied when a command declares no `timeout:`:
+Budgets applied when a command declares no `timeout:`, plus the health-gate budget on `up`, which no Launchfile field can set:
 
-| Command     | Default |
-|-------------|---------|
-| `release`   | 10m     |
-| `bootstrap` | 2m      |
+| Stage               | Default |
+|---------------------|---------|
+| `release`           | 10m     |
+| `bootstrap`         | 2m      |
+| health gate on `up` | 120s    |
 
 An unparseable declared `timeout` is surfaced, never silently replaced: `release` fails the deploy, `bootstrap` reports the failure to the invoker.
+
+When the health-gate budget expires, `up` fails and **the containers are left running** so you can inspect what never came up — `launchfile status`, `launchfile logs`, and `launchfile down` all still reach them. Run `launchfile down --destroy` to clear a failed deployment.
 
 ## Commands
 


### PR DESCRIPTION
Closes #243.

> **Base branch:** open this PR with `--base chore/gov-health-gate-crashloop` (PR #351). It stacks on that branch because both touch the same health-gate code path; retarget to `main` after #351 merges.

## What the verdict bound

The steward verdict on #243 (ACCEPT/High, twin-confirmed) settled the disposition: `up` **keeps the containers running** after a failed health gate, and no code changes. [D-48] binds what a failure *means*; [P-11] leaves the mechanism with the provider, so the record goes in the provider's own docs, not `spec/DESIGN.md`.

One documentation fix was required to close it, and this PR is exactly that fix — the verdict's replacement text for `providers/docker/CLAUDE.md:19-26`, applied verbatim:

- The timeout table gains the health-gate budget (`120s`), and the header becomes **Stage** since the health gate is not a command slot.
- A paragraph records the disposition: on expiry `up` fails, the containers are left running, and `status` / `logs` / `down` all still reach them. `down --destroy` clears a failed deployment.

Why it matters: `spec/PROVIDERS.md:252` is a MUST — a provider documents its timeout defaults, naming "the slot **or health check**" each duration belongs to. `HEALTH_TIMEOUT_MS = 120_000` (`providers/docker/src/provider.ts:793`) appeared in no document, and it is the only budget in this provider that no Launchfile field can set.

Kept to that one file, per the verdict: no `providers/docker/README.md` exists, and a second list could disagree with the first.

## Out of scope, on purpose

- **No `D-*` entry, no `spec/` change.** [D-48] kept recovery mechanism out of the spec layer; pinning teardown there would put it back.
- **Mandatory teardown for every provider is an Author call**, not a steward one.
- **The macos-dev conformance gap** the verdict found (`waitForHealthy`'s result discarded, `providers/macos-dev/src/process-manager.ts:132`) is filed separately as #376. Docker cannot fix it.

## Verification

Docs-only change, but the paragraph asserts runtime behavior, so the behavior was checked live rather than assumed.

**Live docker smoke** (nginx:alpine, `health.command: "exit 1"`, run against this branch's build with state redirected to a scratch `HOME`):

```
UP THREW after 125s: component(s) gov243-healthfail did not become healthy within 120s
--- docker ps after failed up ---
launchfile-gov243-healthfail-gov243-healthfail-1   Up 2 minutes (unhealthy)
--- launchfile status ---   App: gov243-healthfail   (reached it)
--- launchfile logs ---     (reached it)
--- down --destroy ---      Removed all containers, volumes, and state.
--- docker ps -a after down --destroy ---   (none)
```

Every clause of the new paragraph is OBSERVED: the 120s budget ends the deploy, the container is still up afterwards, `status` / `logs` / `down` all reach it, and `--destroy` clears it.

**Tests** (in the worktree, on this branch):

- `providers/docker`: `bun run typecheck` clean; `bun run test` → **26 files, 364 tests passed**.
- `bun test` in `providers/docker` is refused by the repo's runner guard, which points at `bun run test` — so the two runners cannot disagree here.

No changeset: `CLAUDE.md` is not in the package's `files` allowlist, so no published behavior changes.

**Cited:** [P-11] · [D-48]

[P-11]: https://github.com/launchfile/launchfile/blob/main/spec/DESIGN.md#p-11-separate-intent-from-execution
[D-48]: https://github.com/launchfile/launchfile/blob/main/spec/DESIGN.md#d-48-per-stage-failure-semantics-and-one-duration-grammar-zero-new-fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)
