### PR TITLE
spec: define provides.protocol as the app-side listener protocol

### DIFF
--- a/spec/DESIGN.md
+++ b/spec/DESIGN.md
@@ -708,7 +708,7 @@ The change is **annotation-only**. No `type`, `enum`, `required`, or `default` u
 
 ---
 
-### D-next: `provides.protocol` describes the component's own listener
+### D-59: `provides.protocol` describes the component's own listener
 
 **Decision**: Each `provides` entry's `protocol` describes the component's own listener on that entry's `port`, in the configuration represented by the Launchfile. It never describes a public endpoint's scheme. Publishing an HTTPS URL while forwarding cleartext HTTP to a `protocol: http` listener is not a mismatch, and tools must not report it as one. A consumer MUST NOT infer from `protocol: http` that the component cannot be configured to serve TLS. This records the existing meaning, as accepted in [#314](https://github.com/launchfile/launchfile/issues/314#issuecomment-5602689174).
 

--- a/spec/DESIGN.md
+++ b/spec/DESIGN.md
@@ -708,6 +708,20 @@ The change is **annotation-only**. No `type`, `enum`, `required`, or `default` u
 
 ---
 
+### D-next: `provides.protocol` describes the component's own listener
+
+**Decision**: Each `provides` entry's `protocol` describes the component's own listener on that entry's `port`, in the configuration represented by the Launchfile. It never describes a public endpoint's scheme. Publishing an HTTPS URL while forwarding cleartext HTTP to a `protocol: http` listener is not a mismatch, and tools must not report it as one. A consumer MUST NOT infer from `protocol: http` that the component cannot be configured to serve TLS. This records the existing meaning, as accepted in [#314](https://github.com/launchfile/launchfile/issues/314#issuecomment-5602689174).
+
+**Why**: The sibling `port` field already names the container port. The same listener/publication boundary appears in [D-33](#d-33-app-prefix-for-platform-injected-app-properties): `$components.<this>.url` describes the component-side address, while `$app.url` describes the public address. [D-35](#d-35-appauthority--appscheme--apptls-promoted-into-the-standard-app-set) derives `$app.scheme` from that public URL, and [D-58](#d-58-orchestrator-supplied-publication-context--app-under-an-owning-orchestrator) rule 4 limits supplied publication context to the primary endpoint; other published endpoints have no declared public address. [D-27](#d-27-exposed-false-by-default)'s publication intent does not turn listener metadata into proxy configuration. This preserves the app/platform boundary ([P-1](#p-1-app-focused-not-infra-focused), [P-11](#p-11-separate-intent-from-execution)) and changes no existing file's meaning ([P-13](#p-13-additive-extensibility)).
+
+**Rejected**: *Reading `protocol` as a public endpoint's scheme* — duplicates `$app.scheme`, fails the [P-1](#p-1-app-focused-not-infra-focused) litmus by changing when the same app moves behind a TLS proxy, and places proxy configuration in the file where [D-5](#d-5-proxy-is-a-platform-concern-not-an-app-concern) and [D-15](#d-15-routing-is-a-deployment-concern-not-an-app-concern) keep it out.
+
+**Not settled**: This decision does not decide whether `protocol` stays required. It creates no way to declare a capability or a TLS requirement, leaving native TLS capability (A), public HTTPS requirements (B), and named application variants (D) in [#314](https://github.com/launchfile/launchfile/issues/314) open and unprejudiced. It gives providers no new obligation; correcting component URLs built from hardcoded `http://` remains [#391](https://github.com/launchfile/launchfile/issues/391)'s scope, and `PROVIDERS.md` is unchanged.
+
+**Limitation**: The enum has no TLS-bearing member alongside `ws` and `grpc`, so a component terminating TLS on a WebSocket listener still cannot express that fact.
+
+---
+
 ## 4. Known Limitations
 
 Each limitation includes the problem, current stance, and future considerations.

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -161,6 +161,16 @@ Declares what network endpoints a component exposes. Value is an array of object
 | `exposed` | `boolean` | no | `false` | Whether the port is reachable from outside the host. Most components in a multi-component app are internal services — only frontends and API gateways typically need `exposed: true`. |
 | `spec` | `map<string, string>` | no | -- | API spec references (e.g. `openapi: file:docs/openapi.yaml`) |
 
+Each `provides` entry's `protocol` describes what that component's own listener
+speaks on that entry's `port`, in the configuration this Launchfile describes. It
+never describes a public endpoint's scheme. A provider may publish an `https://`
+URL while forwarding cleartext HTTP to a component declaring `protocol: http`;
+that is not a mismatch and no tool may report it as one. The app's primary public
+scheme is `$app.scheme`, derived from `$app.url`; other published endpoints have
+no declared public address (D-58 rule 4). Declaring one listener configuration
+says nothing about the other configurations an app supports — a consumer MUST NOT
+infer from `protocol: http` that a component cannot be configured to serve TLS.
+
 ```yaml
 provides:
   - name: api

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -167,7 +167,7 @@ never describes a public endpoint's scheme. A provider may publish an `https://`
 URL while forwarding cleartext HTTP to a component declaring `protocol: http`;
 that is not a mismatch and no tool may report it as one. The app's primary public
 scheme is `$app.scheme`, derived from `$app.url`; other published endpoints have
-no declared public address (D-58 rule 4). Declaring one listener configuration
+no declared public address ([D-58](DESIGN.md#d-58-orchestrator-supplied-publication-context--app-under-an-owning-orchestrator) rule 4). Declaring one listener configuration
 says nothing about the other configurations an app supports — a consumer MUST NOT
 infer from `protocol: http` that a component cannot be configured to serve TLS.
 

--- a/www-dev/src/pages/learn/ports-storage-health.astro
+++ b/www-dev/src/pages/learn/ports-storage-health.astro
@@ -40,7 +40,7 @@ const ghostYaml = ghostYamlRaw.replace(/^#.*\n/gm, "").trim();
 </p>
 
 <ul>
-  <li><strong><code>protocol</code></strong> — What the endpoint speaks: <code>http</code>, <code>https</code>, <code>tcp</code>, or <code>grpc</code>.</li>
+  <li><strong><code>protocol</code></strong> — What your app's own listener speaks on this port: <code>http</code>, <code>https</code>, <code>tcp</code>, <code>udp</code>, <code>grpc</code>, or <code>ws</code>. It is not the scheme a browser shows — that is <code>$app.scheme</code>, which the platform decides.</li>
   <li><strong><code>port</code></strong> — The port number your app listens on inside the container.</li>
   <li><strong><code>bind</code></strong> — Optional. The address to bind to (defaults to <code>0.0.0.0</code>).</li>
   <li><strong><code>exposed</code></strong> — When <code>true</code>, this port is meant to be <GlossaryTip term="exposed" definition="An exposed port is reachable from outside the deployment, not just from other services in the same deployment.">reachable from outside</GlossaryTip> the deployment — your app's public entry point. When <code>false</code> (the default), it's only reachable by other components in the same deployment.</li>


### PR DESCRIPTION
## What

Define each `provides.protocol` as the component's own listener protocol on that entry's `port`, in the configuration represented by the Launchfile. An HTTPS public URL forwarding to an HTTP listener is valid, and an HTTP declaration does not imply the app lacks native TLS support.

Adds the exact accepted SPEC paragraph, a D-59 decision recording the rationale and limits, and the requested lesson wording with all six protocol values. D-59 was assigned in the final commit before merge, as the Steward requested.

## Why

Implements **Decision 0 only** from the [accepted verdict on #314](https://github.com/launchfile/launchfile/issues/314#issuecomment-5602689174). Related to #314; **keep that issue open as the umbrella** for the separate RFCs.

The decision leaves protocol requiredness, native TLS capabilities, public HTTPS requirements, and named application variants open. It introduces no provider obligation. Existing component URL defects stay in #391. No schema, parser, SDK, provider, catalog, or example changes are included.

## Principle assessment

- **P-1 / P-11:** Listener metadata stays with the app; publication and proxy configuration stay with the platform.
- **P-5 / P-9:** The listener/public scheme boundary becomes explicit and unambiguous without adding translation behavior.
- **P-2 / P-3 / P-4 / P-6 / P-7 / P-8 / P-10 / P-12:** No new authoring mechanism, syntax, wiring, or runtime behavior.
- **P-13 / P-14:** Existing files retain their meanings and validity; no field is deprecated or removed.

## Validation

- `bun run lint:spec-citations --strict`: passed.
- `www-dev`: `bun run typecheck` and `bun run build` passed; 26 pages indexed.
- `www-org`: `bun run typecheck` and `bun run build` passed, including spec coverage; 34 pages indexed.
- Checked the generated lesson, Provides section, and design decision text; `git diff --check` passed.

The local sandbox refused Wrangler's optional log-file writes outside the worktree; both site checks and builds nevertheless exited successfully with zero Astro diagnostics.

## Checklist

- [x] CI is green
- [x] Linked to the accepted proposal and self-assessed against P-1 through P-14
- [x] Documentation-only clarification follows the Steward's requested three-file scope

## Separate follow-ups

- Native TLS capability: [#445](https://github.com/launchfile/launchfile/issues/445) — review after this clarification lands.
- Public HTTPS requirements: [#446](https://github.com/launchfile/launchfile/issues/446) — review after this clarification lands; independent of native TLS acceptance.
- Operator strictness: [#444](https://github.com/launchfile/launchfile/issues/444) — independently reviewable.
- Named application variants: [#447](https://github.com/launchfile/launchfile/issues/447) — separate, unproven concept.

