### PR TITLE
Structured launch errors, part 2: macos-dev capture

### DIFF
--- a/.changeset/macos-launch-failure-capture.md
+++ b/.changeset/macos-launch-failure-capture.md
@@ -9,7 +9,7 @@ The macOS native provider now captures launch failures, so `launchfile diagnose`
 
 A failing native launch throws a `LaunchError` tagged with the D-48 slot it failed in — `prereq`, `resolve`, `parse`, `provision`, `prepare`, `release`, `run` — carrying the redacted command, exit code, output tails, and the component log tails from `.launchfile/logs/`. The CLI persists it and `launchfile diagnose` reads it back from another shell.
 
-**Two failures that previously printed a message and exited now throw instead**: a missing prerequisite and a missing `Launchfile`. Both still print the same message and still exit non-zero; they now also leave a record. Nothing else about them changes.
+**Two failures that previously printed a message and exited now throw instead**: a missing prerequisite and a missing `Launchfile`. Both still print their original message and still exit 1, and they now leave a record. Because they travel through the CLI's top-level handler, stderr gains two more lines: a `Captured. Run launchfile diagnose for the full context.` hint, and an `Error:` restatement of the message. For a missing prerequisite, that restatement collapses the itemized list into one semicolon-joined line.
 
 Records for a native launch are keyed by **project directory**, not by app name. The provider runs one instance per directory and refuses `--name`, so two checkouts of one app are two deployments and keep separate diagnoses. A successful `up` supersedes the record for that directory, and `down --destroy` removes it.
 

--- a/.changeset/macos-launch-failure-capture.md
+++ b/.changeset/macos-launch-failure-capture.md
@@ -1,0 +1,18 @@
+---
+"@launchfile/macos-dev": minor
+"@launchfile/sdk": minor
+"launchfile": minor
+"@launchfile/docker": patch
+---
+
+The macOS native provider now captures launch failures, so `launchfile diagnose` answers for `up --native` the way it already did for Docker (#44, part 2).
+
+A failing native launch throws a `LaunchError` tagged with the D-48 slot it failed in — `prereq`, `resolve`, `parse`, `provision`, `prepare`, `release`, `run` — carrying the redacted command, exit code, output tails, and the component log tails from `.launchfile/logs/`. The CLI persists it and `launchfile diagnose` reads it back from another shell.
+
+**Two failures that previously printed a message and exited now throw instead**: a missing prerequisite and a missing `Launchfile`. Both still print the same message and still exit non-zero; they now also leave a record. Nothing else about them changes.
+
+Records for a native launch are keyed by **project directory**, not by app name. The provider runs one instance per directory and refuses `--name`, so two checkouts of one app are two deployments and keep separate diagnoses. A successful `up` supersedes the record for that directory, and `down --destroy` removes it.
+
+Values a Launchfile declares `sensitive: true` (D-18) and values an operator supplies for a `required:` variable (D-52) are now registered with the native provider's redactor before any command runs. Without that, the first thing this capture would have done is write a plaintext credential to disk (CWE-532).
+
+`@launchfile/sdk` exports `sourceErrorKey`, the single derivation of a record key from a source string — the provider that writes a record and the CLI that later reads or clears it now share one implementation. `@launchfile/docker` keeps identical behaviour; its `dockerErrorKey` delegates to the shared helper.

--- a/packages/launchfile/src/__tests__/up-failure.test.ts
+++ b/packages/launchfile/src/__tests__/up-failure.test.ts
@@ -356,6 +356,40 @@ describe("the macOS branch's failure records", () => {
 		expect(await readLaunchErrorRecord(undefined, recordDir)).toBeNull();
 	});
 
+	it("prints the provider's own message, then the capture hint, and rethrows what the CLI prints", async () => {
+		// The prereq failure used to `process.exit(1)` inside the provider. Now it
+		// throws, so the same run also crosses `withFailureRecord` and the CLI's
+		// top-level handler — two lines the old path never printed. Pinned here so
+		// a change to the sequence fails a test rather than surprising a script.
+		const thrown = await handleUp(
+			projectDir,
+			{ native: true },
+			macosDeps(() => {
+				console.error("Missing prerequisites:");
+				console.error("  - Homebrew is not installed");
+				return Promise.reject(
+					macosError("prereq", "Missing prerequisites: Homebrew is not installed"),
+				);
+			}),
+		).then(
+			() => undefined,
+			(e: unknown) => e as Error,
+		);
+
+		expect(output).toEqual([
+			"Missing prerequisites:",
+			"  - Homebrew is not installed",
+			"\n  Captured. Run `launchfile diagnose` for the full context.",
+		]);
+		// cli.ts's `main().catch` prints `\nError: ${err.message}` and exits 1, so
+		// this message is the third thing a user sees — the itemized list restated
+		// on one line.
+		expect(thrown?.message).toBe("Missing prerequisites: Homebrew is not installed");
+
+		const record = await readLaunchErrorRecord(sourceErrorKey(projectDir), recordDir);
+		expect(record?.phase).toBe("prereq");
+	});
+
 	it("keys two checkouts of one app separately", async () => {
 		const other = await mkdtemp(join(tmpdir(), "lf-project-"));
 		await writeFile(join(other, "Launchfile"), "name: gov23\n");

--- a/packages/launchfile/src/__tests__/up-failure.test.ts
+++ b/packages/launchfile/src/__tests__/up-failure.test.ts
@@ -14,6 +14,7 @@ import {
 	buildLaunchErrorContext,
 	LaunchError,
 	type LaunchPhase,
+	sourceErrorKey,
 } from "@launchfile/sdk";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -295,5 +296,82 @@ describe("the macOS branch's try-split", () => {
 		const printed = output.join("\n");
 		expect(printed).not.toContain("macOS native provider not available.");
 		expect(printed).toContain("Captured.");
+	});
+});
+
+describe("the macOS branch's failure records", () => {
+	/** A macos-dev record: keyed by project directory, which is that provider's identity. */
+	function macosError(phase: LaunchPhase, message = "it broke"): LaunchError {
+		return new LaunchError(
+			buildLaunchErrorContext(
+				{
+					phase,
+					provider: "macos-dev",
+					key: sourceErrorKey(projectDir),
+					app: "gov23",
+					message,
+				},
+				IDENTITY,
+			),
+		);
+	}
+
+	function macosDeps(launchUp: () => Promise<void>) {
+		const fake = { launchUp } as unknown as typeof import("@launchfile/macos-dev");
+		return { importMacos: async () => fake, indexDir, recordDir };
+	}
+
+	it("captures a source-mode prepare failure under the project-directory key", async () => {
+		await expect(
+			handleUp(
+				projectDir,
+				{ native: true },
+				macosDeps(() => Promise.reject(macosError("prepare", "install failed"))),
+			),
+		).rejects.toThrow("install failed");
+
+		const record = await readLaunchErrorRecord(sourceErrorKey(projectDir), recordDir);
+		expect(record?.provider).toBe("macos-dev");
+		expect(record?.phase).toBe("prepare");
+		expect(record?.disposition).toBe("failed-invocation");
+
+		// A bare `diagnose` finds it through the pointer, as it does for docker.
+		expect((await readLaunchErrorRecord(undefined, recordDir))?.phase).toBe("prepare");
+	});
+
+	it("supersedes the record when a later launch of the same directory succeeds", async () => {
+		await expect(
+			handleUp(
+				projectDir,
+				{ native: true },
+				macosDeps(() => Promise.reject(macosError("run", "start failed"))),
+			),
+		).rejects.toThrow("start failed");
+		expect(await readLaunchErrorRecord(undefined, recordDir)).not.toBeNull();
+
+		await handleUp(projectDir, { native: true }, macosDeps(async () => undefined));
+
+		// Retention (#44 §H): the record described a launch that no longer exists.
+		expect(await readLaunchErrorRecord(sourceErrorKey(projectDir), recordDir)).toBeNull();
+		expect(await readLaunchErrorRecord(undefined, recordDir)).toBeNull();
+	});
+
+	it("keys two checkouts of one app separately", async () => {
+		const other = await mkdtemp(join(tmpdir(), "lf-project-"));
+		await writeFile(join(other, "Launchfile"), "name: gov23\n");
+
+		await expect(
+			handleUp(
+				projectDir,
+				{ native: true },
+				macosDeps(() => Promise.reject(macosError("run", "first checkout failed"))),
+			),
+		).rejects.toThrow();
+
+		// The second checkout succeeding must not clear the first's diagnosis.
+		await handleUp(other, { native: true }, macosDeps(async () => undefined));
+
+		const kept = await readLaunchErrorRecord(sourceErrorKey(projectDir), recordDir);
+		expect(kept?.message).toBe("first checkout failed");
 	});
 });

--- a/packages/launchfile/src/commands/bootstrap.ts
+++ b/packages/launchfile/src/commands/bootstrap.ts
@@ -17,7 +17,11 @@ import {
 	dockerLaunchError,
 	loadDockerSource,
 } from "@launchfile/docker";
-import { type NormalizedLaunch, readLaunch } from "@launchfile/sdk";
+import {
+	type NormalizedLaunch,
+	readLaunch,
+	sourceErrorKey,
+} from "@launchfile/sdk";
 import { resolveDeploymentTarget } from "../resolve-target.js";
 import { writeLaunchErrorRecord } from "../state/errors.js";
 import { dockerSlugFor, type DeploymentEntry } from "../state/index.js";
@@ -70,14 +74,36 @@ export async function handleBootstrap(
 
 	if (deployment.entry.provider === "macos") {
 		try {
-			const { launchBootstrap } = await import("@launchfile/macos-dev");
-			const results = await launchBootstrap({
-				projectDir: deployment.entry.source,
+			const macos = await import("@launchfile/macos-dev");
+			const projectDir = deployment.entry.source;
+			const results = await macos.launchBootstrap({
+				projectDir,
 				component: flags.component,
 			});
 			if (results.length === 0) process.exit(0);
-			const anyFailed = results.some((r) => !r.ok);
-			process.exit(anyFailed ? 1 : 0);
+			const failed = results.find((r) => !r.ok);
+			if (failed) {
+				// Redaction runs in this process, against the macos provider's live
+				// registry — hence the provider's own error builder rather than the
+				// docker one a few lines up (#44).
+				const content = await readFile(join(projectDir, "Launchfile"), "utf-8");
+				const launch = readLaunch(content);
+				const error = macos.macosLaunchError({
+					phase: "bootstrap",
+					key: sourceErrorKey(projectDir),
+					app: launch.name,
+					component: failed.component,
+					message: `bootstrap [${failed.component}] failed with exit code ${failed.exitCode}`,
+					command: failed.command,
+					exitCode: failed.exitCode,
+					stdout: failed.stdout,
+					stderr: failed.stderr,
+					env: macos.declaredEnvKeys(launch, failed.component),
+				});
+				await writeLaunchErrorRecord(error.context).catch(() => undefined);
+				console.error("  Captured. Run `launchfile diagnose` for the full context.");
+			}
+			process.exit(failed ? 1 : 0);
 		} catch (err) {
 			console.error(`Error: ${(err as Error).message}`);
 			process.exit(1);

--- a/packages/launchfile/src/commands/diagnose.ts
+++ b/packages/launchfile/src/commands/diagnose.ts
@@ -11,6 +11,7 @@ import {
 	type LaunchDisposition,
 	type LaunchErrorContext,
 	type LaunchPhase,
+	sourceErrorKey,
 } from "@launchfile/sdk";
 import { errorsDir, readLaunchErrorRecord } from "../state/errors.js";
 import { dockerSlugFor, findDeployment, loadIndex } from "../state/index.js";
@@ -114,9 +115,10 @@ function indent(text: string): string {
 
 /**
  * Resolve what the user typed to a record key. A record is filed under the
- * provider's key (a docker slug, or a hash of the source for a failure that
- * happened before a slug existed), so a deployment id or a user-assigned name
- * has to be translated first.
+ * provider's key, so a deployment id or a user-assigned name has to be
+ * translated first — and the two providers key differently: docker by slug (or
+ * by a hash of the source for a failure that happened before a slug existed),
+ * macos-dev by project directory, which is its unit of identity.
  */
 async function resolveKey(target: string, dir: string): Promise<string> {
 	const direct = await readLaunchErrorRecord(target, dir);
@@ -124,7 +126,10 @@ async function resolveKey(target: string, dir: string): Promise<string> {
 
 	const matches = findDeployment(await loadIndex(), target);
 	const entry = matches[0]?.entry;
-	return entry ? dockerSlugFor(entry) : target;
+	if (!entry) return target;
+	return entry.provider === "macos"
+		? sourceErrorKey(entry.source)
+		: dockerSlugFor(entry);
 }
 
 /**

--- a/packages/launchfile/src/commands/down.ts
+++ b/packages/launchfile/src/commands/down.ts
@@ -3,6 +3,7 @@
  */
 
 import { dockerDown } from "@launchfile/docker";
+import { sourceErrorKey } from "@launchfile/sdk";
 import { resolveDeploymentTarget } from "../resolve-target.js";
 import { clearLaunchErrorRecord } from "../state/errors.js";
 import { updateDeployment, removeDeployment, deploymentDir, dockerSlugFor } from "../state/index.js";
@@ -39,6 +40,11 @@ export async function handleDown(target: string | undefined, flags: DownFlags): 
 			await launchDown({ destroy: flags.destroy, projectDir: deployment.entry.source });
 			if (flags.destroy) {
 				await removeDeployment(deployment.id);
+				// Same retention rule as the docker branch (#44 §H): the failure
+				// record holds redacted-but-still-sensitive log tails, so it goes
+				// with the rest of the app's state. macos-dev keys records by
+				// project directory, which is what the index stores as `source`.
+				await clearLaunchErrorRecord(sourceErrorKey(deployment.entry.source));
 			} else {
 				await updateDeployment(deployment.id, { status: "down" });
 			}

--- a/packages/launchfile/src/commands/up.ts
+++ b/packages/launchfile/src/commands/up.ts
@@ -15,6 +15,7 @@ import {
 	isLaunchError,
 	type LaunchPhase,
 	MissingOperatorStoragePathError,
+	sourceErrorKey,
 	UnboundOperatorStorageError,
 } from "@launchfile/sdk";
 import { detectProvider } from "../detect-provider.js";
@@ -263,7 +264,14 @@ export async function handleUp(
 			throw err;
 		}
 
+		// Retention (#44 §H), same rule as the docker branch: the previous record
+		// for this project directory describes a launch that no longer exists.
+		// `@launchfile/macos-dev` keys its records by project directory — one
+		// instance per directory is the provider's identity model — and derives
+		// that key from the same SDK helper, so the two cannot drift.
 		if (!flags.dryRun) {
+			await clearLaunchErrorRecord(sourceErrorKey(projectDir), recordDir);
+
 			await record({
 				appName: inferAppName(upTarget.value),
 				provider: "macos",

--- a/packages/launchfile/src/macos-dev.d.ts
+++ b/packages/launchfile/src/macos-dev.d.ts
@@ -50,4 +50,30 @@ declare module "@launchfile/macos-dev" {
 		component?: string;
 		projectDir?: string;
 	}): Promise<BootstrapResult[]>;
+
+	/**
+	 * Build a redacted `LaunchError` against this provider's live secret
+	 * registry (#44). The CLI calls it for a failure the provider reports
+	 * instead of throwing — a bootstrap failure, which D-48 keeps out of deploy
+	 * status — so the scrub still happens in the process that ran the command.
+	 */
+	export function macosLaunchError(input: {
+		phase: import("@launchfile/sdk").LaunchPhase;
+		key: string;
+		message: string;
+		app?: string;
+		slug?: string;
+		component?: string;
+		command?: string;
+		exitCode?: number;
+		stdout?: string;
+		stderr?: string;
+		env?: Readonly<Record<string, unknown>>;
+	}): import("@launchfile/sdk").LaunchError;
+
+	/** Declared env var **names** — never a value (see `EnvKeyList`). */
+	export function declaredEnvKeys(
+		launch: import("@launchfile/sdk").NormalizedLaunch,
+		component?: string,
+	): Record<string, 0>;
 }

--- a/providers/docker/src/errors.ts
+++ b/providers/docker/src/errors.ts
@@ -13,7 +13,6 @@
  * unredactable from then on (D-18, CWE-532).
  */
 
-import { createHash } from "node:crypto";
 import {
 	buildLaunchErrorContext,
 	isLaunchError,
@@ -21,6 +20,7 @@ import {
 	type LaunchErrorInput,
 	type LaunchPhase,
 	type NormalizedLaunch,
+	sourceErrorKey,
 } from "@launchfile/sdk";
 import { isExpectedRefusal } from "./logger.js";
 import { redactSecrets } from "./redact.js";
@@ -41,8 +41,7 @@ const LOG_TAIL = 200;
  */
 export function dockerErrorKey(opts: { slug?: string; source?: string }): string {
 	if (opts.slug) return opts.slug;
-	const source = opts.source ?? "";
-	return `src-${createHash("sha256").update(source).digest("hex").slice(0, 16)}`;
+	return sourceErrorKey(opts.source ?? "");
 }
 
 /** Build a docker `LaunchError`, redacting every captured string on the way in. */

--- a/providers/macos-dev/src/__tests__/errors.test.ts
+++ b/providers/macos-dev/src/__tests__/errors.test.ts
@@ -1,0 +1,269 @@
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	isLaunchError,
+	readLaunch,
+	resolveSourcePrepareCommand,
+	resolveSourceRunCommand,
+	sourceErrorKey,
+	UnboundOperatorStorageError,
+} from "@launchfile/sdk";
+import { beforeEach, describe, expect, it } from "vitest";
+import { registerSensitiveEnv, registerSuppliedEnv } from "../env-secrets.js";
+import {
+	captureProcessLogs,
+	declaredEnvKeys,
+	inPhase,
+	macosErrorKey,
+	macosLaunchError,
+} from "../errors.js";
+import { clearRegisteredSecrets, REDACTED, registerSecret } from "../redact.js";
+import { shellScript } from "../shell.js";
+
+beforeEach(() => {
+	clearRegisteredSecrets();
+});
+
+describe("macosErrorKey", () => {
+	it("keys a record by project directory, not by app name", () => {
+		// Two checkouts of the same app are two deployments for this provider —
+		// it keeps state per directory and refuses --name. Sharing one record
+		// would lose the loser's diagnosis (PROVIDERS.md §9).
+		const a = macosErrorKey("/Users/dev/work/blog");
+		const b = macosErrorKey("/Users/dev/review/blog");
+		expect(a).not.toBe(b);
+		expect(a).toMatch(/^src-[0-9a-f]{16}$/);
+	});
+
+	it("is the SDK derivation, so the CLI resolves the same key", () => {
+		expect(macosErrorKey("/tmp/proj")).toBe(sourceErrorKey("/tmp/proj"));
+	});
+});
+
+describe("redaction at capture", () => {
+	it("scrubs a registered secret out of a captured tail", () => {
+		registerSecret("sup3r-secret-password");
+		const err = macosLaunchError({
+			phase: "release",
+			key: "demo",
+			message: "release [web] failed with exit code 1",
+			stderr: "FATAL: password authentication failed for sup3r-secret-password",
+			stdout: "connecting as sup3r-secret-password",
+		});
+
+		expect(JSON.stringify(err.context)).not.toContain("sup3r-secret-password");
+		expect(err.context.stderr).toContain(REDACTED);
+	});
+
+	it("scrubs credentials embedded in a captured command URL", () => {
+		const err = macosLaunchError({
+			phase: "release",
+			key: "demo",
+			message: "Command failed",
+			command: "psql postgres://u:hunter2xyz@db:5432/app -c 'select 1'",
+		});
+
+		expect(err.context.command).not.toContain("hunter2xyz");
+		expect(err.context.command).toBe(
+			`psql postgres://u:${REDACTED}@db:5432/app -c 'select 1'`,
+		);
+	});
+
+	it("registers a `sensitive: true` value, including a short one", () => {
+		// D-18 says the author declared it sensitive; the registry's inference
+		// floor must not overrule that, or the PIN lands in the record verbatim.
+		const launch = readLaunch(`
+name: pin-app
+components:
+  default:
+    runtime: node
+    commands:
+      dev: node server.js
+    env:
+      DEVICE_PIN:
+        default: "824193"
+        sensitive: true
+`);
+		const component = launch.components.default!;
+		registerSensitiveEnv(component.env, { DEVICE_PIN: "824193" });
+
+		const err = macosLaunchError({
+			phase: "run",
+			key: "pin-app",
+			message: "start failed",
+			stderr: "auth failed: rejected pin 824193",
+		});
+		expect(err.context.stderr).toBe("auth failed: rejected pin [REDACTED]");
+	});
+
+	it("registers an operator-supplied value (D-52) before anything can echo it", () => {
+		registerSuppliedEnv({ API_TOKEN: "op-supplied-1234" });
+		const err = macosLaunchError({
+			phase: "release",
+			key: "demo",
+			message: "migrate failed: token op-supplied-1234 rejected",
+		});
+		expect(err.context.message).not.toContain("op-supplied-1234");
+	});
+
+	it("keeps env var names and no env values (the sentinel)", () => {
+		const launch = readLaunch(`
+name: sentinel
+components:
+  default:
+    runtime: node
+    commands:
+      dev: node server.js
+    env:
+      API_KEY:
+        default: sentinel-value-never-on-disk
+        sensitive: true
+    requires:
+      - type: postgres
+        set_env:
+          DATABASE_URL: $resource.url
+`);
+		const err = macosLaunchError({
+			phase: "run",
+			key: "sentinel",
+			message: "start failed",
+			env: declaredEnvKeys(launch),
+		});
+
+		expect(err.context.envKeys).toEqual(["API_KEY", "DATABASE_URL"]);
+		expect(JSON.stringify(err.context)).not.toContain(
+			"sentinel-value-never-on-disk",
+		);
+	});
+});
+
+describe("inPhase", () => {
+	it("tags an untagged failure with its phase and the D-48 disposition", async () => {
+		const err = await inPhase("release", { key: "demo" }, async () => {
+			throw new Error("boom");
+		}).catch((e: unknown) => e);
+
+		expect(isLaunchError(err)).toBe(true);
+		if (!isLaunchError(err)) throw new Error("unreachable");
+		expect(err.context.phase).toBe("release");
+		expect(err.context.disposition).toBe("failed-deploy");
+		expect(err.context.provider).toBe("macos-dev");
+	});
+
+	it("lets the innermost phase win", async () => {
+		const err = await inPhase("unknown", { key: "demo" }, () =>
+			inPhase("prepare", { key: "demo" }, async () => {
+				throw new Error("install failed");
+			}),
+		).catch((e: unknown) => e);
+
+		expect(isLaunchError(err) && err.context.phase).toBe("prepare");
+	});
+
+	it("passes an expected refusal through unwrapped", async () => {
+		// The CLI matches the D-50 refusals by `instanceof` to print their own
+		// message; wrapping one would break that match and file an
+		// operator-fixable precondition as a launch failure.
+		const refusal = new UnboundOperatorStorageError([
+			{ component: "web", volume: "library", flag: "--storage library=<path>" },
+		]);
+		const err = await inPhase("provision", { key: "demo" }, async () => {
+			throw refusal;
+		}).catch((e: unknown) => e);
+
+		expect(err).toBe(refusal);
+		expect(isLaunchError(err)).toBe(false);
+	});
+});
+
+describe("source-mode capture (D-38 slots)", () => {
+	const launch = readLaunch(`
+name: srcapp
+components:
+  default:
+    runtime: node
+    source: .
+    commands:
+      install: exit 3
+      build: echo artifact-build
+      dev: exit 4
+      start: echo artifact-start
+`);
+
+	it("captures a failing source prepare as the prepare slot", async () => {
+		const component = launch.components.default!;
+		const prepare = resolveSourcePrepareCommand(component);
+		expect(prepare?.command).toBe("exit 3"); // install ?? build
+
+		const err = await inPhase(
+			"prepare",
+			{ key: "srcapp", app: launch.name, component: "default" },
+			() => shellScript(prepare!.command, { silent: true }),
+		).catch((e: unknown) => e);
+
+		expect(isLaunchError(err)).toBe(true);
+		if (!isLaunchError(err)) throw new Error("unreachable");
+		expect(err.context.phase).toBe("prepare");
+		expect(err.context.disposition).toBe("failed-invocation");
+		expect(err.context.exitCode).toBe(3);
+		expect(err.context.command).toBe("exit 3");
+	});
+
+	it("captures a failing source run as the run slot", async () => {
+		const component = launch.components.default!;
+		const run = resolveSourceRunCommand(component);
+		expect(run?.command).toBe("exit 4"); // dev ?? start
+
+		const err = await inPhase(
+			"run",
+			{ key: "srcapp", app: launch.name, component: "default" },
+			() => shellScript(run!.command, { silent: true }),
+		).catch((e: unknown) => e);
+
+		expect(isLaunchError(err) && err.context.phase).toBe("run");
+		expect(isLaunchError(err) && err.context.exitCode).toBe(4);
+	});
+
+	it("captures the redacted command, never the raw one", async () => {
+		registerSecret("dev-db-password-xyz");
+		const err = await inPhase("release", { key: "srcapp" }, () =>
+			shellScript("echo dev-db-password-xyz && exit 1", { silent: true }),
+		).catch((e: unknown) => e);
+
+		expect(isLaunchError(err)).toBe(true);
+		if (!isLaunchError(err)) throw new Error("unreachable");
+		expect(err.context.command).not.toContain("dev-db-password-xyz");
+		expect(JSON.stringify(err.context)).not.toContain("dev-db-password-xyz");
+	});
+});
+
+describe("captureProcessLogs", () => {
+	it("attaches the component's own output to a run failure", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "lf-macos-logs-"));
+		await mkdir(join(dir, ".launchfile", "logs"), { recursive: true });
+		await writeFile(
+			join(dir, ".launchfile", "logs", "web.log"),
+			"listening on 3000\nEADDRINUSE\n",
+		);
+
+		const err = await inPhase(
+			"run",
+			{ key: "demo", logs: () => captureProcessLogs(dir, ["web", "worker"]) },
+			async () => {
+				throw new Error("start failed");
+			},
+		).catch((e: unknown) => e);
+
+		expect(isLaunchError(err)).toBe(true);
+		if (!isLaunchError(err)) throw new Error("unreachable");
+		// A component with no log file is skipped rather than recorded empty.
+		expect(Object.keys(err.context.serviceLogs ?? {})).toEqual(["web"]);
+		expect(err.context.serviceLogs?.web).toContain("EADDRINUSE");
+	});
+
+	it("returns nothing when no component has a log", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "lf-macos-nologs-"));
+		expect(await captureProcessLogs(dir, ["web"])).toBeUndefined();
+	});
+});

--- a/providers/macos-dev/src/__tests__/launch-throw-sites.test.ts
+++ b/providers/macos-dev/src/__tests__/launch-throw-sites.test.ts
@@ -1,0 +1,139 @@
+/**
+ * The two `launchUp` failures that throw instead of exiting: a missing
+ * prerequisite (`prereq`) and a missing `Launchfile` (`resolve`).
+ *
+ * They are the earliest two failure points, so they are also the two most
+ * likely to be a user's first experience of the tool, and the only two whose
+ * control flow this feature changed. A record only exists for them because
+ * they throw, so the phase and the key on the thrown error are the contract —
+ * `launchfile diagnose` finds nothing if either is wrong.
+ *
+ * The mock set mirrors operator-storage.test.ts: real subprocess exec and a
+ * real pm2 registration have no place in a unit test. `checkPrereqs` is the
+ * exception — it is the subject here, so it is driven from `mocks.prereq`
+ * rather than pinned to a passing result.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { isLaunchError, sourceErrorKey } from "@launchfile/sdk";
+
+const mocks = vi.hoisted(() => ({
+	prereq: { ok: true, missing: [] as string[] },
+}));
+
+vi.mock("../prereqs.js", () => ({
+	checkPrereqs: async () => mocks.prereq,
+}));
+
+vi.mock("../runtimes/index.js", () => ({
+	getRuntimeInstaller: () => undefined,
+}));
+
+vi.mock("../shell.js", () => ({
+	shell: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+	shellOk: async () => true,
+	shellScript: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+}));
+
+vi.mock("../process-manager.js", () => ({
+	ProcessManager: class {
+		register() {}
+		async startAll() {}
+		async stopAll() {}
+		getRecordedProcesses() {
+			return {};
+		}
+	},
+}));
+
+const { launchUp } = await import("../provider.js");
+
+const VALID = `
+name: app
+runtime: node
+commands:
+  start: "node server.js"
+`;
+
+describe("launchUp — the two failures that throw rather than exit", () => {
+	let projectDir: string;
+	let consoleErrors: string[];
+	let exitCode: number | undefined;
+
+	beforeEach(() => {
+		mocks.prereq = { ok: true, missing: [] };
+		consoleErrors = [];
+		exitCode = undefined;
+		projectDir = mkdtempSync(join(tmpdir(), "lf-macos-throw-"));
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+		vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+			consoleErrors.push(args.map(String).join(" "));
+		});
+		vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+			exitCode = code;
+			throw new Error(`__exit__${code}`);
+		}) as never);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		rmSync(projectDir, { recursive: true, force: true });
+	});
+
+	it("tags a missing prerequisite `prereq`, keyed by project directory", async () => {
+		mocks.prereq = { ok: false, missing: ["Homebrew is not installed"] };
+		writeFileSync(join(projectDir, "Launchfile"), VALID);
+
+		const err = await launchUp({ projectDir }).catch((e: unknown) => e);
+
+		expect(isLaunchError(err)).toBe(true);
+		if (!isLaunchError(err)) return;
+		expect(err.context.phase).toBe("prereq");
+		expect(err.context.key).toBe(sourceErrorKey(projectDir));
+		expect(err.message).toBe("Missing prerequisites: Homebrew is not installed");
+	});
+
+	it("still prints the itemized prerequisite list, and does not exit", async () => {
+		// The throw replaced a `process.exit(1)`. The itemized list is the
+		// actionable half of the diagnosis and has to survive that swap; the CLI's
+		// top-level handler supplies the non-zero exit.
+		mocks.prereq = { ok: false, missing: ["Homebrew is not installed", "git is not installed"] };
+		writeFileSync(join(projectDir, "Launchfile"), VALID);
+
+		await expect(launchUp({ projectDir })).rejects.toThrow("Missing prerequisites");
+
+		expect(consoleErrors).toContain("Missing prerequisites:");
+		expect(consoleErrors).toContain("  - Homebrew is not installed");
+		expect(consoleErrors).toContain("  - git is not installed");
+		expect(exitCode).toBeUndefined();
+	});
+
+	it("tags a missing Launchfile `resolve`, keyed by project directory", async () => {
+		const err = await launchUp({ projectDir }).catch((e: unknown) => e);
+
+		expect(isLaunchError(err)).toBe(true);
+		if (!isLaunchError(err)) return;
+		expect(err.context.phase).toBe("resolve");
+		expect(err.context.key).toBe(sourceErrorKey(projectDir));
+		expect(err.message).toBe(`No Launchfile found at ${join(projectDir, "Launchfile")}`);
+		expect(consoleErrors).toContain(`No Launchfile found at ${join(projectDir, "Launchfile")}`);
+		expect(exitCode).toBeUndefined();
+	});
+
+	it("checks prerequisites before it looks for a Launchfile", async () => {
+		// Order matters for the phase: an empty directory on a machine with no
+		// Homebrew must record `prereq`, not `resolve`.
+		mocks.prereq = { ok: false, missing: ["Homebrew is not installed"] };
+
+		const err = await launchUp({ projectDir }).catch((e: unknown) => e);
+
+		expect(isLaunchError(err)).toBe(true);
+		if (!isLaunchError(err)) return;
+		expect(err.context.phase).toBe("prereq");
+	});
+});

--- a/providers/macos-dev/src/env-secrets.ts
+++ b/providers/macos-dev/src/env-secrets.ts
@@ -1,0 +1,56 @@
+/**
+ * Registers the credential-bearing env values this provider does not generate —
+ * the mirror of `providers/docker/src/env-secrets.ts`.
+ *
+ * The secret registry (`redact.ts`) covers only provider-*minted* values and
+ * persisted state, which leaves two classes of real credential unscrubbable:
+ *
+ * 1. A literal `env:` value the author marked `sensitive: true` (D-18). An
+ *    author-declared API key is exactly the value a failing `release` command
+ *    echoes back in the error that killed the launch.
+ * 2. An operator-supplied value for a `required:` declaration (D-52). Same
+ *    reasoning, opposite origin: the platform never saw it before the operator
+ *    handed it over, so nothing else can have registered it.
+ *
+ * Both must be registered *before* any output is captured, or the capture writes
+ * plaintext credentials to disk (CWE-532, CWE-312). Until this provider captured
+ * anything the gap was survivable; a record written to `~/.launchfile/errors/`
+ * by default is exactly the sink D-18 forbids a declared-sensitive value from
+ * reaching.
+ *
+ * Both register through `registerDeclaredSecret`, which has no length floor.
+ * These values are sensitive because something said so, not because this
+ * provider guessed — and `registerSecret`'s floor would silently drop a short
+ * one (a PIN, a numeric code) straight into a record.
+ */
+
+import type { NormalizedEnvVar } from "@launchfile/sdk";
+import { registerDeclaredSecret } from "./redact.js";
+
+/**
+ * Register the resolved values of every `sensitive: true` declaration in one
+ * component's env. `resolved` is the post-resolution map this provider is about
+ * to write into a `.env` file and hand to the app's commands.
+ */
+export function registerSensitiveEnv(
+	declared: Readonly<Record<string, NormalizedEnvVar>> | undefined,
+	resolved: Readonly<Record<string, string>>,
+): void {
+	if (!declared) return;
+	for (const [key, definition] of Object.entries(declared)) {
+		if (!definition?.sensitive) continue;
+		registerDeclaredSecret(resolved[key]);
+	}
+}
+
+/**
+ * Register every value an operator supplied for this component (D-52). The
+ * operator channel is a value the platform cannot classify, so all of it is
+ * treated as credential material.
+ */
+export function registerSuppliedEnv(
+	supplied: Readonly<Record<string, string>> | undefined,
+): void {
+	if (!supplied) return;
+	for (const value of Object.values(supplied)) registerDeclaredSecret(value);
+}

--- a/providers/macos-dev/src/errors.ts
+++ b/providers/macos-dev/src/errors.ts
@@ -1,0 +1,206 @@
+/**
+ * Launch-failure capture for the macOS dev provider — the mirror of
+ * `providers/docker/src/errors.ts`.
+ *
+ * The SDK owns the shape (`LaunchErrorContext`) and the D-48 disposition table;
+ * this module owns the macos-dev half: which redactor runs, how a storage key is
+ * derived, which log tails are worth keeping, and the wrapper that tags a throw
+ * with the phase it happened in. One shared context shape rather than a private
+ * per-provider one is P-5: the same Launchfile failing under either provider
+ * produces the same record, so `launchfile diagnose` reads one format.
+ *
+ * Everything captured here is scrubbed **in this process**, at the moment of
+ * capture. `redactSecrets` matches against a process-global in-memory registry
+ * populated during the run; a reader started later has an empty registry and can
+ * scrub nothing, so text that leaves this module unredacted is unredactable from
+ * then on (D-18, CWE-532).
+ *
+ * The one deliberate difference from the docker module is the key. A docker
+ * deployment is identified by its slug; a macos-dev deployment is identified by
+ * its **project directory** — the provider keeps state in
+ * `<projectDir>/.launchfile/state.json` and refuses `--name` because it runs one
+ * instance per directory. Keying a record by app name would make two checkouts
+ * of the same app share one record and lose the loser's diagnosis, which is the
+ * concurrency case PROVIDERS.md §9 calls out.
+ */
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+	buildLaunchErrorContext,
+	isLaunchError,
+	LaunchError,
+	type LaunchErrorInput,
+	type LaunchPhase,
+	type NormalizedLaunch,
+	sourceErrorKey,
+} from "@launchfile/sdk";
+import { redactSecrets } from "./redact.js";
+
+export const MACOS_PROVIDER = "macos-dev";
+
+/** How many trailing log lines to read back per component. The SDK trims again. */
+const LOG_TAIL = 200;
+
+/**
+ * The storage key a failure record is filed under: the project directory, which
+ * is this provider's unit of identity. Derived through the SDK helper so the
+ * provider that writes the record and the CLI that later clears or reads it
+ * cannot drift apart.
+ */
+export function macosErrorKey(projectDir: string): string {
+	return sourceErrorKey(projectDir);
+}
+
+/** Build a macos-dev `LaunchError`, redacting every captured string on the way in. */
+export function macosLaunchError(
+	input: Omit<LaunchErrorInput, "provider">,
+): LaunchError {
+	return new LaunchError(
+		buildLaunchErrorContext({ ...input, provider: MACOS_PROVIDER }, redactSecrets),
+	);
+}
+
+/**
+ * The env var **names** a component declares — its own `env:` keys plus the keys
+ * every `requires[].set_env` wiring writes. Read from the Launchfile, not from a
+ * resolved env map, so no resolved value is ever in scope at the call site.
+ * Omitting `component` unions every component's declarations.
+ */
+export function declaredEnvKeys(
+	launch: NormalizedLaunch,
+	component?: string,
+): Record<string, 0> {
+	const keys: Record<string, 0> = {};
+	for (const [name, comp] of Object.entries(launch.components)) {
+		if (component && name !== component) continue;
+		for (const key of Object.keys(comp.env ?? {})) keys[key] = 0;
+		for (const req of comp.requires ?? []) {
+			for (const key of Object.keys(req.set_env ?? {})) keys[key] = 0;
+		}
+	}
+	return keys;
+}
+
+/**
+ * Tail the per-component log files `ProcessManager` writes, so a `run` failure
+ * carries the app's own output and not just a spawn error.
+ *
+ * This is the macos-dev counterpart of docker's `compose logs`: the processes
+ * are on this host and their output is already on disk at
+ * `<projectDir>/.launchfile/logs/<component>.log`. A component whose log is
+ * missing or unreadable is skipped — a missing tail is a worse diagnosis, not a
+ * worse failure.
+ */
+export async function captureProcessLogs(
+	projectDir: string,
+	components: readonly string[],
+): Promise<Record<string, string> | undefined> {
+	const logs: Record<string, string> = {};
+	for (const name of components) {
+		try {
+			const text = await readFile(
+				join(projectDir, ".launchfile", "logs", `${name}.log`),
+				"utf8",
+			);
+			const tail = text.split("\n").slice(-LOG_TAIL).join("\n").trim();
+			if (tail) logs[name] = tail;
+		} catch {
+			// No log file for this component — it may never have spawned.
+		}
+	}
+	return Object.keys(logs).length > 0 ? logs : undefined;
+}
+
+/** What a phase wrapper knows about the launch it is wrapping. */
+export interface PhaseContext {
+	key: string;
+	app?: string;
+	slug?: string;
+	component?: string;
+	/** An env map whose keys are captured. Values never leave this call. */
+	env?: Readonly<Record<string, unknown>>;
+	warnings?: readonly string[];
+	/** Called only on failure, to attach log tails. */
+	logs?: () => Promise<Record<string, string> | undefined>;
+}
+
+/**
+ * Run `fn`, and on failure re-throw it as a `LaunchError` tagged with `phase`.
+ *
+ * The phase is attached at the throw site, where it is known — a top-level catch
+ * would have to guess it from the message. A `LaunchError` thrown by an inner
+ * wrapper passes through untouched, so the innermost (most specific) phase wins.
+ *
+ * A deliberate refusal passes through unwrapped. The D-50 storage refusals carry
+ * the SDK's `expectedRefusal` marker, the CLI matches them by `instanceof` to
+ * print their own actionable message, and wrapping one would both break that
+ * match and file an operator-fixable precondition as a launch failure.
+ */
+export async function inPhase<T>(
+	phase: LaunchPhase,
+	context: PhaseContext,
+	fn: () => Promise<T>,
+): Promise<T> {
+	try {
+		return await fn();
+	} catch (err) {
+		if (isLaunchError(err)) throw err;
+		if (isExpectedRefusal(err)) throw err;
+		throw await launchErrorFrom(phase, context, err);
+	}
+}
+
+/**
+ * Whether a thrown value marks itself an expected refusal — an operator-fixable
+ * precondition the CLI has an actionable message for, not a crash. Mirrors the
+ * docker provider's check, which lives in its logger module; this provider has
+ * no logger to put it in.
+ */
+export function isExpectedRefusal(error: unknown): boolean {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		(error as { expectedRefusal?: unknown }).expectedRefusal === true
+	);
+}
+
+/**
+ * Convert an arbitrary thrown value into a `LaunchError` for `phase`.
+ *
+ * `shell()` and `shellScript()` attach the command result and the
+ * already-redacted display string to the errors they reject with; both are
+ * lifted here so the record carries the exit code and output tails without
+ * re-running anything. The command captured is the redacted form the provider
+ * echoed — never the pre-scrub string (D-18).
+ */
+export async function launchErrorFrom(
+	phase: LaunchPhase,
+	context: PhaseContext,
+	err: unknown,
+): Promise<LaunchError> {
+	const error = err instanceof Error ? err : new Error(String(err));
+	const carrier = error as {
+		result?: { exitCode: number; stdout: string; stderr: string };
+		display?: string;
+	};
+	const logs = context.logs
+		? await context.logs().catch(() => undefined)
+		: undefined;
+
+	return macosLaunchError({
+		phase,
+		key: context.key,
+		app: context.app,
+		slug: context.slug,
+		component: context.component,
+		message: error.message,
+		command: carrier.display,
+		exitCode: carrier.result?.exitCode,
+		stdout: carrier.result?.stdout,
+		stderr: carrier.result?.stderr,
+		serviceLogs: logs,
+		env: context.env,
+		warnings: context.warnings,
+	});
+}

--- a/providers/macos-dev/src/index.ts
+++ b/providers/macos-dev/src/index.ts
@@ -9,3 +9,16 @@ export { launchUp, launchDown, launchStatus, launchEnv } from "./provider.js";
 export type { LaunchUpOpts } from "./provider.js";
 export { launchBootstrap } from "./bootstrap.js";
 export type { BootstrapResult } from "./bootstrap.js";
+export {
+	captureProcessLogs,
+	declaredEnvKeys,
+	inPhase,
+	isExpectedRefusal,
+	launchErrorFrom,
+	MACOS_PROVIDER,
+	macosErrorKey,
+	macosLaunchError,
+	type PhaseContext,
+} from "./errors.js";
+export { registerSensitiveEnv, registerSuppliedEnv } from "./env-secrets.js";
+export { registerDeclaredSecret, redactSecrets } from "./redact.js";

--- a/providers/macos-dev/src/provider.ts
+++ b/providers/macos-dev/src/provider.ts
@@ -43,6 +43,15 @@ import { ProcessManager } from "./process-manager.js";
 import { stopRecordedProcesses } from "./process-stopper.js";
 import { shellScript } from "./shell.js";
 import { parseDuration } from "./bootstrap.js";
+import {
+	captureProcessLogs,
+	declaredEnvKeys,
+	inPhase,
+	macosErrorKey,
+	macosLaunchError,
+	type PhaseContext,
+} from "./errors.js";
+import { registerSensitiveEnv, registerSuppliedEnv } from "./env-secrets.js";
 
 /**
  * This provider runs apps from source. A component is source-runnable when
@@ -178,13 +187,37 @@ export function applyHostCapabilityRefusals(
 
 export async function launchUp(opts: LaunchUpOpts = {}): Promise<void> {
 	const projectDir = opts.projectDir ?? process.cwd();
+	// Anything that escapes without a phase still gets a record, tagged
+	// `unknown` rather than guessed at — an untagged failure would leave
+	// `diagnose` with nothing to show for a run that visibly failed.
+	return inPhase("unknown", { key: macosErrorKey(projectDir) }, () =>
+		runLaunchUp(projectDir, opts),
+	);
+}
+
+async function runLaunchUp(projectDir: string, opts: LaunchUpOpts): Promise<void> {
+	// Every throw below is tagged with the phase it happened in, at the throw
+	// site where the phase is known, and carries an already-redacted context the
+	// CLI persists for `launchfile diagnose` (#44). Phases are the D-48 slot
+	// names plus the pre-slot failure points, never command names — so a source
+	// prepare that resolves `install ?? build` and an artifact build both record
+	// `prepare` (D-38).
+	//
+	// The key is the project directory: this provider runs one instance per
+	// directory, so two checkouts of one app are two deployments and must not
+	// share a record.
+	const key = macosErrorKey(projectDir);
 
 	// 1. Check prerequisites
 	const prereqs = await checkPrereqs();
 	if (!prereqs.ok) {
 		console.error("Missing prerequisites:");
 		for (const m of prereqs.missing) console.error(`  - ${m}`);
-		process.exit(1);
+		throw macosLaunchError({
+			phase: "prereq",
+			key,
+			message: `Missing prerequisites: ${prereqs.missing.join("; ")}`,
+		});
 	}
 
 	// 2. Read and parse Launchfile
@@ -194,10 +227,26 @@ export async function launchUp(opts: LaunchUpOpts = {}): Promise<void> {
 		launchfileContent = await readFile(launchfilePath, "utf8");
 	} catch {
 		console.error(`No Launchfile found at ${launchfilePath}`);
-		process.exit(1);
+		throw macosLaunchError({
+			phase: "resolve",
+			key,
+			message: `No Launchfile found at ${launchfilePath}`,
+		});
 	}
 
-	const launch = readLaunch(launchfileContent);
+	const launch = await inPhase("parse", { key }, async () =>
+		readLaunch(launchfileContent),
+	);
+
+	// Identity + declared env names, shared by every phase context below.
+	// `declaredEnvKeys` reads names from the Launchfile — no resolved value is
+	// ever in scope here, so none can reach a record.
+	const failure = (extra: Partial<PhaseContext> = {}): PhaseContext => ({
+		key,
+		app: launch.name,
+		env: declaredEnvKeys(launch),
+		...extra,
+	});
 	const allComponentNames = Object.keys(launch.components);
 
 	// Resolve component selector (#77) into its D-41 start-set: selected
@@ -319,6 +368,11 @@ export async function launchUp(opts: LaunchUpOpts = {}): Promise<void> {
 			missingRequired.push({ component: name, key, sensitive });
 		}
 	}
+	// D-52 values arrive from outside the platform, so nothing else can have
+	// registered them. Registered here, the moment they are read, and before any
+	// command runs that could echo one into a captured tail (CWE-532).
+	for (const supplied of Object.values(operatorEnv)) registerSuppliedEnv(supplied);
+
 	if (missingRequired.length > 0) {
 		console.error(
 			`\nCannot launch: ${missingRequired.length} required environment variable${missingRequired.length === 1 ? "" : "s"} had no value.`,
@@ -413,7 +467,7 @@ export async function launchUp(opts: LaunchUpOpts = {}): Promise<void> {
 	// 6. Provision required resources
 	const resourceMap: Record<string, ResourceProperties> = {};
 
-	for (const [_compName, component] of Object.entries(launch.components)) {
+	for (const [compName, component] of Object.entries(launch.components)) {
 		for (const req of component.requires ?? []) {
 			if (req.host) continue; // capability, not a backing service (D-44)
 			const resourceName = req.name ?? req.type;
@@ -433,7 +487,9 @@ export async function launchUp(opts: LaunchUpOpts = {}): Promise<void> {
 
 			process.stdout.write(`  \u2193 Provisioning ${req.type}...`);
 			const existing = state.resources[resourceName];
-			const result = await provisioner.provision(req, { appName: launch.name, projectDir }, existing);
+			const result = await inPhase("provision", failure({ component: compName }), () =>
+				provisioner.provision(req, { appName: launch.name, projectDir }, existing),
+			);
 			resourceMap[resourceName] = result.properties;
 			state.resources[resourceName] = result.state;
 			console.log(" done");
@@ -470,7 +526,9 @@ export async function launchUp(opts: LaunchUpOpts = {}): Promise<void> {
 	}
 
 	// 7. Allocate ports
-	const componentPorts = await allocatePorts(launch.components, launch.name, state.ports);
+	const componentPorts = await inPhase("provision", failure(), () =>
+		allocatePorts(launch.components, launch.name, state.ports),
+	);
 	state.ports = componentPorts;
 
 	// 8. Build resolver context (including $app.* properties from D-33)
@@ -497,13 +555,15 @@ export async function launchUp(opts: LaunchUpOpts = {}): Promise<void> {
 			continue;
 		}
 
-		const version = await installer.detectVersion(projectDir);
-		if (version) {
-			console.log(`  \u2193 Installing ${component.runtime} ${version}... done`);
-			await installer.install(version);
-		} else {
-			console.log(`  \u2193 Using system ${component.runtime}`);
-		}
+		await inPhase("provision", failure({ component: name }), async () => {
+			const version = await installer.detectVersion(projectDir);
+			if (version) {
+				console.log(`  \u2193 Installing ${component.runtime} ${version}... done`);
+				await installer.install(version);
+			} else {
+				console.log(`  \u2193 Using system ${component.runtime}`);
+			}
+		});
 	}
 
 	// 10. Detect package manager
@@ -513,11 +573,8 @@ export async function launchUp(opts: LaunchUpOpts = {}): Promise<void> {
 	// so it can be injected as $storage.<name>.path (D-39). Scoped per component.
 	const componentStorage: Record<string, Record<string, Record<string, string>>> = {};
 	for (const [name, component] of Object.entries(launch.components)) {
-		const volumeMap = await provisionStorage(
-			component.storage,
-			name,
-			projectDir,
-			operatorStorage[name],
+		const volumeMap = await inPhase("provision", failure({ component: name }), () =>
+			provisionStorage(component.storage, name, projectDir, operatorStorage[name]),
 		);
 		const storageCtx: Record<string, Record<string, string>> = {};
 		for (const [volName, localPath] of Object.entries(volumeMap)) {
@@ -535,12 +592,26 @@ export async function launchUp(opts: LaunchUpOpts = {}): Promise<void> {
 	const generatedEnv = (state.generatedEnv ??= {});
 
 	for (const [name, component] of Object.entries(launch.components)) {
-		const { env } = resolveComponentEnv(component, context, resourceMap, componentStorage[name]);
-		await resolveGenerators(component, env, name, generatedEnv);
+		const env = await inPhase("provision", failure({ component: name }), async () => {
+			const { env: resolved } = resolveComponentEnv(
+				component,
+				context,
+				resourceMap,
+				componentStorage[name],
+			);
+			await resolveGenerators(component, resolved, name, generatedEnv);
+			return resolved;
+		});
 
 		// Operator-supplied `required:` values (step 2c) join the resolved set, so
 		// they reach `release` and `start` alike and show up in `launch env`.
 		Object.assign(env, operatorEnv[name] ?? {});
+
+		// D-18: a value the author declared `sensitive: true` is registered here,
+		// once it is resolved and before any command that could echo it runs. The
+		// registry is what a capture scrubs against, so a value that is not in it
+		// by now is one no later redaction can remove (CWE-532).
+		registerSensitiveEnv(component.env, env);
 
 		const port = componentPorts[name];
 		if (port && !env.PORT) {
@@ -569,7 +640,7 @@ export async function launchUp(opts: LaunchUpOpts = {}): Promise<void> {
 	// The bound operator paths ride along so `env` can report the directory the
 	// app actually reads (D-50); a later `up` still has to supply them again.
 	state.operatorStorage = operatorStorage;
-	await saveState(projectDir, state);
+	await inPhase("provision", failure(), () => saveState(projectDir, state));
 
 	if (opts.dryRun) {
 		console.log("\n[dry-run] Would now run build, release, and start commands.");
@@ -584,13 +655,19 @@ export async function launchUp(opts: LaunchUpOpts = {}): Promise<void> {
 			const cmd = prepare?.command ?? pm?.installCommand;
 			if (cmd) {
 				console.log(`  \u2193 Preparing${componentNames.length > 1 ? ` [${name}]` : ""}...`);
-				await shellScript(cmd, {
-					cwd: join(projectDir, component.source ?? component.build?.context ?? "."),
-					env: allEnvs[name],
-					// Installs/compiles routinely exceed the 2-minute shell default;
-					// honor a declared timeout, else allow 10 minutes.
-					timeout: declaredTimeout(prepare?.timeout, `prepare [${name}]`) ?? 600_000,
-				});
+				// D-38: in source mode the prepare slot resolves `install ?? build`,
+				// and the package manager's install stands in when neither is
+				// declared. All three record `prepare` — the slot, never the
+				// command name.
+				await inPhase("prepare", failure({ component: name }), () =>
+					shellScript(cmd, {
+						cwd: join(projectDir, component.source ?? component.build?.context ?? "."),
+						env: allEnvs[name],
+						// Installs/compiles routinely exceed the 2-minute shell default;
+						// honor a declared timeout, else allow 10 minutes.
+						timeout: declaredTimeout(prepare?.timeout, `prepare [${name}]`) ?? 600_000,
+					}),
+				);
 			}
 		}
 	}
@@ -600,11 +677,15 @@ export async function launchUp(opts: LaunchUpOpts = {}): Promise<void> {
 		const release = component.commands?.release;
 		if (release?.command) {
 			console.log(`  \u2193 Running release${componentNames.length > 1 ? ` [${name}]` : ""}...`);
-			await shellScript(release.command, {
-				cwd: join(projectDir, component.source ?? component.build?.context ?? "."),
-				env: allEnvs[name],
-				timeout: declaredTimeout(release.timeout, `release [${name}]`),
-			});
+			// D-48: a release failure fails the DEPLOY — a different disposition
+			// from the prepare and run slots either side of it.
+			await inPhase("release", failure({ component: name }), () =>
+				shellScript(release.command, {
+					cwd: join(projectDir, component.source ?? component.build?.context ?? "."),
+					env: allEnvs[name],
+					timeout: declaredTimeout(release.timeout, `release [${name}]`),
+				}),
+			);
 		}
 	}
 
@@ -641,7 +722,17 @@ export async function launchUp(opts: LaunchUpOpts = {}): Promise<void> {
 		process.exit(0);
 	});
 
-	await pm2.startAll();
+	// The run slot resolves `dev ?? start` in source mode (D-38) and records
+	// `run` either way. Component log tails are attached only on failure — the
+	// processes write them to `.launchfile/logs/`, so a start that dies takes its
+	// own output into the record.
+	await inPhase(
+		"run",
+		failure({
+			logs: () => captureProcessLogs(projectDir, Object.keys(launch.components)),
+		}),
+		() => pm2.startAll(),
+	);
 	console.log("");
 	console.log(`  \u2713 All components started`);
 

--- a/providers/macos-dev/src/shell.ts
+++ b/providers/macos-dev/src/shell.ts
@@ -58,11 +58,25 @@ function failure(display: string, result: ShellResult): Error {
 	// The message reaches the user and may be logged by a caller; both the
 	// command and the child's stderr can echo a secret back, so neither goes
 	// in unscrubbed (D-18, CWE-532).
+	//
+	// `display` rides along as its own property so a failure capture records the
+	// command as a field without parsing it back out of prose, and the attached
+	// output is scrubbed here rather than only at capture: anything that
+	// serializes this error before it reaches the capture path — a caller's
+	// `console.error`, a future logger — would otherwise print the raw tails.
+	// Capture-time redaction still runs, and is idempotent.
 	return Object.assign(
 		new Error(
 			`Command failed: ${redactSecrets(display)}\n${redactSecrets(result.stderr)}`,
 		),
-		{ result },
+		{
+			result: {
+				...result,
+				stdout: redactSecrets(result.stdout),
+				stderr: redactSecrets(result.stderr),
+			} satisfies ShellResult,
+			display: redactSecrets(display),
+		},
 	);
 }
 

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -21,6 +21,8 @@
  *    than merely avoided.
  */
 
+import { createHash } from "node:crypto";
+
 // ---------------------------------------------------------------------------
 // Phases, slots, dispositions
 // ---------------------------------------------------------------------------
@@ -162,6 +164,28 @@ export function dispositionForPhase(phase: LaunchPhase): LaunchDisposition {
 		default:
 			return "failed-invocation";
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Record keys
+// ---------------------------------------------------------------------------
+
+/**
+ * The record key for a failure that has no provider slug to file itself under.
+ *
+ * Two callers need the same answer for the same source and cannot get it from
+ * each other: the provider, which writes the record inside the failing process,
+ * and the CLI, which later clears or reads it. A second implementation of the
+ * derivation is a silent divergence — the record is written under one name and
+ * looked up under another — so the derivation lives here, where both already
+ * depend.
+ *
+ * `source` is whatever identifies the app to the provider that failed: the
+ * source string for `@launchfile/docker` before a slug exists, the project
+ * directory for `@launchfile/macos-dev`, whose instances are directories.
+ */
+export function sourceErrorKey(source: string): string {
+	return `src-${createHash("sha256").update(source).digest("hex").slice(0, 16)}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -34,6 +34,7 @@ export {
 	parseLaunchErrorContext,
 	type Redactor,
 	slotForCommand,
+	sourceErrorKey,
 	stripControl,
 	TAIL_LINES,
 	tailLines,

--- a/www-dev/src/pages/quick-start.astro
+++ b/www-dev/src/pages/quick-start.astro
@@ -106,7 +106,7 @@ npx launchfile up --native
 
   <p>Both providers record failures. A Docker launch files its record under the app; a <code>--native</code> launch files one per <em>project directory</em>, because the native provider runs one instance per directory — two checkouts of the same app keep separate diagnoses.</p>
 
-  <p>One failure has its own phase: <code>health</code>, and it belongs to the Docker provider — the native provider has no launch-wide health gate. A component that never becomes healthy fails the launch, so <code>up</code> exits non-zero and names the components that never passed. Their containers stay running so you can look at them, and the deployment is listed as <code>unhealthy</code> — <code>launchfile status</code>, <code>launchfile logs</code>, and <code>launchfile down</code> all reach it. A component that declares no health check counts as healthy once its container is running.</p>
+  <p>One failure has its own phase: <code>health</code>. Under Docker, a component that never becomes healthy fails the launch, so <code>up</code> exits non-zero and names the components that never passed. Their containers stay running so you can look at them, and the deployment is listed as <code>unhealthy</code> — <code>launchfile status</code>, <code>launchfile logs</code>, and <code>launchfile down</code> all reach it. A component that declares no health check counts as healthy once its container is running. The native provider does not yet apply this gate: a component that never becomes healthy does not currently fail a <code>--native</code> launch (<a href="https://github.com/launchfile/launchfile/issues/376">#376</a>).</p>
 
   <h2 id="next-steps">Next steps</h2>
 

--- a/www-dev/src/pages/quick-start.astro
+++ b/www-dev/src/pages/quick-start.astro
@@ -102,9 +102,11 @@ npx launchfile up --native
   <Code lang="bash" theme="github-dark" code={`npx launchfile diagnose --json | jq .phase
 # "release"`} />
 
-  <p><code>--json</code> writes the raw record to stdout and nothing else, so it pipes cleanly. Records live at <code>~/.launchfile/errors/</code>, one per app, and are cleared by the next successful <code>up</code>.</p>
+  <p><code>--json</code> writes the raw record to stdout and nothing else, so it pipes cleanly. Records live at <code>~/.launchfile/errors/</code> and are cleared by the next successful <code>up</code>, or by <code>down --destroy</code>.</p>
 
-  <p>One failure has its own phase: <code>health</code>. A component that never becomes healthy fails the launch, so <code>up</code> exits non-zero and names the components that never passed. Their containers stay running so you can look at them, and the deployment is listed as <code>unhealthy</code> — <code>launchfile status</code>, <code>launchfile logs</code>, and <code>launchfile down</code> all reach it. A component that declares no health check counts as healthy once its container is running.</p>
+  <p>Both providers record failures. A Docker launch files its record under the app; a <code>--native</code> launch files one per <em>project directory</em>, because the native provider runs one instance per directory — two checkouts of the same app keep separate diagnoses.</p>
+
+  <p>One failure has its own phase: <code>health</code>, and it belongs to the Docker provider — the native provider has no launch-wide health gate. A component that never becomes healthy fails the launch, so <code>up</code> exits non-zero and names the components that never passed. Their containers stay running so you can look at them, and the deployment is listed as <code>unhealthy</code> — <code>launchfile status</code>, <code>launchfile logs</code>, and <code>launchfile down</code> all reach it. A component that declares no health check counts as healthy once its container is running.</p>
 
   <h2 id="next-steps">Next steps</h2>
 


### PR DESCRIPTION
Closes #44.

> **Stacked.** Open this against `chore/gov-osc-redos` (`--base chore/gov-osc-redos`), not `main`. That branch carries the macos-dev ReDoS bound (#203), which part 1 named as the blocker for this work: feeding 200-line log tails through an unbounded redactor is exactly the input that makes it bite. Retarget to `main` once it lands.

---

## What this is

**Part 2 of #44.** Part 1 (#226) shipped `LaunchError`, the slot-keyed phase enum, `launchfile diagnose`, and Docker capture, and deferred the macos-dev half explicitly:

> **C. Port the ReDoS bound to macos-dev — deferred to PR 2, by design.** … which is why **macos-dev captures nothing in this PR**. See #203.

So `up --native` failed with a line on stderr and left nothing behind, while `up` (docker) left a record. This closes that half. Six commits, each scoped to one top-level directory.

| Commit | Directory | What |
|---|---|---|
| `sdk:` | `sdk/` | `sourceErrorKey` — one derivation of a record key, shared by both providers and the CLI |
| `providers:` | `providers/docker/` | `dockerErrorKey` delegates to it; behaviour identical |
| `providers:` | `providers/macos-dev/` | `errors.ts`, `env-secrets.ts`, phase tagging through `launchUp`, redacted attach in `shell.ts`, tests |
| `packages:` | `packages/launchfile/` | Retention, key resolution in `diagnose`, native bootstrap capture, tests |
| `www-dev:` | `www-dev/` | Quick start says which provider records what |
| `chore:` | `.changeset/` | Changeset |

---

## The bound shape, and where this PR deviates from the issue text

The issue's §2 says both providers "wrap launch failures in `LaunchError` and persist the context to `~/.launchfile/last-error.json`". The steward's triage on the thread added three conditions, all of which bind here: **redaction is load-bearing** (env *names* only, and `stdout`/`stderr` tails and `command` strings need the same treatment as logs), **`0600` file mode**, and reuse of the existing phase vocabulary rather than a parallel one.

Part 1 already replaced the issue's single `last-error.json` with one record per key plus a pointer, and replaced the command-named phase enum with the D-48 slot-keyed one. This PR implements that landed shape, not the issue's original text.

**One deviation is new here, and it is deliberate: the record key.**

Docker keys a record by slug. macos-dev has no slug — it keeps state in `<projectDir>/.launchfile/state.json` and *refuses* `--name` (D-55) precisely because it runs one instance per project directory. Keying by app name would make two checkouts of one app share a record, so the second failing run would erase the first's diagnosis. That is the concurrency case `PROVIDERS.md` §9 calls out (UC3 worktrees), and it is the same reasoning part 1 used to reject the issue's single global file. So a native record is keyed by project directory, through the same `src-<hash>` derivation docker uses before a slug exists.

`launchfile diagnose <name|id>` still resolves: `resolveKey` translates a macos index entry through its `source` (the project directory). Verified live below.

---

## What the capture covers

Every throw in `launchUp` is tagged at the throw site with the D-48 phase it happened in, never guessed at from a message:

| Phase | Where | Disposition |
|---|---|---|
| `prereq` | Homebrew/git missing | failed-invocation |
| `resolve` | no `Launchfile` at the target | failed-invocation |
| `parse` | `readLaunch` | failed-invocation |
| `provision` | resources, ports, runtimes, storage, env resolution, state save | failed-invocation |
| `prepare` | source prepare — `install ?? build`, or the package manager's install (D-38) | failed-invocation |
| `release` | the release command | **failed-deploy** |
| `run` | `startAll` — `dev ?? start` (D-38) | failed-invocation |
| `unknown` | anything that escapes untagged | failed-invocation |

The phases are the **slots**, so the source-mode resolutions of D-38 collapse correctly: an `install` and a `build` both record `prepare`; a `dev` and a `start` both record `run`. That is required test 10's macos half.

A `run` failure additionally carries the per-component log tails the process manager already writes to `<projectDir>/.launchfile/logs/<component>.log` — the macos-dev counterpart of docker's `compose logs`. A component with no log file is skipped rather than recorded empty.

### ⚠️ Two failures now throw where they used to `process.exit(1)`

A missing prerequisite and a missing `Launchfile`. Both still print the same message and still exit non-zero — the CLI's top-level catch prints `Error: <message>`. They throw so a record exists, which is the point of the feature; docker's `prereq` path does the same thing for the same reason. Every other refusal in `launchUp` (the component selector, the source-mode guard, host-capability refusals, the D-52 missing-`required:` list) keeps its `process.exit(1)`: those messages are already the complete, actionable diagnosis, and docker treats the equivalent paths the same way.

### Expected refusals pass through unwrapped

The D-50 storage refusals (`UnboundOperatorStorageError`, `MissingOperatorStoragePathError`) carry the SDK's `expectedRefusal` marker, and `up.ts` matches them by `instanceof` to print their own message. `inPhase` re-throws anything carrying that marker unchanged — the same fix part 1 had to make after its rebase, applied here before it could bite.

---

## Security — the coverage gap had to close first

**A. Redaction happens at capture, in the failing process.** `macosLaunchError` runs the provider's `redactSecrets` over every free-text field via the SDK builder. The registry is process-global and in-memory; `launchfile diagnose` runs later, with an empty registry, and can scrub nothing. Text that reaches a record unredacted is unredactable from then on (CWE-532).

**B. Two classes of credential were unregistered, and this feature would have written them to disk.** `redact.ts` registered only values this provider *minted* or read back from its own state. Neither of these was covered:

- a literal `env:` value marked `sensitive: true` (D-18);
- an operator-supplied value for a `required:` variable (D-52).

`env-secrets.ts` (mirroring `providers/docker/src/env-secrets.ts`) registers both through `registerDeclaredSecret`, which applies **no length floor** — `registerSecret`'s 8-character floor is defensible for a value the provider *infers* is secret and wrong for one something *declares* is secret. Part 1 landed `registerDeclaredSecret` in this provider for exactly this moment; nothing called it until now.

Ordering: operator values are registered the moment step 2c reads them, before any directory, resource, or process exists. Declared-sensitive values are registered at step 12 as each component's env resolves — before prepare, release, or run can echo one.

**C. The redacted command form is captured, never the raw one.** `shell.ts` now attaches `display: redactSecrets(display)` and the redacted tails to the error it rejects with, rather than only embedding them in the message string. Capture then records the command as its own field without parsing it back out of prose. This is `providers/docker/src/shell.ts`'s §I shape, and it is negative-controlled: dropping the `display` attach fails two tests.

**D. `envKeys` — names only.** `declaredEnvKeys` reads names out of the **Launchfile**, so no resolved value is in scope at the call site, and the SDK's `EnvKeyList` brand makes a value-carrying assignment fail to typecheck. Paired with a sentinel test and verified live.

**E. `0600` files, `0700` directories, no path knob.** Unchanged from part 1 — the CLI's `state/errors.ts` owns persistence for both providers, and this PR adds no second writer. Verified live below.

**F. ReDoS.** The bound this capture depends on is the base branch's (#203), not this PR's. Required test 11 lives there (`providers/macos-dev/src/__tests__/redact.test.ts`). Nothing here feeds a tail to an unbounded pattern.

---

## Retention (§H)

The record holds redacted-but-still-sensitive log tails, so it must not outlive the launch it describes. The docker branch already did this; the macos branch did not:

- a successful `up --native` supersedes the record for that project directory;
- `down --destroy` removes it with the rest of the app's state.

Both verified live.

---

## Tests

**tests pass (1163/1163)** under `bun run test` (vitest) at `3bd34e0`. That is the only runner: `bun test` fails by design repo-wide since #264 (the `bunfig.toml` preload guard), and CI runs `bun run test`.

| Workspace | `bun run test` | typecheck |
|---|---|---|
| `sdk` | 425 pass, 0 fail (18 files) | ✅ (+ build) |
| `providers/docker` | 358 pass, 0 fail (26 files) | ✅ (+ build) |
| `providers/macos-dev` | 226 pass, 0 fail (22 files) — **+15 new** | ✅ (+ build) |
| `packages/launchfile` | 99 pass, 0 fail (10 files) — **+3 new** | ✅ (+ build, `dist/cli.js` present) |
| `providers/aws` (untouched, regression check) | 55 pass, 0 fail (3 files) | ✅ |

`www-dev`: `astro check` 0 errors / 0 warnings / 0 hints, `bun run build` green (pagefind indexed 26 pages). `www-shared` needs its own `bun install` first, as CI does at `ci.yml:127`.

New tests — `providers/macos-dev/src/__tests__/errors.test.ts` (15) and three in `packages/launchfile/src/__tests__/up-failure.test.ts`:

- **Registry scrub** — a registered secret is absent from the serialized record (required test 1's macos half).
- **Coverage gap** — a `sensitive: true` **six-digit** value and an operator-supplied value are both scrubbed out of a captured record (required test 2's macos half).
- **URL credential** in a captured `command` is scrubbed (required test 3).
- **Sentinel** — the value appears nowhere in the record, the name appears in `envKeys` (required test 4).
- **Source-mode slot capture** — a real failing `shellScript` through `resolveSourcePrepareCommand` records `prepare`/exit 3, through `resolveSourceRunCommand` records `run`/exit 4 (required test 10's macos half).
- Innermost phase wins; an expected refusal passes through unwrapped; log tails attach on failure only and skip components with no log; the key differs between two checkouts and equals the SDK derivation.
- CLI: a native failure lands under the project-directory key and is reachable by a bare `diagnose`; a later success supersedes it; a success in *one* checkout does not clear the *other* checkout's record.

**Negative controls.** Dropping the `display` attach in `shell.ts` fails 2 of the new tests (verified red). The `registerSensitiveEnv` wiring cannot be negative-controlled through `provider.ts` — removing the call leaves an unused import and the build fails before the test runs — so it is verified live instead, below.

---

## Verified live

A real `up --native` on a macOS host with Homebrew and git present, against a Launchfile declaring `PLANTED_PIN: "824193"` with `sensitive: true` — a value **below** the inference floor, chosen because it is the case the registry used to drop — whose `release` prints it to stderr and exits 7. Full transcript re-run at `3bd34e0`; the real `~/.launchfile` was restored afterwards and its four pre-existing records were untouched.

- **`parse`**: an `up --native` against a syntactically broken Launchfile → exit 1, and `launchfile diagnose` in a fresh process printed `failed during reading the Launchfile`, `phase: parse`, `disposition: failed the invocation — nothing is serving (D-48)`, with the YAML error.
- **`prepare`**: an `install` that exits 3 → `{phase: "prepare", disposition: "failed-invocation", exitCode: 3, component: "default", command: "echo installing deps; exit 3", provider: "macos-dev"}`.
- **`release`**: exit 7 → `gov44-diag failed during release slot`, `phase: release`, `disposition: failed the deploy — the release stage aborted it (D-48)`, `exit code: 7`, the redacted command, the stderr tail, and `Declared env variables: PLANTED_PIN, PUBLIC_NOTE`.
- **The planted-secret grep:** `grep -c 824193 ~/.launchfile/errors/src-526b248372795354.json` → **0, absent**. The terminal, the error message, and the record all read `auth failed: rejected pin [REDACTED]`. Control: the literal *is* present in the Launchfile and in the generated `.env.local` (the app's own env, unchanged behaviour), so the grep proves redaction and not a typo. Without the `registerSensitiveEnv` wiring nothing registers the PIN at all, so this is the live control for it.
- **`--json`**: parseable JSON on stdout, **0 bytes on stderr** (required test 8's shape), `envKeys: ["PLANTED_PIN","PUBLIC_NOTE"]` and no env value anywhere in the record.
- **Modes**: `~/.launchfile/errors` `drwx------`; the record and `last.json` both `-rw-------`.
- **Pointer**: `{version: 1, key: "src-526b248372795354", path: …, timestamp: …}`.
- **Supersession**: a later successful `up --native` of the same directory removed both the record and the pointer, and a bare `launchfile diagnose` then exited **1** with `No captured launch failure.` and no stack trace.
- **Key resolution**: after a failure that followed a successful launch, `launchfile diagnose gov44-live` (the index name) and `launchfile diagnose ccc4c63` (the deployment id) both resolved to the project-directory key and printed the release failure.
- **`down --destroy`**: removed the record, the pointer, and the index entry; the four unrelated records in the directory were untouched.

Not verified live: a `run`-phase failure. `startAll` throws only on a spawn failure, which is hard to provoke without lying to the process manager; the phase and its log-tail attach are covered by tests instead.

---

## Principle check

| Principle | Result |
|---|---|
| P-1 App-focused | N/A — no Launchfile field, nothing enters the format |
| P-5 Provider-translatable | PASS — one shared `LaunchErrorContext`, the same phases, the same disposition table; the two providers now answer `diagnose` identically |
| P-6 It's just YAML | PASS — zero schema, parser, or syntax change |
| P-11 Separate intent from execution | PASS — disposition is spec (D-48); capturing and reporting is provider mechanism |
| P-13 Additive extensibility | PASS — new exports and a new record for a command that already exists; the two `process.exit` → throw conversions keep their message and exit code |
| D-18 `sensitive` | Obligation now met for author-declared values under this provider too |
| D-38 mode resolution | Phases are slots, so `install ?? build` and `dev ?? start` each record one phase |
| D-48 failure semantics | Constrains and is satisfied: slot-keyed phases, stored disposition, release fails the deploy |
| D-50 / D-52 refusals | Unchanged — expected refusals pass through unwrapped and keep their print-and-exit UX |
| D-55 instance identity | The record key follows the provider's own identity rule (one instance per directory) |

**No new `D-*` is needed.** D-48 binds the disposition of a failure and leaves mechanism to the provider (P-11); capturing and reporting is mechanism. Zero schema change, zero `SPEC.md` change, no `www-org` change.

**Reversibility:** high. New exports and a record file, removable without touching a single Launchfile.

---

## Follow-ups (not filed — flagging for the reviewer)

- **macos-dev has no launch-wide health gate.** `ProcessManager.startOne` awaits `waitForHealthy` for a `depends_on: {condition: healthy}` edge and **ignores the result**, so a component that never becomes healthy does not fail the launch. `SPEC.md` § *Failure semantics* says it should — this is the same non-conformance part 1 fixed in docker. Deliberately not fixed here: it is a second user-visible behaviour change, independent of capture, and it deserves its own review. The quick-start doc is corrected to say the `health` phase belongs to the Docker provider.
- The CLI's macos branch records `appName: inferAppName(source)` (the directory basename) while the provider knows the Launchfile `name:`. Pre-existing; unchanged here.
- `unsupplied` (D-52) stays reserved and unpopulated in native records, as in docker — #242 tracks wiring it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
