### PR TITLE
www-org: fix dead cross-section SPEC.md anchors (register ###+ headings, emit heading ids)

### DIFF
--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -568,6 +568,8 @@ commands:
         pattern: "https?://\\S+"
         description: "One-time invite link"
         sensitive: true
+```
+
 ### Command Capture
 
 Any command that uses the expanded form can declare **captures** — named values extracted from the command's stdout via regex patterns. The platform matches each capture's regex against the command's stdout and stores the first capture group's value (or, if the pattern has no capture group, the full match).

--- a/www-org/scripts/check-spec-coverage.ts
+++ b/www-org/scripts/check-spec-coverage.ts
@@ -3,10 +3,15 @@
  * check-spec-coverage — enforce that every Launchfile schema field is reachable
  * at a predictable URL under /spec/.
  *
- * Runs in prebuild. Catches three real failure modes:
+ * Runs in prebuild. Catches these real failure modes:
  *   1. Schema field added but no ## section in SPEC.md.
  *   2. Schema field documented but no sidebar entry in navigation.ts.
  *   3. Sidebar href points at a slug with no matching SPEC.md section.
+ *   4. A `[text](#anchor)` cross-reference in SPEC.md points at a slug no
+ *      heading in the document produces (issue #198).
+ *   5. Two ###+ headings produce the same slug, so one shadows the other.
+ *   6. An anchor's target page never got the matching `id=` in its
+ *      rendered HTML (renderer.heading and the anchor map drifted apart).
  *
  * Slug convention: kebab-cased YAML key, verbatim, unless listed in
  * SLUG_OVERRIDES in spec-sections.ts (e.g. `env` → prose heading "Environment
@@ -18,6 +23,8 @@ import { resolve } from "path";
 import { navigation } from "../src/lib/navigation";
 import {
   SLUG_OVERRIDES,
+  getAnchorCollisions,
+  getAnchorMap,
   getSpecSections,
 } from "../src/lib/spec-sections";
 
@@ -114,7 +121,48 @@ async function main(): Promise<void> {
     }
   }
 
-  // 5. Report.
+  // 5. Every `](#anchor)` in SPEC.md must resolve to a real heading — a `##`
+  // section or a `###`+ sub-heading — and every heading-level anchor's
+  // fragment must actually be emitted as an `id=` in the rendered HTML.
+  const specPath = resolve(process.cwd(), "../spec/SPEC.md");
+  const specRaw = readFileSync(specPath, "utf-8");
+  const usedAnchors = new Set(
+    [...specRaw.matchAll(/\]\(#([^)]+)\)/g)].map((m) => m[1]),
+  );
+  const anchorMap = await getAnchorMap();
+  for (const anchor of usedAnchors) {
+    if (!anchorMap.has(anchor)) {
+      errors.push(
+        `SPEC.md links to "#${anchor}", but no ## section or ###+ heading in the document produces that slug.`,
+      );
+    }
+  }
+
+  const anchorCollisions = await getAnchorCollisions();
+  for (const slug of anchorCollisions) {
+    errors.push(
+      `Heading slug "${slug}" is produced by more than one ###+ heading in SPEC.md. The first in document order keeps the anchor; rename the others.`,
+    );
+  }
+
+  const sectionsBySlug = new Map(sections.map((s) => [s.slug, s]));
+  for (const [anchor, href] of anchorMap) {
+    const fragmentMatch = href.match(/^\/spec\/([^/]+)\/#(.+)$/);
+    if (!fragmentMatch) continue; // a ## section href has no fragment to check
+    const [, pageSlug, fragment] = fragmentMatch;
+    const page = sectionsBySlug.get(pageSlug);
+    if (!page) {
+      errors.push(`Anchor "#${anchor}" maps to unknown page slug "${pageSlug}".`);
+      continue;
+    }
+    if (!page.html.includes(`id="${fragment}"`)) {
+      errors.push(
+        `Anchor "#${anchor}" resolves to /spec/${pageSlug}/#${fragment}, but no heading with id="${fragment}" is emitted on that page — renderer.heading in spec-sections.ts must be emitting a mismatched id.`,
+      );
+    }
+  }
+
+  // 6. Report.
   if (errors.length > 0) {
     console.error("\n✗ Spec coverage check failed:\n");
     for (const err of errors) console.error(`  - ${err}`);
@@ -125,7 +173,7 @@ async function main(): Promise<void> {
   }
 
   console.log(
-    `✓ Spec coverage: ${schemaFields.length} schema fields, ${sections.length} sections, ${specGroup?.items.length} sidebar entries — all reachable.`,
+    `✓ Spec coverage: ${schemaFields.length} schema fields, ${sections.length} sections, ${specGroup?.items.length} sidebar entries, ${usedAnchors.size} cross-reference anchors — all reachable.`,
   );
 }
 

--- a/www-org/src/lib/spec-sections.ts
+++ b/www-org/src/lib/spec-sections.ts
@@ -37,8 +37,17 @@ export function resolveSlug(title: string): string {
   return SLUG_OVERRIDES[defaultSlug] ?? defaultSlug;
 }
 
-/** Map of anchor → href for cross-reference rewriting */
+/** Map of anchor → href for cross-reference rewriting. Keys are the plain
+ * slug of an `##` section title or of an `###`+ heading anywhere in the
+ * document; values are `/spec/<slug>/` for a section, or
+ * `/spec/<enclosing-section-slug>/#<heading-slug>` for a sub-heading. */
 const sectionSlugs = new Map<string, string>();
+
+/** `###`+ heading slugs that collided with an earlier heading's slug — the
+ * earlier one (first in document order) kept the map entry; these lost the
+ * anchor and are unreachable by link until one heading is renamed. Surfaced
+ * by `check-spec-coverage.ts`. */
+const anchorCollisions: string[] = [];
 
 function rewriteInternalLinks(markdown: string): string {
   return markdown.replace(
@@ -100,6 +109,17 @@ export async function getSpecSections(): Promise<SpecSection[]> {
       return `<pre class="shiki github-dark"><code>${escaped}</code></pre>`;
     }
   };
+  renderer.heading = function ({ tokens, depth, text }: Tokens.Heading): string {
+    const html = this.parser.parseInline(tokens);
+    // The `##` line is stripped from each section's body before it reaches
+    // marked (see below), so this only ever renders `###`+ headings — which
+    // are exactly the ones that need an id for a same-page or cross-page
+    // `#anchor` link to have something to scroll to.
+    if (depth < 3) {
+      return `<h${depth}>${html}</h${depth}>\n`;
+    }
+    return `<h${depth} id="${slugify(text)}">${html}</h${depth}>\n`;
+  };
 
   // Remove the h1 title line
   const withoutH1 = raw.replace(/^# .+\n/, "");
@@ -124,7 +144,30 @@ export async function getSpecSections(): Promise<SpecSection[]> {
     }
   }
 
-  // Second pass: parse and render
+  // Second pass: register `###`+ heading anchors, keyed to their enclosing
+  // `##` section. The fragment is the plain heading slug — what an author
+  // writes and what GitHub already resolves — never a second override
+  // table. First occurrence in document order wins a slug; a later heading
+  // that produces the same slug is recorded as a collision rather than
+  // silently overwriting the winner's href (reported by
+  // check-spec-coverage.ts).
+  for (const part of parts) {
+    const titleMatch = part.match(/^## (.+)$/m);
+    if (!titleMatch) continue;
+    const defaultSlug = slugify(titleMatch[1]);
+    const enclosingSlug = SLUG_OVERRIDES[defaultSlug] ?? defaultSlug;
+
+    for (const [, headingText] of part.matchAll(/^#{3,6} (.+)$/gm)) {
+      const headingSlug = slugify(headingText);
+      if (sectionSlugs.has(headingSlug)) {
+        anchorCollisions.push(headingSlug);
+        continue;
+      }
+      sectionSlugs.set(headingSlug, `/spec/${enclosingSlug}/#${headingSlug}`);
+    }
+  }
+
+  // Third pass: parse and render
   const sections: SpecSection[] = [];
   for (const part of parts) {
     const titleMatch = part.match(/^## (.+)$/m);
@@ -151,4 +194,20 @@ export async function getSpecSection(
 ): Promise<SpecSection | undefined> {
   const sections = await getSpecSections();
   return sections.find((s) => s.slug === slug);
+}
+
+/** The anchor → href map, keyed by every `##` section slug and every
+ * `###`+ heading slug in `spec/SPEC.md`. Used by `check-spec-coverage.ts`
+ * to verify every `](#anchor)` in the spec resolves to a real heading. */
+export async function getAnchorMap(): Promise<Map<string, string>> {
+  await getSpecSections();
+  return sectionSlugs;
+}
+
+/** Heading slugs produced by more than one `###`+ heading — the first in
+ * document order won the anchor in `getAnchorMap()`; the rest are
+ * unreachable by link until one heading is renamed. */
+export async function getAnchorCollisions(): Promise<string[]> {
+  await getSpecSections();
+  return anchorCollisions;
 }


### PR DESCRIPTION
Closes #198

## The bound shape

The steward's ACCEPT verdict on #198 required both halves in one PR — a
map-only fix routes a link to the right page but leaves it landing at the
top, since the target heading has no `id` to scroll to:

1. Register `###`+ headings in `getSpecSections()`'s anchor map, alongside
   the existing `##` section map, as `/spec/<enclosing-section-slug>/#<slug>`.
2. Add a `renderer.heading` override (next to the existing `renderer.code`
   override) that emits `id="<slugify(text)>"` on every `###`+ heading,
   using the same `slugify()` the map uses.
3. No second override table for fragments — the fragment is the plain
   heading slug, same as `SLUG_OVERRIDES` already does for the page slug.
4. Add a regression check to `check-spec-coverage.ts` (already wired as
   `prebuild`, so no new CI plumbing) that fails the build on a dead
   `](#anchor)`, a slug collision between two `###`+ headings, or an
   anchor whose target page never got the matching `id=`.
5. Re-derive the link list against current `main` rather than trusting the
   issue's snapshot (see below) and confirm the same-section links the
   verdict called out separately.

## An additional bug found while implementing this

`spec/SPEC.md`'s `commands.bootstrap.capture` example (around line 561) opened
a ```` ```yaml ```` fence with no closing ```` ``` ````. `marked` has no
implicit fence-close at a heading boundary, so it swallowed the `###
Command Capture` heading, its field table, and its prose into one literal
`<pre><code>` block — that whole section never rendered as real HTML on
launchfile.org, independent of this issue. Without closing it, the
`#command-capture` anchor fix below would have nothing to attach an `id`
to. Fixed in a separate `spec:` commit since it's a content bug, not a
`www-org` build-logic bug.

## Re-derived link count

The issue counted 11 (corrected by the steward to 12) *dead links*. Against
current `main` there are 9 distinct `###`+ anchors actually referenced by
`[text](#anchor)` in `SPEC.md`, at 23 total occurrences (some same-section,
which were never routing-broken but still had no `id` to scroll to):
`bootstrap-stage`, `capability-vocabulary`, `command-capture`, `durations`,
`execution-modes-and-source-trust`, `host-capabilities`,
`migrating-off-the-host-block`, `source-mode-commands`, `value-provenance`.
All 9 now resolve; `check:spec`'s new checks pass for all of them (0 dead
anchors, 0 collisions, 0 missing ids).

## Verification

- **Tests**: `bun run typecheck` (`astro check`, Node v24.14.1, satisfies
  the >=22.12 requirement) — 0 errors/warnings/hints. `bun run check:spec`
  — passes: `27 schema fields, 28 sections, 19 sidebar entries, 29
  cross-reference anchors — all reachable`. `bun run build` (`astro build
  && pagefind`) — 34 pages built, prebuild gate passes.
- **Regression-check sanity (OBSERVED, not just written)**: temporarily
  added a `](#totally-made-up-anchor)` link to a scratch copy of
  `SPEC.md` → `check:spec` and `bun run build` both fail with the exact
  new error message, and `bun run build`'s `prebuild` hook aborts before
  `astro build` runs. Temporarily reverted the `renderer.heading` depth
  guard to `depth < 4` (so `<h3>` stops getting an `id`) → `check:spec`
  correctly reports every `###`-targeted anchor's page as missing its
  `id=`. Both reverted before committing; the committed diff is clean.
- **Live evidence in the built HTML** (`www-org/dist/client/`, `bun run
  build`), 3+ previously-dead cross-section links now resolving:
  - `/spec/quick-start/index.html` → `href="/spec/commands/#source-mode-commands"`;
    `/spec/commands/index.html` → `id="source-mode-commands"`.
  - `/spec/health/index.html` → `href="/spec/commands/#durations"` (×3,
    the three previously-dead `Health` → `Commands` links);
    `/spec/commands/index.html` → `id="durations"`.
  - `/spec/secrets/index.html` → `href="/spec/env/#value-provenance"`;
    `/spec/env/index.html` → `id="value-provenance"`.
  - `/spec/components/index.html` → `href="/spec/commands/#command-capture"`;
    `/spec/commands/index.html` → `<h3 id="command-capture">Command
    Capture</h3>` — this one only renders now because of the fence fix
    above.
  - Same-section links the verdict flagged separately also now scroll:
    `/spec/commands/` still links `#source-mode-commands` correctly within
    its own page (SPEC.md:446/449), and
    `/spec/security-considerations/` resolves its own
    `#execution-modes-and-source-trust` link (SPEC.md:1186).
- **Not separately tested**: the client-side anchor-icon and scroll-spy
  JS in `DocsLayout.astro` (`article h2[id], article h3[id]` selectors) —
  no browser/e2e harness exists for this site. Their precondition (real
  `id` attributes on `h3`/`h4` elements) is now verified present in the
  built HTML, which is the documented root cause of both being inert.

## Caveat for the reviewer

`www-shared/` and this repo's `spec/` sibling had no installed
dependencies in this worktree (`satteri` was missing, breaking `astro
check`) — ran `bun install` in both `www-shared/` and `www-org/` to build
and typecheck locally. That's local worktree setup, not a repo change; no
lockfile or package.json edits are in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
