### PR TITLE
providers: docker reports a requires[].version it cannot meet

### DIFF
--- a/.changeset/docker-requires-version-reporting.md
+++ b/.changeset/docker-requires-version-reporting.md
@@ -1,0 +1,11 @@
+---
+"@launchfile/docker": patch
+---
+
+Report a `requires[].version` constraint the provider cannot meet, instead of dropping it ([#271](https://github.com/launchfile/launchfile/issues/271)). Every backing-service factory pins one image tag — `postgres:16-alpine`, `mysql:8`, `mariadb:11`, `redis:7-alpine`, `mongo:7`, `clickhouse/clickhouse-server:latest` — and no code path read the declared range, so a Launchfile asking for `version: ">=17"` got postgres 16 with no diagnostic. PROVIDERS.md §10 rule 8 requires the gap to be surfaced.
+
+This provider still never selects a version. It compares the declared range against the tag the deployment actually runs — after any `config.extensions` image substitution — and reacts three ways. A tag whose whole version family satisfies the range is honored and stays silent: `>=15` against `postgres:16-alpine` warns nothing, which is what keeps the three shipped catalog entries that declare `version` (hedgedoc, hedgedoc-v2, plausible) quiet. A range the tag can never satisfy warns that it is not satisfied. A range the tag is too coarse to decide (`^16.2` against `16`), a tag with no version (`latest`), and an unparseable range each warn that the constraint could not be checked.
+
+Warnings name the entry by its `name ?? type`, the declared range, and the image this provider runs. They state what the provider does and never predict what the app will do. They go through the existing warning channel, so `up` prints them and the structured log carries them.
+
+`semver` joins the dependencies for the range comparison, matching the version `@launchfile/macos-dev` already uses.

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "packages/launchfile": {
       "name": "launchfile",
-      "version": "0.3.0",
+      "version": "0.7.1",
       "bin": {
         "launchfile": "dist/cli.js",
       },
@@ -30,7 +30,7 @@
     },
     "providers/aws": {
       "name": "@launchfile/aws",
-      "version": "0.1.1",
+      "version": "0.2.1",
       "bin": {
         "launchfile-aws": "dist/cli.js",
       },
@@ -48,23 +48,25 @@
     },
     "providers/docker": {
       "name": "@launchfile/docker",
-      "version": "0.3.0",
+      "version": "0.7.1",
       "dependencies": {
-        "@launchfile/sdk": "^0.3.0",
+        "@launchfile/sdk": "^0.7.0",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
+        "semver": "^7.7.4",
         "yaml": "^2.8.3",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.10",
         "@types/bun": "^1.3.11",
+        "@types/semver": "^7.7.1",
         "typescript": "^7.0.2",
         "vitest": "^4.1.3",
       },
     },
     "providers/macos-dev": {
       "name": "@launchfile/macos-dev",
-      "version": "0.3.0",
+      "version": "0.7.0",
       "dependencies": {
         "@launchfile/sdk": "^0.3.0",
         "semver": "^7.7.4",
@@ -79,7 +81,7 @@
     },
     "sdk": {
       "name": "@launchfile/sdk",
-      "version": "0.3.0",
+      "version": "0.7.0",
       "dependencies": {
         "yaml": "^2.8.3",
         "zod": "^4.3.6",

--- a/providers/docker/package.json
+++ b/providers/docker/package.json
@@ -36,11 +36,13 @@
     "@launchfile/sdk": "^0.7.0",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
+    "semver": "^7.7.4",
     "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.10",
     "@types/bun": "^1.3.11",
+    "@types/semver": "^7.7.1",
     "typescript": "^7.0.2",
     "vitest": "^4.1.3"
   }

--- a/providers/docker/src/__tests__/version-constraint.test.ts
+++ b/providers/docker/src/__tests__/version-constraint.test.ts
@@ -1,0 +1,134 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { readLaunch } from "@launchfile/sdk";
+import { describe, expect, it } from "vitest";
+import { launchToCompose } from "../compose-generator.js";
+
+/**
+ * PROVIDERS.md §10 rule 8 (general form): a field this provider cannot honor
+ * is surfaced, never silently dropped. This provider provisions fixed image
+ * tags and never selects a version, so a declared `requires[].version` is
+ * compared against the tag the deployment actually runs.
+ *
+ * Honoring is silent: a tag that provably satisfies the range is not a gap,
+ * and warning there would train authors to ignore the channel (the D-51
+ * standard — say what this provider does, never predict the app).
+ */
+describe("requires[].version constraint reporting", () => {
+	const compose = (requires: string) =>
+		launchToCompose(
+			readLaunch(
+				`version: launch/v1\nname: app\nimage: x:1\nrequires:\n${requires}`,
+			),
+		);
+
+	const versionWarnings = (requires: string) =>
+		compose(requires).warnings.filter((w) => w.includes("declared version"));
+
+	it("stays silent when the pinned image satisfies the range", () => {
+		// postgres:16-alpine covers every 16.x, all of which are >= 15.
+		expect(versionWarnings('  - type: postgres\n    version: ">=15"\n')).toEqual(
+			[],
+		);
+	});
+
+	it("warns when the pinned image cannot satisfy the range", () => {
+		const [warning] = versionWarnings(
+			'  - type: postgres\n    version: ">=17"\n',
+		);
+		expect(warning).toContain('requires[postgres]: declared version ">=17"');
+		expect(warning).toContain("is not satisfied");
+		expect(warning).toContain("postgres:16-alpine");
+	});
+
+	it("warns when the tag is too coarse to decide the range", () => {
+		// `16` names the whole 16.x family; ^16.2 excludes 16.0 and 16.1.
+		const [warning] = versionWarnings(
+			'  - type: postgres\n    version: "^16.2"\n',
+		);
+		expect(warning).toContain("cannot be checked against the fixed image");
+		expect(warning).toContain("postgres:16-alpine");
+	});
+
+	it("warns when the image tag names no version", () => {
+		const [warning] = versionWarnings(
+			'  - type: clickhouse\n    version: ">=24"\n',
+		);
+		expect(warning).toContain("clickhouse/clickhouse-server:latest");
+		expect(warning).toContain("whose version is not fixed");
+	});
+
+	it("warns on a range it cannot parse rather than dropping it", () => {
+		const [warning] = versionWarnings(
+			'  - type: redis\n    version: "seven-ish"\n',
+		);
+		expect(warning).toContain("is not a valid semver range");
+		expect(warning).toContain("redis:7-alpine");
+	});
+
+	it("names the entry by its `name` when one is given", () => {
+		const [warning] = versionWarnings(
+			'  - type: postgres\n    name: primary-db\n    version: ">=17"\n',
+		);
+		expect(warning).toContain("requires[primary-db]:");
+	});
+
+	it("checks every backing-service type, not postgres alone", () => {
+		for (const [type, image] of [
+			["mysql", "mysql:8"],
+			["mariadb", "mariadb:11"],
+			["redis", "redis:7-alpine"],
+			["mongodb", "mongo:7"],
+		] as const) {
+			const [warning] = versionWarnings(
+				`  - type: ${type}\n    version: ">=99"\n`,
+			);
+			expect(warning).toContain(`requires[${type}]:`);
+			expect(warning).toContain(image);
+		}
+	});
+
+	it("stays silent for an entry that declares no version", () => {
+		expect(versionWarnings("  - type: postgres\n")).toEqual([]);
+	});
+
+	it("checks the substituted extension image, not the default one", () => {
+		// `config.extensions` swaps the image; the check must run against what
+		// the compose file actually carries.
+		const requires =
+			'  - type: postgres\n    version: ">=17"\n    config:\n      extensions: [pgvector]\n';
+		const [warning] = versionWarnings(requires);
+		expect(warning).toContain("pgvector/pgvector:pg16");
+		expect(warning).not.toContain("postgres:16-alpine");
+	});
+
+	it("stays silent when the substituted extension image satisfies the range", () => {
+		const requires =
+			'  - type: postgres\n    version: ">=15"\n    config:\n      extensions: [pgvector]\n';
+		expect(versionWarnings(requires)).toEqual([]);
+	});
+});
+
+/**
+ * The three shipped entries that declare `requires[].version` all state lower
+ * bounds the pinned major already clears. None is mis-provisioned today, so
+ * none may warn — this is what keeps the check from becoming noise on files
+ * that are correct.
+ */
+describe("shipped catalog entries declaring requires[].version", () => {
+	const CATALOG = join(import.meta.dirname, "../../../../catalog");
+
+	for (const entry of [
+		"apps/hedgedoc",
+		"drafts/hedgedoc-v2",
+		"drafts/plausible",
+	]) {
+		it(`${entry} generates no version warning`, async () => {
+			const yaml = await readFile(join(CATALOG, entry, "Launchfile"), "utf8");
+			const { warnings } = launchToCompose(readLaunch(yaml));
+			expect(warnings.filter((w) => w.includes("declared version"))).toEqual(
+				[],
+			);
+		});
+	}
+});

--- a/providers/docker/src/compose-generator.ts
+++ b/providers/docker/src/compose-generator.ts
@@ -22,6 +22,7 @@ import {
 	type UnboundOperatorVolume,
 	unsuppliedRequiredEnv,
 } from "@launchfile/sdk";
+import { intersects, subset, validRange } from "semver";
 import { stringify } from "yaml";
 import { computeAppProperties } from "./app-url.js";
 import {
@@ -193,6 +194,80 @@ function applyPostgresConfig(
 	}
 
 	return `${sqlNames.map((n) => `CREATE EXTENSION IF NOT EXISTS "${n}";`).join("\n")}\n`;
+}
+
+// --- requires.version handling ---
+
+/**
+ * The version family an image tag denotes, as a semver range — `undefined`
+ * when the tag names no version (`latest`). A tag is a family, not a release:
+ * `16` covers every 16.x the registry may resolve it to. Some tags carry a
+ * short alphabetic prefix that is not part of the version
+ * (`pgvector/pgvector:pg16`).
+ */
+function tagVersionRange(image: string): string | undefined {
+	const lastSlash = image.lastIndexOf("/");
+	const colon = image.indexOf(":", lastSlash + 1);
+	if (colon === -1) return undefined;
+	const match = /^[a-z]*(\d+(?:\.\d+)*)/.exec(image.slice(colon + 1));
+	if (!match) return undefined;
+	const parts = match[1]!.split(".");
+	if (parts.length === 1) return `${parts[0]}.x`;
+	if (parts.length === 2) return `${parts[0]}.${parts[1]}.x`;
+	return match[1]!;
+}
+
+/**
+ * Honor `requires[].version` (PROVIDERS.md §10 rule 8: report gaps, not silent
+ * drops). This provider provisions fixed image tags and never selects a
+ * version, so the declared range is compared against the tag the deployment
+ * will actually run — after any extension substitution. A range the tag
+ * provably satisfies is honored, and honoring it is silent. Anything else —
+ * provably unsatisfiable, undecidable, or an unparseable range — is a gap and
+ * is surfaced. The message states what this provider does and never asserts
+ * what the app will do (the D-51 rule).
+ */
+function checkVersionConstraint(
+	req: NormalizedRequirement,
+	image: string,
+	warnings: string[],
+): void {
+	const declared = req.version;
+	if (!declared) return;
+	const key = req.name ?? req.type;
+	const quoted = JSON.stringify(declared);
+
+	if (validRange(declared) === null) {
+		warnings.push(
+			`requires[${key}]: declared version ${quoted} is not a valid semver range — ` +
+				`this provider cannot check it against ${image}.`,
+		);
+		return;
+	}
+
+	const tagRange = tagVersionRange(image);
+	if (tagRange === undefined) {
+		warnings.push(
+			`requires[${key}]: declared version ${quoted} cannot be checked — this provider provisions ` +
+				`${image}, whose version is not fixed, and does not select versions.`,
+		);
+		return;
+	}
+
+	if (subset(tagRange, declared)) return;
+
+	if (!intersects(tagRange, declared)) {
+		warnings.push(
+			`requires[${key}]: declared version ${quoted} is not satisfied — this provider provisions the ` +
+				`fixed image ${image} and does not select versions.`,
+		);
+		return;
+	}
+
+	warnings.push(
+		`requires[${key}]: declared version ${quoted} cannot be checked against the fixed image ${image} — ` +
+			`this provider does not select versions.`,
+	);
 }
 
 /**
@@ -1454,6 +1529,13 @@ function addBackingService(
 
 		services[serviceName] = service;
 	}
+
+	// The image checked is the one the deployment actually runs — after any
+	// extension substitution above — so the message never names an image that
+	// is not in the compose file. A shared service is checked per requirement:
+	// a second entry declaring a version the first entry's image does not
+	// satisfy is its own gap.
+	checkVersionConstraint(req, services[serviceName]!.image as string, warnings);
 
 	return {
 		serviceName,


### PR DESCRIPTION
Closes #271.

The docker provider pins one image tag per backing-service type and no code path read `req.version`. A Launchfile declaring `version: ">=17"` got `postgres:16-alpine` with no diagnostic — the silent drop `spec/PROVIDERS.md:235` (§10 rule 8) forbids in its general form.

## How the bound shape was implemented

The steward verdict on #271 bound nine points. Each maps to something in this diff.

| Bound | Where |
|---|---|
| Compare, never select — no registry query, no tag substitution | `checkVersionConstraint` in `compose-generator.ts`; all six pinned tags unchanged |
| Three outcomes: subset → silent, disjoint → "not satisfied", otherwise → "cannot be checked" | same function, via `semver.subset` / `semver.intersects` |
| Silence when the constraint holds | `subset` returns early; two tests assert `>=15` and the three catalog entries warn nothing |
| Warning names entry (`name ?? type`), declared range, and the image run; states provider behavior only | the four `warnings.push` messages |
| Check the image actually used, after extension substitution | the call site reads `services[serviceName].image`, placed after `applyPostgresConfig` |
| All six types, one call site | the call sits in `addBackingService`, which every backing-service type passes through |
| Use `semver` at `^7.7.4` | `providers/docker/package.json`, matching `providers/macos-dev/package.json:40` |
| Docker only; no spec change; `version` stays out of rule 8's two stronger-form fields | no file under `spec/` is touched; `providers/macos-dev` and `providers/aws` untouched |
| Tests per outcome, plus the catalog regression | `providers/docker/src/__tests__/version-constraint.test.ts` |

The verdict also required the neighbouring providers be written down rather than quietly left — filed as #404 (macos-dev drops the field; aws strips its range operators).

## An unparseable range warns too

The verdict's three states leave one case unnamed: a `version` string that is not a semver range at all. Dropping it would be the same defect this PR closes, so it takes a fourth message ("is not a valid semver range"). Called out because it is the one thing here the verdict did not spell out.

## Verification

**Tests.** `providers/docker`: `bun run typecheck` clean, `bun run build` clean, `bun run test` **365 passed (27 files)** — the 352 that passed before this change, plus 13 new. `sdk` 425/425, `providers/macos-dev` 205/205, `providers/aws` 55/55, `packages/launchfile` 96/96 all still pass. CI runs `bun run test` (Vitest); `bun test` is blocked by the package's own test guard, so there is no second runner to disagree.

**Live, on real Docker** (29.7.2 / Compose v5.5.0), not just unit tests:

`up` on a Launchfile declaring postgres `version: ">=17"` printed, before pulling anything:

```
Warning: requires[postgres]: declared version ">=17" is not satisfied — this provider provisions the fixed image postgres:16-alpine and does not select versions.
```

The deploy then continued and passed its health check — this warns, it does not fail. `down --destroy` removed all containers, volumes and state. The same file changed to `">=15"` produced zero version warnings.

## What this does not change

No image is substituted and no tag is parameterized. `POSTGRES_EXTENSION_IMAGES` keeps its pg16 lockstep — the check reads the substituted image rather than changing it, so the extension path and the version path cannot disagree. Compose generation stays offline and deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

