### PR TITLE
catalog: share chatwoot/dify's per-component secret via a top-level secrets: block

### DIFF
--- a/catalog/drafts/chatwoot/Launchfile
+++ b/catalog/drafts/chatwoot/Launchfile
@@ -3,6 +3,10 @@ version: launch/v1
 name: chatwoot
 description: "Open-source customer support platform"
 
+secrets:
+  secret-key-base:
+    generator: secret
+
 components:
   web:
     image: chatwoot/chatwoot:latest
@@ -19,7 +23,7 @@ components:
           REDIS_URL: $url
     env:
       SECRET_KEY_BASE:
-        generator: secret
+        default: "$secrets.secret-key-base"
         sensitive: true
       FRONTEND_URL:
         required: true
@@ -44,7 +48,7 @@ components:
           REDIS_URL: $url
     env:
       SECRET_KEY_BASE:
-        generator: secret
+        default: "$secrets.secret-key-base"
         sensitive: true
       RAILS_ENV:
         default: "production"

--- a/catalog/drafts/dify/Launchfile
+++ b/catalog/drafts/dify/Launchfile
@@ -3,6 +3,10 @@ version: launch/v1
 name: dify
 description: "AI application development platform"
 
+secrets:
+  secret-key:
+    generator: secret
+
 components:
   api:
     image: langgenius/dify-api:latest
@@ -25,7 +29,7 @@ components:
           REDIS_PASSWORD: $password
     env:
       SECRET_KEY:
-        generator: secret
+        default: "$secrets.secret-key"
         sensitive: true
         description: "Application secret key"
       CONSOLE_WEB_URL:
@@ -75,9 +79,9 @@ components:
           REDIS_PASSWORD: $password
     env:
       SECRET_KEY:
-        generator: secret
+        default: "$secrets.secret-key"
         sensitive: true
-        description: "Application secret key (must match api)"
+        description: "Application secret key, shared with api via secrets.secret-key"
       MODE:
         default: worker
         description: "Run mode"


### PR DESCRIPTION
Closes #236

## What

`catalog/drafts/chatwoot` declared `SECRET_KEY_BASE` under both `web` and
`sidekiq`; `catalog/drafts/dify` declared `SECRET_KEY` under both `api` and
`worker`. Per D-25 each component's `env:` entry is its own property, and per
D-49 a `generator:` mints one value **per declaration** — so these were two
independent values, not one shared value. #186 made each value stable across
redeploys, which froze the divergence rather than fixing it: chatwoot's `web`
and `sidekiq` verify Rails sessions/job signatures with different
`SECRET_KEY_BASE` values; dify's `api` and `worker` sign with different
`SECRET_KEY`s.

This follows the steward's ACCEPT verdict on #236 exactly: move each value to
the app's top-level `secrets:` block (already documented in
`spec/SPEC.md` § Secrets) and reference it from every component via
`$secrets.<name>`. Both providers already persist `secrets:` values app-wide,
so no provider change is needed. Authoring fix only — two draft catalog
files, no schema/format/provider change.

- `chatwoot`: added `secrets.secret-key-base`; `web` and `sidekiq` now both
  read `default: "$secrets.secret-key-base"`.
- `dify`: added `secrets.secret-key`; `api` and `worker` now both read
  `default: "$secrets.secret-key"`. Rewrote worker's description from
  "must match api" (an unenforced obligation) to state the sharing is now
  structural.

## Full-catalog audit

Per the verdict's ask, re-audited all 113 catalog Launchfiles (72 `apps/` +
41 `drafts/`) for the same pattern — a `generator:` env var declared
independently under two or more sibling components. **2 of 113 were
affected: chatwoot and dify, both now fixed.** No other app has this pattern.
(A generic `noUnusedLocals`-style YAML scan; script available on request —
not part of this diff since it isn't a linter yet. A follow-up to
`sdk/src/lint.ts` for this pattern is explicitly out of scope per the
verdict.)

## Verification

**Automated:** `cd catalog/test && bun run test` (vitest) — 33/33 pass. Confirmed `bun test` (the bare Bun runner) still refuses via the repo's test-guard preload, so CI can't silently take the wrong path.

**Verified live**, against the real Docker provider's compose generator
(`providers/docker/src/compose-generator.ts`, not the catalog/test harness
stub) with both fixed Launchfiles:
- **Run 1** (first `up`, no persisted state): `chatwoot`'s `web` and
  `sidekiq` resolve to the identical 64-hex-char `SECRET_KEY_BASE`; `dify`'s
  `api` and `worker` resolve to the identical `SECRET_KEY`.
- **Run 2** (simulated redeploy, `opts.secrets` seeded from run 1's
  returned `secrets` map — exactly what `provider.ts` persists to
  `state.secrets` and reloads): both apps' values are **preserved
  unchanged** across the run, and both sibling components still match each
  other.

This exercises the actual persistence mechanism the verdict named
(`state.secrets`, kept disjoint from `state.generatedEnv`), not just the
YAML shape.

**Note for anyone already running these drafts:** this mints one fresh value per app.
`state.secrets` and `state.generatedEnv` are separate stores
(`providers/docker/src/state.ts:40-53`), so moving off the per-component `generator:`
adopts neither of today's per-component values — the next deploy generates a new shared
value and leaves the old two unused. For chatwoot that invalidates existing Rails sessions
and any column encrypted under the old `SECRET_KEY_BASE`; for dify, existing sessions and
stored credentials encrypted under the old `SECRET_KEY`. Both apps are unpromoted drafts
(`catalog/README.md:19` — "Proposed — Launchfile written, not yet verified"), so no
verified deployment is affected. Landing it now, while that is still true, is cheaper than
landing it after promotion.

## Caveat for the reviewer

The audit script isn't checked in (verdict scoped this as authoring-only,
catalog files only). If a linter check for this pattern is wanted, that's
the separate follow-up issue the verdict already flagged as out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
