### PR TITLE
sdk: carry env var `example` (D-31) through parse and serialize

### DIFF
--- a/.changeset/env-example-roundtrip.md
+++ b/.changeset/env-example-roundtrip.md
@@ -1,0 +1,5 @@
+---
+"@launchfile/sdk": patch
+---
+
+Fix `example` field on environment variables (D-31) being silently dropped by `readLaunch`/`writeLaunch`. `EnvVarObjectSchema`, the `EnvVar`/`NormalizedEnvVar` types, and the reader/writer normalization now carry `example` through parse and serialize, matching the published JSON Schema.

--- a/sdk/src/__tests__/reader-writer.test.ts
+++ b/sdk/src/__tests__/reader-writer.test.ts
@@ -123,6 +123,22 @@ env:
 		expect(env?.NAME).toEqual({ default: "my-app" });
 	});
 
+	it("reads the D-31 example field the published schema defines", () => {
+		const result = readLaunch(`
+name: my-app
+env:
+  API_KEY:
+    description: The key
+    example: "sk-live-abc123"
+    required: true
+`);
+		expect(result.components.default?.env?.API_KEY).toEqual({
+			description: "The key",
+			example: "sk-live-abc123",
+			required: true,
+		});
+	});
+
 	// Multi-component
 	it("reads multi-component apps", () => {
 		const result = readLaunch(`
@@ -429,6 +445,18 @@ commands:
 		const launch = readLaunch(`name: my-app\nenv:\n  PORT: "8080"`);
 		const yaml = writeLaunch(launch);
 		expect(yaml).toContain("PORT: \"8080\"");
+	});
+
+	it("carries the D-31 example field through parse → serialize", () => {
+		const yaml = `version: launch/v1
+name: my-app
+runtime: node
+env:
+  API_KEY:
+    default: "sk-live-default"
+    example: "sk-live-abc123"
+`;
+		expect(writeLaunch(readLaunch(yaml))).toContain("example: sk-live-abc123");
 	});
 
 	// Keeps object form when extra fields present

--- a/sdk/src/reader.ts
+++ b/sdk/src/reader.ts
@@ -192,6 +192,7 @@ function normalizeEnv(
 				required: val.required,
 				generator: val.generator,
 				sensitive: val.sensitive,
+				example: val.example,
 			};
 		}
 	}

--- a/sdk/src/schema.ts
+++ b/sdk/src/schema.ts
@@ -119,6 +119,7 @@ const EnvVarObjectSchema = z.object({
 	required: z.boolean().optional(),
 	generator: GeneratorSchema.optional(),
 	sensitive: z.boolean().optional(),
+	example: z.string().max(256).optional(),
 });
 
 /** Accepts string shorthand ("8080") or full object */

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -145,6 +145,8 @@ export interface EnvVar {
 	generator?: Generator;
 	/** Whether this value should be stored in a secrets manager */
 	sensitive?: boolean;
+	/** Example value showing expected format (informational, D-31) */
+	example?: string;
 }
 
 // --- Build ---
@@ -398,6 +400,7 @@ export interface NormalizedEnvVar {
 	required?: boolean;
 	generator?: Generator;
 	sensitive?: boolean;
+	example?: string;
 }
 
 /** Fully expanded requirement (no string shorthand) */

--- a/sdk/src/writer.ts
+++ b/sdk/src/writer.ts
@@ -158,7 +158,8 @@ function denormalizeEnv(
 			!val.label &&
 			!val.required &&
 			!val.generator &&
-			!val.sensitive
+			!val.sensitive &&
+			!val.example
 		) {
 			result[key] = val.default;
 		} else {
@@ -169,6 +170,7 @@ function denormalizeEnv(
 			if (val.required) obj.required = val.required;
 			if (val.generator) obj.generator = val.generator;
 			if (val.sensitive) obj.sensitive = val.sensitive;
+			if (val.example) obj.example = val.example;
 			result[key] = obj;
 		}
 	}


### PR DESCRIPTION
Closes #175

## Problem

`EnvVarObjectSchema` (`sdk/src/schema.ts`) listed six fields against the published JSON Schema's seven (`$defs.envVar`). `example` — normative per [D-31](https://github.com/launchfile/launchfile/blob/main/spec/DESIGN.md#d-31-example-field-on-environment-variables) — was missing, so zod's default strip mode silently deleted it on every parse. No app in the catalog uses `example:` yet, which is why this went unnoticed.

## How the issue verdict's bound shape was addressed

The steward's ACCEPT verdict named five exact edit sites (not the two the issue body originally proposed) because `env` is rebuilt field-by-field in both directions, unlike `storage` which is passed through by reference. All five are addressed in this PR:

1. `sdk/src/schema.ts:115-122` — added `example: z.string().max(256).optional()` to `EnvVarObjectSchema`, matching `label`'s bound.
2. `sdk/src/types.ts` — added `example?: string` to both `EnvVar` and `NormalizedEnvVar`.
3. `sdk/src/reader.ts` — `normalizeEnv` now copies `example` onto the normalized object.
4. `sdk/src/writer.ts` (object branch) — `denormalizeEnv` now writes `example` back when present.
5. `sdk/src/writer.ts` (scalar-collapse guard) — added `!val.example` to the guard, so a var with both `default` and `example` no longer collapses to a bare scalar and silently loses `example` on write.

Two tests were added to `sdk/src/__tests__/reader-writer.test.ts`:
- `reads the D-31 example field the published schema defines` — `readLaunch` preserves `example`.
- `carries the D-31 example field through parse → serialize` — a var with both `default` and `example` round-trips through `writeLaunch(readLaunch(yaml))` without losing `example` (the case that exercises the scalar-collapse guard, edit site 5).

A changeset (`.changeset/env-example-roundtrip.md`, patch bump for `@launchfile/sdk`) is included since this is a published-package behavior fix.

No spec change, no new `D-*` entry, no documentation-site change — per the verdict, D-31 already decided the field exists; this is the reference parser catching up.

## Verification (OBSERVED)

- `cd sdk && bun run typecheck` — clean, no errors.
- `cd sdk && bun run build` — clean.
- `cd sdk && bun run test` (vitest run, the actual CI runner per `.github/workflows/ci.yml:36`) — **427/427 passed**, including the 2 new tests.
- `bun test` (bare) correctly refuses in this package with a guard message pointing at `bun run test` — confirms `bun run test` is the real CI-matching runner and the bare `bun test` bypass is blocked.
- `bun run lint` (biome): 42 errors / 91 warnings — **identical count on `main` before this change** (verified by running the same command against the unmodified `sdk/` in the main checkout). No new lint issues introduced.
- Live-ran the issue's own reproduction case through `readLaunch`/`writeLaunch` directly (not just the test suite):
  ```
  parsed.env.API_KEY: {"description":"The key","required":true,"example":"sk-live-abc123"}
  serialized output includes: "example: sk-live-abc123"
  ```
  `example` now survives parse → serialize, matching the issue's exact repro.

## Caveat for the reviewer

Per the verdict, an `lintUnknownEnvKeys` diagnostic (mirroring `lintUnknownStorageKeys`) and the general "normalize functions enumerate fields by name" pattern (tracked in #233) are explicitly out of scope for this fix — this PR closes the one field only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
