### PR TITLE
packages: demonstrate certificate-bound native TLS (RFC A)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "packages/launchfile": {
       "name": "launchfile",
-      "version": "0.3.0",
+      "version": "0.7.1",
       "bin": {
         "launchfile": "dist/cli.js",
       },
@@ -28,9 +28,22 @@
         "@launchfile/macos-dev": "^0.3.0",
       },
     },
+    "packages/native-tls-prototype": {
+      "name": "@launchfile/native-tls-prototype",
+      "dependencies": {
+        "@launchfile/docker": "workspace:*",
+        "@launchfile/sdk": "workspace:*",
+        "yaml": "^2.9.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.4.2",
+        "typescript": "^7.0.2",
+        "vitest": "^5.0.0",
+      },
+    },
     "providers/aws": {
       "name": "@launchfile/aws",
-      "version": "0.1.1",
+      "version": "0.2.1",
       "bin": {
         "launchfile-aws": "dist/cli.js",
       },
@@ -48,9 +61,9 @@
     },
     "providers/docker": {
       "name": "@launchfile/docker",
-      "version": "0.3.0",
+      "version": "0.7.1",
       "dependencies": {
-        "@launchfile/sdk": "^0.3.0",
+        "@launchfile/sdk": "^0.7.0",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
         "yaml": "^2.8.3",
@@ -64,7 +77,7 @@
     },
     "providers/macos-dev": {
       "name": "@launchfile/macos-dev",
-      "version": "0.3.0",
+      "version": "0.7.0",
       "dependencies": {
         "@launchfile/sdk": "^0.3.0",
         "semver": "^7.7.4",
@@ -79,7 +92,7 @@
     },
     "sdk": {
       "name": "@launchfile/sdk",
-      "version": "0.3.0",
+      "version": "0.7.0",
       "dependencies": {
         "yaml": "^2.8.3",
         "zod": "^4.3.6",
@@ -150,13 +163,19 @@
 
     "@clack/prompts": ["@clack/prompts@1.7.0", "", { "dependencies": { "@clack/core": "1.4.3", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A=="],
 
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@launchfile/aws": ["@launchfile/aws@workspace:providers/aws"],
 
     "@launchfile/docker": ["@launchfile/docker@workspace:providers/docker"],
 
     "@launchfile/macos-dev": ["@launchfile/macos-dev@workspace:providers/macos-dev"],
+
+    "@launchfile/native-tls-prototype": ["@launchfile/native-tls-prototype@workspace:packages/native-tls-prototype"],
 
     "@launchfile/sdk": ["@launchfile/sdk@workspace:sdk"],
 
@@ -206,7 +225,7 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
+    "@types/bun": ["@types/bun@1.4.2", "", { "dependencies": { "bun-types": "1.4.2" } }, "sha512-GimotNn7+ZV0uVArItBbriZsR1oNf0+WTzPkdcFrzShI7k2norL0uzEaJT8T33dWr7O/c9ZDuAFQrctKCi72oQ=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -276,7 +295,7 @@
 
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
-    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
+    "bun-types": ["bun-types@1.4.2", "", { "dependencies": { "@types/node": "*" } }, "sha512-bxV1FgK7yBIzjRe5zBozIM4Bem11ZJcCXSrjWRG3YWLt8yFDePu4cLjpebO8OvPeIE9trbyPF4fuj3Cia4Fj3w=="],
 
     "cac": ["cac@7.0.0", "", {}, "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ=="],
 
@@ -444,6 +463,18 @@
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
+    "@launchfile/native-tls-prototype/vitest": ["vitest@5.0.0", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/mocker": "5.0.0", "chai": "^6.2.2", "es-module-lexer": "^2.3.2", "expect-type": "^1.4.0", "magic-string": "^1.2.3", "obug": "^2.1.4", "picomatch": "^4.0.7", "std-env": "^4.2.0", "tinybench": "6.1.4", "tinyexec": "1.3.0", "tinyglobby": "^0.2.17", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "5.0.0", "@vitest/browser-preview": "5.0.0", "@vitest/browser-webdriverio": "^5.0.0-beta.5 || >=5.0.0", "@vitest/coverage-istanbul": "5.0.0", "@vitest/coverage-v8": "5.0.0", "@vitest/ui": "5.0.0", "happy-dom": "*", "jsdom": "*", "vite": "^6.4.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q=="],
+
     "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
+
+    "@launchfile/native-tls-prototype/vitest/@vitest/mocker": ["@vitest/mocker@5.0.0", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.31", "@vitest/spy": "5.0.0", "estree-walker": "^3.0.3", "magic-string": "^1.2.3" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA=="],
+
+    "@launchfile/native-tls-prototype/vitest/magic-string": ["magic-string@1.2.3", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g=="],
+
+    "@launchfile/native-tls-prototype/vitest/picomatch": ["picomatch@4.0.7", "", {}, "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA=="],
+
+    "@launchfile/native-tls-prototype/vitest/tinybench": ["tinybench@6.1.4", "", {}, "sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ=="],
+
+    "@launchfile/native-tls-prototype/vitest/@vitest/mocker/@vitest/spy": ["@vitest/spy@5.0.0", "", {}, "sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g=="],
   }
 }

--- a/catalog/TLS-CAPABILITIES.md
+++ b/catalog/TLS-CAPABILITIES.md
@@ -1,0 +1,86 @@
+# Native TLS capability audit for RFC A
+
+Audited 2026-09-09 against this repository's tested `catalog/apps` entries and primary upstream documentation/source. No shipping catalog application declarations were changed and no additional application deployment was run for this audit. Mapping examples use the revised experimental `$listener.port` namespace; listener coordinates are not certificate properties.
+
+## Finding and evidence count
+
+The catalog's missing conditional TLS declarations do **not** demonstrate missing upstream capability. Gitea, Grafana, Miniflux, and Vaultwarden all have documented native HTTPS configuration while their tested catalog files describe HTTP defaults. Grafana and Miniflux provide **two additional concrete app motivations beyond Gitea** for the proposed selected-listener capability. Vaultwarden provides a fourth capability example with an upstream recommendation caveat. ntfy is a fifth documented native-TLS app whose additional-listener behavior tests the proposal's limits.
+
+This is a bounded sample, not a full 72-app census or five newly proven TLS deployments. Catalog metadata records successful baseline tests for Grafana (2026-04-11), Miniflux (2026-04-06), Vaultwarden (2026-04-06), and ntfy (2026-04-08). Gitea's native TLS arrangements already have separate live proof in the public prototype. Upstream capabilities and source were reviewed for the other applications; no native TLS health result is claimed for them.
+
+The HTTP baseline declarations are correct under D-59 for the configuration represented. The omission is a way to express another supported application configuration and its coordinated wiring, not an incorrectly labeled existing listener. Do not insert the proposed `tls` syntax into the shipping catalog before its format/provider decisions.
+
+## 1. Gitea — established live-proof example
+
+- Catalog: `catalog/apps/gitea/Launchfile`, HTTP on port 3000 plus its independent SSH endpoint. Its `GITEA__server__ROOT_URL` already uses `$app.url`.
+- Proposed certificate `set_env` mapping: `GITEA__server__PROTOCOL: https`, `GITEA__server__HTTP_PORT: $listener.port`, `GITEA__server__CERT_FILE: $cert_file`, `GITEA__server__KEY_FILE: $key_file`. Explicit HTTP/3000 defaults support switching back.
+- Listener semantics: the server protocol selects HTTPS on the configured HTTP port. Gitea's separate redirect-server controls must not be confused with the selected listener; the prototype does not enable another listener. Native support does not imply that every deployment must terminate TLS in Gitea.
+- Primary evidence: [HTTPS setup](https://docs.gitea.com/administration/https-setup/), [server configuration](https://docs.gitea.com/administration/config-cheat-sheet/#server-server), and the Launchfile native-TLS prototype's recorded seven-arrangement live proof.
+
+## 2. Grafana — strong additional selected-listener example
+
+- Catalog: `catalog/apps/grafana/Launchfile`, HTTP on 3000; `GF_SERVER_ROOT_URL` already uses `$app.url`.
+- Proposed certificate `set_env` mapping:
+
+```yaml
+GF_SERVER_PROTOCOL: https
+GF_SERVER_HTTP_PORT: $listener.port
+GF_SERVER_CERT_FILE: $cert_file
+GF_SERVER_CERT_KEY: $key_file
+```
+
+Grafana documents the `GF_<SECTION>_<KEY>` environment override rule and the server's protocol, port, certificate, and key options. Its [HTTPS guide](https://grafana.com/docs/grafana/latest/setup-grafana/set-up-https/) configures HTTPS on the existing default port 3000. [Configuration reference](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#server).
+
+The [HTTP server implementation](https://github.com/grafana/grafana/blob/main/pkg/api/http_server.go) constructs its TCP listener from the configured HTTP address/port and selects `Serve` versus `ServeTLS` from the protocol. Thus this configuration changes that listener's transport; it does not automatically add an HTTP redirect listener. An optional Unix socket is a separate feature. This establishes optional native TLS capability, not a mandatory public-HTTPS requirement. Public URL context remains independent of backend transport.
+
+## 3. Miniflux — strong additional certificate-activated example
+
+- Catalog: `catalog/apps/miniflux/Launchfile`, HTTP on 8080 with PostgreSQL; `BASE_URL` already uses `$app.url`.
+- Proposed certificate `set_env` mapping:
+
+```yaml
+CERT_FILE: $cert_file
+KEY_FILE: $key_file
+PORT: $listener.port
+```
+
+The [configuration reference](https://miniflux.app/docs/configuration.html) documents the certificate/key paths. `PORT` configures `0.0.0.0:$PORT`; alternatively, `LISTEN_ADDR` selects explicit addresses. A single-address fixture is the bounded candidate for A; multiple addresses and `CERT_DOMAIN` automatic certificate acquisition are separate cases to exclude from this demonstration.
+
+The [server implementation](https://github.com/miniflux/v2/blob/main/internal/http/server/server.go) confirms that `determineListenTargets` selects `modeTLS` when both certificate files are configured and `modeHTTP` otherwise; `startTLSServer` uses the same target address with `ServeTLS`. With one TCP address and no `CERT_DOMAIN`/systemd/socket mode, this replaces that listener's transport. The automatic-certificate path separately starts an HTTP ACME challenge listener and is outside the proposed fixture.
+
+Crucially, Miniflux's `HTTPS` option controls secure cookies and HSTS; it is **not** the certificate/listener activation setting. The server enables that setting internally when it discovers TLS targets. Likewise `BASE_URL` describes publication context. These must not be counted as proof that the backend already uses TLS.
+
+## 4. Vaultwarden — capability exists, with a recommendation caveat
+
+- Catalog: `catalog/apps/vaultwarden/Launchfile`, HTTP on 80; `DOMAIN` already uses `$app.url`.
+- Proposed certificate `set_env` mapping:
+
+```yaml
+ROCKET_TLS: '{certs="$cert_file",key="$key_file"}'
+ROCKET_PORT: $listener.port
+```
+
+The [upstream HTTPS guide](https://github.com/dani-garcia/vaultwarden/wiki/Enabling-HTTPS) documents this native Rocket TLS configuration and its container example maps external 443 to internal 80. The [environment template](https://github.com/dani-garcia/vaultwarden/blob/main/.env.template) documents `ROCKET_PORT`, with Docker's default 80. This configures TLS on Rocket's chosen port, not an additional HTTP listener. Interpolated paths in the TOML-shaped value must be safely quoted or constrained by the adapter; certificate material must be delivered into the container.
+
+Upstream recommends proxy termination rather than its native Rocket path. Preserve that caveat; available capability is not the recommended deployment. The web vault's browser cryptography also supplies separate public secure-context motivation, which must not be conflated with mandatory app-side TLS. The upstream full-chain deployment guidance exceeds A's current direct-leaf/root test scope. Avoid generalizing the wiki's historical algorithm limitations to untested current releases.
+
+## 5. ntfy — additional-listener boundary, not another single-listener proof
+
+- Catalog: `catalog/apps/ntfy/Launchfile`, HTTP on 80.
+- Documented native settings: `NTFY_LISTEN_HTTPS` (an address such as `:8443`), `NTFY_CERT_FILE`, and `NTFY_KEY_FILE`. A proposed `set_env` mapping would use `NTFY_LISTEN_HTTPS: ':$listener.port'`, `NTFY_CERT_FILE: $cert_file`, and `NTFY_KEY_FILE: $key_file`.
+- [Configuration documentation](https://docs.ntfy.sh/config/#config-options) lists each environment variable; its examples include simultaneous HTTP and HTTPS. The [server implementation](https://github.com/binwiederhier/ntfy/blob/main/server/server.go) independently starts an HTTP server when `ListenHTTP` is nonempty and an HTTPS server when `ListenHTTPS` is nonempty.
+- Therefore merely supplying the HTTPS settings adds a TLS listener while default HTTP remains. Do not present that as proof of A's replacement semantics. A single-listener adapter would also need proven HTTP-disable wiring, or the author must declare a distinct supported topology; simultaneous listeners remain outside A's current demonstration. A public HTTPS URL alone does not select either arrangement.
+
+## Existing-format catalog assessment
+
+No native-TLS correction to the four existing HTTP declarations is justified: they describe the default deployments correctly. Grafana, Miniflux, and Vaultwarden already carry the appropriate public URL expression, as does Gitea. Adding cert-path variables without conditional activation/material fulfillment would make the catalog ambiguous and would not establish portable support.
+
+One adjacent existing-format improvement is identifiable in ntfy: its catalog file omits `NTFY_BASE_URL`, while upstream documents that as the service's public-facing URL. `NTFY_BASE_URL: { default: $app.url }` is a normal publication-context mapping to consider separately, with the catalog's usual validation/runtime checks. It does not enable native TLS and is outside this A-focused change. No ntfy catalog edit was made.
+
+## Review implication
+
+Use a capability audit, not a search for unavailable syntax, when counting motivations. The strongest initial three-app evidence set is **Gitea + Grafana + Miniflux**. Vaultwarden corroborates availability while preserving its proxy recommendation; ntfy demonstrates why coordinated activation must specify replacement versus additional listeners. These examples justify evaluating A. Delivery already fits D-53 mode 1 via D-56; whether an optional binding may change a sibling listener declaration remains an Authors decision. Trust vocabulary, provider adoption, and advanced topologies are not established by this audit.
+
+## Candidate authoring updates
+
+The private [native TLS demonstration](../packages/native-tls-prototype/README.md) contains candidate files derived from the tested catalog entries for [Gitea](../packages/native-tls-prototype/examples/catalog/gitea/Launchfile), [Grafana](../packages/native-tls-prototype/examples/catalog/grafana/Launchfile), [Miniflux](../packages/native-tls-prototype/examples/catalog/miniflux/Launchfile), and [Vaultwarden](../packages/native-tls-prototype/examples/catalog/vaultwarden/Launchfile). They retain shipped database/storage/listener baselines, add explicit baseline port/protocol settings where appropriate, and show the proposed optional binding. Tests check baseline preservation, five arrangement plans, and changed-port wiring for all four. Only the separate Gitea proof has live deployment evidence; these candidate files have not been promoted into the catalog.

--- a/packages/native-tls-prototype/README.md
+++ b/packages/native-tls-prototype/README.md
@@ -1,0 +1,65 @@
+# Native TLS capability demonstration
+
+Runnable, private experiment for [RFC A #445](https://github.com/launchfile/launchfile/issues/445), split from [#314](https://github.com/launchfile/launchfile/issues/314). This is proposed syntax, not a `launch/v1` feature. It leaves the canonical parser, schema, providers, and CLI unchanged. The listener definition landed as D-59 in [#443](https://github.com/launchfile/launchfile/pull/443); native TLS capability still needs its separate RFC decision.
+
+## Try it
+
+Install from the repository root with `bun install --frozen-lockfile`, then use this package directory:
+
+```sh
+bun run verify
+bun run plan examples/gitea/Launchfile --tls=off --url=http://localhost:33000
+bun run plan examples/gitea/Launchfile --tls=edge --url=https://localhost:3443
+bun run prove
+```
+
+`verify` builds the SDK/Docker dependencies, checks TypeScript, and runs tests. Active certificate validation (including Compose compilation) requires OpenSSL on PATH; the adapter checks server purpose as well as key/chain/hostname validity. `plan` performs no deployment. `prove` requires Docker, OpenSSL, and the cached official `gitea/gitea:latest` image. It uses real Gitea with a persistent SQLite volume, disposable certificates, and its own loopback proxy servers. It removes the containers, volumes, certificates, and listeners it creates. It never changes system trust or restarts another service. See [the verification record](evidence/verification.md) for the tested image digest and results.
+
+## Author and consumer experience
+
+The [complete Gitea Launchfile](examples/gitea/Launchfile) contains explicit HTTP defaults plus this optional capability:
+
+```yaml
+provides:
+  - name: web
+    protocol: http
+    port: 3000
+    exposed: true
+    tls: server-cert
+supports:
+  - name: server-cert
+    type: certificate
+    set_env:
+      GITEA__server__PROTOCOL: https
+      GITEA__server__HTTP_PORT: $port
+      GITEA__server__CERT_FILE: $cert_file
+      GITEA__server__KEY_FILE: $key_file
+```
+
+“I serve HTTP on 3000; I can serve HTTPS with this certificate, configured here.” Supplying a certificate does not activate native TLS. Consumer selection coordinates the environment, effective protocol/port, certificate delivery, and health probe. Moving the certificate to `requires` makes native TLS mandatory. Explicit unsupported choices and missing/invalid active material fail.
+
+`tls: server-cert` expands to `tls: { certificate: server-cert }`. Adding `port: 3443` to that object replaces the selected listener's port; it does not add a second listener. `$port` wires the selected value into the app's actual configuration. Explicit HTTP baseline settings allow a return from HTTPS even when the app persists configuration.
+
+| Consumer mode | Public connection               | App listener | Certificate at app |
+| ------------- | ------------------------------- | ------------ | ------------------ |
+| off           | Direct HTTP                     | HTTP         | No                 |
+| edge          | HTTPS terminates at proxy       | HTTP         | No                 |
+| native        | Direct HTTPS                    | HTTPS        | Yes                |
+| passthrough   | Client TLS session reaches app  | HTTPS        | Yes                |
+| reencrypt     | Proxy opens authenticated TLS   | HTTPS        | Yes                |
+
+For native planning, pass `--tls=native --url=https://localhost:33000 --cert=/absolute/server.pem --key=/absolute/server.key --ca=/absolute/root.pem`. The optional `--compose-file=/absolute/compose.yaml` validates material and emits an artifact with mode `0600`, refusing overwrite. No route or app is started. The command reports planning/compilation status rather than successful deployment.
+
+## What the code demonstrates
+
+- `src/planner.ts` validates proposed fields before the permissive SDK can discard them, selects one listener, and produces the existing normalized representation and resource coordinates.
+- `src/docker.ts` uses the existing Compose generator, adds read-only certificate mounts, and supplies scheme-correct authenticated health checks. It refuses unsupported native-TLS sibling URL references affected by [#391](https://github.com/launchfile/launchfile/issues/391).
+- `scripts/prove.ts` exercises seven sequential deployments: HTTP, edge, native, passthrough, re-encryption, a changed native port, and return to HTTP. Distinct edge/backend certificates identify where TLS terminates; negative probes check CA/hostname failures and prevent plaintext fallback.
+
+## Deliberate limits
+
+One selected public HTTP(S) endpoint per invocation. The Docker demonstration publishes only that endpoint; it is not a general multi-endpoint deployment engine. Certificate material is one leaf and its directly issuing root CA. Intermediate chains, ACME, renewal/reload, mTLS, non-HTTP TLS, shared certificates, and simultaneous listeners are excluded. Gitea's curl-based health probe is not assumed to exist in every image.
+
+Certificate classification, trust vocabulary, feature negotiation, and production provider integration still need decisions. An old reader can strip unknown fields; a new version label alone does not prevent downgrade through that reader. This package only protects calls through its own validation boundary.
+
+[Public HTTPS requirements (#446)](https://github.com/launchfile/launchfile/issues/446), [operator strictness (#444)](https://github.com/launchfile/launchfile/issues/444), and [variants (#447)](https://github.com/launchfile/launchfile/issues/447) are separate demonstrations. This package rejects their new contracts/options instead of silently implementing or discarding them. Ordinary provider warnings remain warnings.

--- a/packages/native-tls-prototype/README.md
+++ b/packages/native-tls-prototype/README.md
@@ -40,13 +40,13 @@ supports:
 
 `tls: server-cert` expands to `tls: { certificate: server-cert }`. Adding `port: 3443` to that object replaces the selected listener's port; it does not add a second listener. `$port` wires the selected value into the app's actual configuration. Explicit HTTP baseline settings allow a return from HTTPS even when the app persists configuration.
 
-| Consumer mode | Public connection               | App listener | Certificate at app |
-| ------------- | ------------------------------- | ------------ | ------------------ |
-| off           | Direct HTTP                     | HTTP         | No                 |
-| edge          | HTTPS terminates at proxy       | HTTP         | No                 |
-| native        | Direct HTTPS                    | HTTPS        | Yes                |
-| passthrough   | Client TLS session reaches app  | HTTPS        | Yes                |
-| reencrypt     | Proxy opens authenticated TLS   | HTTPS        | Yes                |
+| Consumer mode | Public connection              | App listener | Certificate at app |
+| ------------- | ------------------------------ | ------------ | ------------------ |
+| off           | Direct HTTP                    | HTTP         | No                 |
+| edge          | HTTPS terminates at proxy      | HTTP         | No                 |
+| native        | Direct HTTPS                   | HTTPS        | Yes                |
+| passthrough   | Client TLS session reaches app | HTTPS        | Yes                |
+| reencrypt     | Proxy opens authenticated TLS  | HTTPS        | Yes                |
 
 For native planning, pass `--tls=native --url=https://localhost:33000 --cert=/absolute/server.pem --key=/absolute/server.key --ca=/absolute/root.pem`. The optional `--compose-file=/absolute/compose.yaml` validates material and emits an artifact with mode `0600`, refusing overwrite. No route or app is started. The command reports planning/compilation status rather than successful deployment.
 

--- a/packages/native-tls-prototype/README.md
+++ b/packages/native-tls-prototype/README.md
@@ -17,7 +17,7 @@ bun run prove
 
 ## Author and consumer experience
 
-The [Gitea proof fixture](examples/gitea/Launchfile) uses SQLite to isolate TLS switching. The shipped catalog file instead requires PostgreSQL and leaves its HTTP endpoint unnamed. This example adds the optional name `web` for readable selection; `tls` always binds to the entry containing it, including an unnamed entry. The proposed capability is:
+The [Gitea proof fixture](examples/gitea/Launchfile) uses SQLite to isolate TLS switching. Unlike the [shipped catalog file](../../catalog/apps/gitea/Launchfile), it omits `version: launch/v1`, replaces required PostgreSQL with SQLite, omits the separate SSH listener, and names the HTTP endpoint `web`. The [catalog-derived candidate](examples/catalog/gitea/Launchfile) preserves those shipped declarations, but has authoring/plan evidence only. None of the seven live deployments proves PostgreSQL or multiple listeners. `tls` binds to the entry containing it, including an unnamed entry. The proposed capability is:
 
 ```yaml
 provides:
@@ -40,8 +40,6 @@ supports:
 
 `tls: server-cert` expands to `tls: { certificate: server-cert }`. Adding `port: 3443` to that object replaces the selected listener's port; it does not add a second listener. `$listener.port` wires the selected value into the app's actual configuration. Explicit HTTP baseline settings allow a return from HTTPS even when the app persists configuration.
 
-`$listener.port` is valid only in the bound certificate's `set_env`; `$port` retains its resource-local meaning and is not synthesized on a certificate. A certificate named by two entries is an error in every mode. The normalized listener carries the effective protocol/port; URL-emitting expressions must use those effective values, while `$app.url` remains the separately supplied public origin. Until #391's provider path honors that rule, this adapter refuses affected sibling URL references.
-
 | Consumer mode | Public connection              | App listener | Certificate at app |
 | ------------- | ------------------------------ | ------------ | ------------------ |
 | off           | Direct HTTP                    | HTTP         | No                 |
@@ -60,12 +58,27 @@ For native planning, pass `--tls=native --url=https://localhost:33000 --cert=/ab
 - `src/redaction.ts` demonstrates `key_file` and all `*_key`/`*_key_file` values staying credential-bearing even if a future registry includes them. Tests use the provider redactor; the production registry remains unchanged.
 - `scripts/prove.ts` exercises seven sequential deployments: HTTP, edge, native, passthrough, re-encryption, a changed native port, and return to HTTP. Distinct edge/backend certificates identify where TLS terminates; negative probes check CA/hostname failures and prevent plaintext fallback.
 
+## Relationship to the revised RFC
+
+The [revised #445](https://github.com/launchfile/launchfile/issues/445) and [issue follow-up](https://github.com/launchfile/launchfile/issues/445#issuecomment-5609929110) record these choices. They are evidence for an Authors decision, not ratified native-TLS semantics:
+
+1. **Effective protocol:** the source declares the HTTP baseline. Native selection emits a normalized HTTPS listener and the selected port, consistent with D-59's meaning of `provides.protocol`. The optional binding's ability to change that declaration is still proposed.
+2. **Port scope:** `$listener.port` is valid only in the bound certificate's `set_env`. Resource-local `$port` retains its meaning; certificates receive no synthetic `port`. A certificate named by two entries is invalid in every mode. This replaces the earlier experiment's resource-port workaround.
+3. **Sibling URLs:** the proposed shared rule is that listener-derived URLs read the effective protocol/port. `$app.url` remains separate public-origin input. The production provider path in #391 is unchanged; this adapter refuses affected native sibling-URL references until that path can honor the rule. Refusal contains the implementation gap; it does not implement the shared URL rule.
+4. **Verification owner:** planning and provider compilation check supplied binding/path syntax only. The separate supplying-consumer proof explicitly checks certificate bytes, trust, purpose, and hostname before calling the existing Docker provider, then probes the deployed route. A plan or compiled artifact alone proves neither authentication nor deployment success. The provider gains no material/readiness verification obligation; moving verification into it would require a separate policy decision.
+
 ## Deliberate limits
 
 One selected public HTTP(S) endpoint per invocation. The Docker demonstration publishes only that endpoint; it is not a general multi-endpoint deployment engine. Certificate material is one leaf and its directly issuing root CA. Intermediate chains, ACME, renewal/reload, mTLS, non-HTTP TLS, shared certificates, and simultaneous listeners are excluded. Gitea's curl-based health probe is not assumed to exist in every image.
 
 Certificate delivery already fits D-53 mode 1 through D-56, with an open resource type under D-46. The new Authors decision is whether an optional binding may change a sibling listener's effective declaration. A future vocabulary registration must land with the D-56 credential-list protection, never ahead of it. Feature negotiation and production integration remain unimplemented; old readers can discard this syntax.
 
-The [catalog capability audit](../../../catalog/TLS-CAPABILITIES.md) records upstream-native TLS support separately from current declaration coverage. Candidate examples preserve catalog defaults and add proposed wiring; they are authoring/plan checks, not additional live deployment claims.
+The [catalog capability audit](../../catalog/TLS-CAPABILITIES.md) records upstream-native TLS support separately from current declaration coverage. Candidate examples preserve catalog defaults and add proposed wiring; they are authoring/plan checks, not additional live deployment claims.
 
 [Public HTTPS requirements (#446)](https://github.com/launchfile/launchfile/issues/446), [operator strictness (#444)](https://github.com/launchfile/launchfile/issues/444), and [variants (#447)](https://github.com/launchfile/launchfile/issues/447) are separate demonstrations. This package rejects their new contracts/options instead of silently implementing or discarding them. Ordinary provider warnings remain warnings.
+
+## Verification and lifecycle
+
+No CI job builds, typechecks, or tests this package: `.github/workflows/ci.yml` names its target directories and does not name `packages/native-tls-prototype`. Green repository checks do not verify these 115 prototype tests or the live proof. SDK/Docker changes can invalidate the recorded results without a failing prototype check. Re-run `bun run verify` before citing test results and `bun run prove` before claiming fresh live-deployment evidence; record the runtime and dependency versions in [the verification record](evidence/verification.md).
+
+The RFC/PR author owns keeping this demonstration reproducible while #445 is under consideration and submitting its removal when the Authors decide #445 in either direction. Remove `packages/native-tls-prototype/` and regenerate `bun.lock`; retain the evidence through the PR's immutable commits. An accepted design needs a separately reviewed production implementation, not promotion of this package. The accompanying `catalog/TLS-CAPABILITIES.md` is an additional documentation change outside the package; retire its proposal-specific candidate links with the prototype, retaining any generally useful catalog findings only through a separate catalog review. No compatibility or continuing maintenance guarantee is made for this experiment.

--- a/packages/native-tls-prototype/README.md
+++ b/packages/native-tls-prototype/README.md
@@ -13,11 +13,11 @@ bun run plan examples/gitea/Launchfile --tls=edge --url=https://localhost:3443
 bun run prove
 ```
 
-`verify` builds the SDK/Docker dependencies, checks TypeScript, and runs tests. Active certificate validation (including Compose compilation) requires OpenSSL on PATH; the adapter checks server purpose as well as key/chain/hostname validity. `plan` performs no deployment. `prove` requires Docker, OpenSSL, and the cached official `gitea/gitea:latest` image. It uses real Gitea with a persistent SQLite volume, disposable certificates, and its own loopback proxy servers. It removes the containers, volumes, certificates, and listeners it creates. It never changes system trust or restarts another service. See [the verification record](evidence/verification.md) for the tested image digest and results.
+`verify` builds the SDK/Docker dependencies, checks TypeScript, and runs tests; the consumer-verification tests use OpenSSL on PATH. Planning and Compose compilation do not read certificate files or check their validity, existence, or readiness. `prove` requires Docker, OpenSSL, and the cached official `gitea/gitea:latest` image. Its supplying consumer explicitly verifies certificates and exercises real Gitea with a persistent SQLite volume, disposable certificates, and owned loopback proxy servers. It removes the containers, volumes, certificates, and listeners it creates. See [the verification record](evidence/verification.md) for the tested image digest and results.
 
 ## Author and consumer experience
 
-The [complete Gitea Launchfile](examples/gitea/Launchfile) contains explicit HTTP defaults plus this optional capability:
+The [Gitea proof fixture](examples/gitea/Launchfile) uses SQLite to isolate TLS switching. The shipped catalog file instead requires PostgreSQL and leaves its HTTP endpoint unnamed. This example adds the optional name `web` for readable selection; `tls` always binds to the entry containing it, including an unnamed entry. The proposed capability is:
 
 ```yaml
 provides:
@@ -31,14 +31,16 @@ supports:
     type: certificate
     set_env:
       GITEA__server__PROTOCOL: https
-      GITEA__server__HTTP_PORT: $port
+      GITEA__server__HTTP_PORT: $listener.port
       GITEA__server__CERT_FILE: $cert_file
       GITEA__server__KEY_FILE: $key_file
 ```
 
-“I serve HTTP on 3000; I can serve HTTPS with this certificate, configured here.” Supplying a certificate does not activate native TLS. Consumer selection coordinates the environment, effective protocol/port, certificate delivery, and health probe. Moving the certificate to `requires` makes native TLS mandatory. Explicit unsupported choices and missing/invalid active material fail.
+“I serve HTTP on 3000; I can serve HTTPS with this certificate, configured here.” Supplying a certificate does not activate native TLS. Consumer selection coordinates the environment, effective protocol/port, supplied certificate paths, and health probe. Moving the certificate to `requires` makes native TLS mandatory. Unsupported choices and missing binding paths fail before compilation; the provider does not inspect certificate contents or validity (D-56).
 
-`tls: server-cert` expands to `tls: { certificate: server-cert }`. Adding `port: 3443` to that object replaces the selected listener's port; it does not add a second listener. `$port` wires the selected value into the app's actual configuration. Explicit HTTP baseline settings allow a return from HTTPS even when the app persists configuration.
+`tls: server-cert` expands to `tls: { certificate: server-cert }`. Adding `port: 3443` to that object replaces the selected listener's port; it does not add a second listener. `$listener.port` wires the selected value into the app's actual configuration. Explicit HTTP baseline settings allow a return from HTTPS even when the app persists configuration.
+
+`$listener.port` is valid only in the bound certificate's `set_env`; `$port` retains its resource-local meaning and is not synthesized on a certificate. A certificate named by two entries is an error in every mode. The normalized listener carries the effective protocol/port; URL-emitting expressions must use those effective values, while `$app.url` remains the separately supplied public origin. Until #391's provider path honors that rule, this adapter refuses affected sibling URL references.
 
 | Consumer mode | Public connection              | App listener | Certificate at app |
 | ------------- | ------------------------------ | ------------ | ------------------ |
@@ -48,18 +50,22 @@ supports:
 | passthrough   | Client TLS session reaches app | HTTPS        | Yes                |
 | reencrypt     | Proxy opens authenticated TLS  | HTTPS        | Yes                |
 
-For native planning, pass `--tls=native --url=https://localhost:33000 --cert=/absolute/server.pem --key=/absolute/server.key --ca=/absolute/root.pem`. The optional `--compose-file=/absolute/compose.yaml` validates material and emits an artifact with mode `0600`, refusing overwrite. No route or app is started. The command reports planning/compilation status rather than successful deployment.
+For native planning, pass `--tls=native --url=https://localhost:33000 --cert=/absolute/server.pem --key=/absolute/server.key --ca=/absolute/root.pem`. The optional `--compose-file=/absolute/compose.yaml` checks binding paths syntactically and emits an artifact with mode `0600`, refusing overwrite. It performs no certificate-content or network verification. `--ca` is consumer-selected trust for the prototype's health probe, not a server-presentation property; only `cert_file` and `key_file` reach the certificate resource. No route or app is started.
 
 ## What the code demonstrates
 
 - `src/planner.ts` validates proposed fields before the permissive SDK can discard them, selects one listener, and produces the existing normalized representation and resource coordinates.
 - `src/docker.ts` uses the existing Compose generator, adds read-only certificate mounts, and supplies scheme-correct authenticated health checks. It refuses unsupported native-TLS sibling URL references affected by [#391](https://github.com/launchfile/launchfile/issues/391).
+- `src/certificate-verification.ts` is an optional supplying-consumer check used explicitly by the proof, separate from compilation. It checks purpose, key, chain, and hostname with bounded I/O. The provider does not gain a D-56 verification obligation.
+- `src/redaction.ts` demonstrates `key_file` and all `*_key`/`*_key_file` values staying credential-bearing even if a future registry includes them. Tests use the provider redactor; the production registry remains unchanged.
 - `scripts/prove.ts` exercises seven sequential deployments: HTTP, edge, native, passthrough, re-encryption, a changed native port, and return to HTTP. Distinct edge/backend certificates identify where TLS terminates; negative probes check CA/hostname failures and prevent plaintext fallback.
 
 ## Deliberate limits
 
 One selected public HTTP(S) endpoint per invocation. The Docker demonstration publishes only that endpoint; it is not a general multi-endpoint deployment engine. Certificate material is one leaf and its directly issuing root CA. Intermediate chains, ACME, renewal/reload, mTLS, non-HTTP TLS, shared certificates, and simultaneous listeners are excluded. Gitea's curl-based health probe is not assumed to exist in every image.
 
-Certificate classification, trust vocabulary, feature negotiation, and production provider integration still need decisions. An old reader can strip unknown fields; a new version label alone does not prevent downgrade through that reader. This package only protects calls through its own validation boundary.
+Certificate delivery already fits D-53 mode 1 through D-56, with an open resource type under D-46. The new Authors decision is whether an optional binding may change a sibling listener's effective declaration. A future vocabulary registration must land with the D-56 credential-list protection, never ahead of it. Feature negotiation and production integration remain unimplemented; old readers can discard this syntax.
+
+The [catalog capability audit](../../../catalog/TLS-CAPABILITIES.md) records upstream-native TLS support separately from current declaration coverage. Candidate examples preserve catalog defaults and add proposed wiring; they are authoring/plan checks, not additional live deployment claims.
 
 [Public HTTPS requirements (#446)](https://github.com/launchfile/launchfile/issues/446), [operator strictness (#444)](https://github.com/launchfile/launchfile/issues/444), and [variants (#447)](https://github.com/launchfile/launchfile/issues/447) are separate demonstrations. This package rejects their new contracts/options instead of silently implementing or discarding them. Ordinary provider warnings remain warnings.

--- a/packages/native-tls-prototype/evidence/live-proof.json
+++ b/packages/native-tls-prototype/evidence/live-proof.json
@@ -1,0 +1,300 @@
+{
+  "timestamp": "2026-09-09T14:41:08.481Z",
+  "runtime": "Bun 1.4.0",
+  "image": {
+    "reference": "gitea/gitea:latest",
+    "id": "sha256:87a67ee09d3ae0d1df5fda5dcda3e2a1f9236a45b0a59025d6e00e46adc43bef",
+    "digests": [
+      "gitea/gitea@sha256:87a67ee09d3ae0d1df5fda5dcda3e2a1f9236a45b0a59025d6e00e46adc43bef"
+    ]
+  },
+  "assertions": [
+    {
+      "name": "Edge and backend use distinct certificate identities",
+      "passed": true
+    },
+    {
+      "name": "Private leaf keys have mode 0600",
+      "passed": true
+    },
+    {
+      "name": "Unsupported native TLS is rejected before Docker starts",
+      "passed": true,
+      "detail": "default.web does not declare native TLS support"
+    },
+    {
+      "name": "Missing certificate material is rejected before Docker starts",
+      "passed": true,
+      "detail": "Native TLS requires supplied certificate material for server-cert"
+    },
+    {
+      "name": "Client-only certificate is rejected before Docker starts",
+      "passed": true,
+      "detail": "TLS server certificate verification failed; check certificate purpose and OpenSSL availability"
+    },
+    {
+      "name": "off: plan selects expected listener port",
+      "passed": true
+    },
+    {
+      "name": "off: selected listener is published only on loopback",
+      "passed": true
+    },
+    {
+      "name": "Gitea has persistent named data volume",
+      "passed": true
+    },
+    {
+      "name": "off: real Gitea responds with its version",
+      "passed": true
+    },
+    {
+      "name": "off: Docker health check passes",
+      "passed": true
+    },
+    {
+      "name": "edge: plan selects expected listener port",
+      "passed": true
+    },
+    {
+      "name": "edge: selected listener is published only on loopback",
+      "passed": true
+    },
+    {
+      "name": "edge: same named data volume retained",
+      "passed": true
+    },
+    {
+      "name": "edge: data survives configuration switch",
+      "passed": true
+    },
+    {
+      "name": "edge: real Gitea responds with its version",
+      "passed": true
+    },
+    {
+      "name": "edge: client sees edge certificate",
+      "passed": true
+    },
+    {
+      "name": "edge: Docker health check passes",
+      "passed": true
+    },
+    {
+      "name": "native: plan selects expected listener port",
+      "passed": true
+    },
+    {
+      "name": "native: selected listener is published only on loopback",
+      "passed": true
+    },
+    {
+      "name": "native: same named data volume retained",
+      "passed": true
+    },
+    {
+      "name": "native: data survives configuration switch",
+      "passed": true
+    },
+    {
+      "name": "native: real Gitea responds with its version",
+      "passed": true
+    },
+    {
+      "name": "native: client sees backend certificate",
+      "passed": true
+    },
+    {
+      "name": "native: Docker health check passes",
+      "passed": true
+    },
+    {
+      "name": "Native client rejects an untrusted CA",
+      "passed": true,
+      "detail": "UNABLE_TO_VERIFY_LEAF_SIGNATURE"
+    },
+    {
+      "name": "Native client rejects a mismatched backend hostname",
+      "passed": true,
+      "detail": "ERR_TLS_CERT_ALTNAME_INVALID"
+    },
+    {
+      "name": "passthrough: plan selects expected listener port",
+      "passed": true
+    },
+    {
+      "name": "passthrough: selected listener is published only on loopback",
+      "passed": true
+    },
+    {
+      "name": "passthrough: same named data volume retained",
+      "passed": true
+    },
+    {
+      "name": "passthrough: data survives configuration switch",
+      "passed": true
+    },
+    {
+      "name": "passthrough: real Gitea responds with its version",
+      "passed": true
+    },
+    {
+      "name": "passthrough: client sees backend certificate",
+      "passed": true
+    },
+    {
+      "name": "passthrough: Docker health check passes",
+      "passed": true
+    },
+    {
+      "name": "reencrypt: plan selects expected listener port",
+      "passed": true
+    },
+    {
+      "name": "reencrypt: selected listener is published only on loopback",
+      "passed": true
+    },
+    {
+      "name": "reencrypt: same named data volume retained",
+      "passed": true
+    },
+    {
+      "name": "reencrypt: data survives configuration switch",
+      "passed": true
+    },
+    {
+      "name": "reencrypt: real Gitea responds with its version",
+      "passed": true
+    },
+    {
+      "name": "reencrypt: client sees edge certificate",
+      "passed": true
+    },
+    {
+      "name": "Re-encryption independently authenticates backend certificate",
+      "passed": true
+    },
+    {
+      "name": "Re-encryption has no upstream verification failures",
+      "passed": true
+    },
+    {
+      "name": "reencrypt: Docker health check passes",
+      "passed": true
+    },
+    {
+      "name": "Re-encryption fails closed when backend CA is untrusted",
+      "passed": true
+    },
+    {
+      "name": "Re-encryption rejects a trusted leaf with the wrong backend identity",
+      "passed": true
+    },
+    {
+      "name": "native-expanded-port: plan selects expected listener port",
+      "passed": true
+    },
+    {
+      "name": "native-expanded-port: selected listener is published only on loopback",
+      "passed": true
+    },
+    {
+      "name": "native-expanded-port: same named data volume retained",
+      "passed": true
+    },
+    {
+      "name": "native-expanded-port: data survives configuration switch",
+      "passed": true
+    },
+    {
+      "name": "native-expanded-port: real Gitea responds with its version",
+      "passed": true
+    },
+    {
+      "name": "native-expanded-port: client sees backend certificate",
+      "passed": true
+    },
+    {
+      "name": "native-expanded-port: Docker health check passes",
+      "passed": true
+    },
+    {
+      "name": "return-to-http: plan selects expected listener port",
+      "passed": true
+    },
+    {
+      "name": "return-to-http: selected listener is published only on loopback",
+      "passed": true
+    },
+    {
+      "name": "return-to-http: same named data volume retained",
+      "passed": true
+    },
+    {
+      "name": "return-to-http: data survives configuration switch",
+      "passed": true
+    },
+    {
+      "name": "return-to-http: real Gitea responds with its version",
+      "passed": true
+    },
+    {
+      "name": "return-to-http: Docker health check passes",
+      "passed": true
+    },
+    {
+      "name": "Only this proof project was cleaned; no owned containers or volumes remain",
+      "passed": true
+    }
+  ],
+  "deployments": [
+    {
+      "mode": "off",
+      "status": "healthy",
+      "listenerPort": 3000,
+      "certificateIdentity": "none"
+    },
+    {
+      "mode": "edge",
+      "status": "healthy",
+      "listenerPort": 3000,
+      "certificateIdentity": "edge"
+    },
+    {
+      "mode": "native",
+      "status": "healthy",
+      "listenerPort": 3000,
+      "certificateIdentity": "backend"
+    },
+    {
+      "mode": "passthrough",
+      "status": "healthy",
+      "listenerPort": 3000,
+      "certificateIdentity": "backend"
+    },
+    {
+      "mode": "reencrypt",
+      "status": "healthy",
+      "listenerPort": 3000,
+      "certificateIdentity": "edge"
+    },
+    {
+      "mode": "native-expanded-port",
+      "status": "healthy",
+      "listenerPort": 3443,
+      "certificateIdentity": "backend"
+    },
+    {
+      "mode": "return-to-http",
+      "status": "healthy",
+      "listenerPort": 3000,
+      "certificateIdentity": "none"
+    }
+  ],
+  "cleanup": {
+    "containersRemoved": true,
+    "volumesRemoved": true,
+    "temporaryFilesRemoved": true
+  },
+  "passed": true
+}

--- a/packages/native-tls-prototype/evidence/live-proof.json
+++ b/packages/native-tls-prototype/evidence/live-proof.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-09-09T14:41:08.481Z",
+  "timestamp": "2026-09-09T22:43:57.393Z",
   "runtime": "Bun 1.4.0",
   "image": {
     "reference": "gitea/gitea:latest",
@@ -28,7 +28,7 @@
       "detail": "Native TLS requires supplied certificate material for server-cert"
     },
     {
-      "name": "Client-only certificate is rejected before Docker starts",
+      "name": "Supplying consumer rejects a client-only certificate before Docker starts",
       "passed": true,
       "detail": "TLS server certificate verification failed; check certificate purpose and OpenSSL availability"
     },

--- a/packages/native-tls-prototype/evidence/verification.md
+++ b/packages/native-tls-prototype/evidence/verification.md
@@ -1,14 +1,14 @@
 # Verification record
 
-Verified on 2026-09-09 from `codex/demo-native-tls`, based on public commit [093983b214473c2a188cebeb0d31bfdf31498664](https://github.com/launchfile/launchfile/commit/093983b214473c2a188cebeb0d31bfdf31498664).
+Verified on 2026-09-09 from `codex/demo-native-tls`. The branch includes the D-59 listener-definition documentation merge [bae761d4c562e703da959b733dfd432602a10a96](https://github.com/launchfile/launchfile/commit/bae761d4c562e703da959b733dfd432602a10a96); it changes no production code from the initial proof base.
 
-| Check                      | Result                                        |
-| -------------------------- | --------------------------------------------- |
-| `bun run verify`            | SDK/Docker builds, strict TypeScript, 89 tests |
-| SDK `bun run test`          | 425 passed                                    |
-| Docker `bun run test`       | 352 passed                                    |
-| `bun run prove`             | Seven real Gitea deployments, 58 assertions    |
-| Owned resource cleanup     | Containers, volumes, proxies, temp files gone  |
+| Check                  | Result                                         |
+| ---------------------- | ---------------------------------------------- |
+| `bun run verify`       | SDK/Docker builds, strict TypeScript, 89 tests |
+| SDK `bun run test`     | 425 passed                                     |
+| Docker `bun run test`  | 352 passed                                     |
+| `bun run prove`        | Seven real Gitea deployments, 58 assertions    |
+| Owned resource cleanup | Containers, volumes, proxies, temp files gone  |
 
 The recorded [live proof](live-proof.json) uses `gitea/gitea:latest` resolved to `sha256:87a67ee09d3ae0d1df5fda5dcda3e2a1f9236a45b0a59025d6e00e46adc43bef`. It authenticates CA chains and hostnames, distinguishes edge/backend certificates, rejects bad trust/identity without plaintext fallback, preserves a data sentinel through all switches, and verifies Gitea's version endpoint plus Docker health. Certificate paths include a literal dollar sign to exercise Compose escaping. No system trust was installed.
 

--- a/packages/native-tls-prototype/evidence/verification.md
+++ b/packages/native-tls-prototype/evidence/verification.md
@@ -1,0 +1,17 @@
+# Verification record
+
+Verified on 2026-09-09 from `codex/demo-native-tls`, based on public commit [093983b214473c2a188cebeb0d31bfdf31498664](https://github.com/launchfile/launchfile/commit/093983b214473c2a188cebeb0d31bfdf31498664).
+
+| Check                      | Result                                        |
+| -------------------------- | --------------------------------------------- |
+| `bun run verify`            | SDK/Docker builds, strict TypeScript, 89 tests |
+| SDK `bun run test`          | 425 passed                                    |
+| Docker `bun run test`       | 352 passed                                    |
+| `bun run prove`             | Seven real Gitea deployments, 58 assertions    |
+| Owned resource cleanup     | Containers, volumes, proxies, temp files gone  |
+
+The recorded [live proof](live-proof.json) uses `gitea/gitea:latest` resolved to `sha256:87a67ee09d3ae0d1df5fda5dcda3e2a1f9236a45b0a59025d6e00e46adc43bef`. It authenticates CA chains and hostnames, distinguishes edge/backend certificates, rejects bad trust/identity without plaintext fallback, preserves a data sentinel through all switches, and verifies Gitea's version endpoint plus Docker health. Certificate paths include a literal dollar sign to exercise Compose escaping. No system trust was installed.
+
+The seven arrangements are HTTP, edge termination, native HTTPS, passthrough, re-encryption, native HTTPS on port 3443, and return to HTTP on port 3000. The final test suite additionally checks refusal of a partial app when any component is skipped, preservation of required-environment failures, and secret-safe parse diagnostics. The live proof now also refuses a client-authentication-only certificate before Docker starts; certificate-purpose verification uses [OpenSSL verify](https://docs.openssl.org/3.0/man1/openssl-verify/).
+
+The proof intentionally excludes public-HTTPS requirements and strictness; those are separate RFC demonstrations. This is not evidence of production-wide provider integration, general certificate lifecycle management, intermediate chains, multi-endpoint routing, or variants. See the package README for limits and commands.

--- a/packages/native-tls-prototype/evidence/verification.md
+++ b/packages/native-tls-prototype/evidence/verification.md
@@ -2,6 +2,8 @@
 
 Steward follow-up verified from `codex/demo-native-tls`. The branch includes the D-59 listener-definition documentation merge [bae761d4c562e703da959b733dfd432602a10a96](https://github.com/launchfile/launchfile/commit/bae761d4c562e703da959b733dfd432602a10a96); it changes no production code from the initial proof base. The live report records its own UTC execution timestamp.
 
+The documentation follow-up on 2026-09-10 re-ran `bun run verify`: 115 tests passed on Bun 1.4.0 / Node.js 24.14.1, with the workspace SDK 0.7.0 and Docker provider 0.7.1 built first. No implementation changed in that follow-up. The seven-deployment proof remains the earlier recorded run preserved at [0a87583](https://github.com/launchfile/launchfile/commit/0a87583ec333dcf7dbbb7406f1fc47318f61dec7); it was not re-run for the documentation edit. These are manual verification records: no CI job runs this package.
+
 | Check                  | Result                                          |
 | ---------------------- | ----------------------------------------------- |
 | `bun run verify`       | SDK/Docker builds, strict TypeScript, 115 tests |

--- a/packages/native-tls-prototype/evidence/verification.md
+++ b/packages/native-tls-prototype/evidence/verification.md
@@ -1,17 +1,19 @@
 # Verification record
 
-Verified on 2026-09-09 from `codex/demo-native-tls`. The branch includes the D-59 listener-definition documentation merge [bae761d4c562e703da959b733dfd432602a10a96](https://github.com/launchfile/launchfile/commit/bae761d4c562e703da959b733dfd432602a10a96); it changes no production code from the initial proof base.
+Steward follow-up verified from `codex/demo-native-tls`. The branch includes the D-59 listener-definition documentation merge [bae761d4c562e703da959b733dfd432602a10a96](https://github.com/launchfile/launchfile/commit/bae761d4c562e703da959b733dfd432602a10a96); it changes no production code from the initial proof base. The live report records its own UTC execution timestamp.
 
-| Check                  | Result                                         |
-| ---------------------- | ---------------------------------------------- |
-| `bun run verify`       | SDK/Docker builds, strict TypeScript, 89 tests |
-| SDK `bun run test`     | 425 passed                                     |
-| Docker `bun run test`  | 352 passed                                     |
-| `bun run prove`        | Seven real Gitea deployments, 58 assertions    |
-| Owned resource cleanup | Containers, volumes, proxies, temp files gone  |
+| Check                  | Result                                          |
+| ---------------------- | ----------------------------------------------- |
+| `bun run verify`       | SDK/Docker builds, strict TypeScript, 115 tests |
+| SDK `bun run test`     | 425 passed                                      |
+| Docker `bun run test`  | 352 passed                                      |
+| `bun run prove`        | Seven real Gitea deployments, 58 assertions     |
+| Owned resource cleanup | Containers, volumes, proxies, temp files gone   |
 
 The recorded [live proof](live-proof.json) uses `gitea/gitea:latest` resolved to `sha256:87a67ee09d3ae0d1df5fda5dcda3e2a1f9236a45b0a59025d6e00e46adc43bef`. It authenticates CA chains and hostnames, distinguishes edge/backend certificates, rejects bad trust/identity without plaintext fallback, preserves a data sentinel through all switches, and verifies Gitea's version endpoint plus Docker health. Certificate paths include a literal dollar sign to exercise Compose escaping. No system trust was installed.
 
-The seven arrangements are HTTP, edge termination, native HTTPS, passthrough, re-encryption, native HTTPS on port 3443, and return to HTTP on port 3000. The final test suite additionally checks refusal of a partial app when any component is skipped, preservation of required-environment failures, and secret-safe parse diagnostics. The live proof now also refuses a client-authentication-only certificate before Docker starts; certificate-purpose verification uses [OpenSSL verify](https://docs.openssl.org/3.0/man1/openssl-verify/).
+The seven arrangements are HTTP, edge termination, native HTTPS, passthrough, re-encryption, native HTTPS on port 3443, and return to HTTP on port 3000. The supplying consumer rejects a client-authentication-only certificate before Docker starts; its separate verification helper uses [OpenSSL verify](https://docs.openssl.org/3.0/man1/openssl-verify/). Provider compilation does not call that helper or read certificate bytes. A test compiles nonexistent supplied paths successfully while retaining an explicitly unverified status; missing binding fields still refuse with a named error.
+
+The revised tests cover `$listener.port` scope without changing resource-local `$port`, inactive malformed/shared bindings, retained expression transforms/escapes, and key-file redaction even with a registered vocabulary. Four catalog-derived candidate files preserve shipped dependency/storage/listener baselines and demonstrate documented wiring across five planned arrangements and changed native ports. Those are authoring/plan checks; only Gitea has live TLS deployment evidence. Existing SDK 425 and Docker 352 tests passed during the original extraction; neither production codebase changed in this follow-up.
 
 The proof intentionally excludes public-HTTPS requirements and strictness; those are separate RFC demonstrations. This is not evidence of production-wide provider integration, general certificate lifecycle management, intermediate chains, multi-endpoint routing, or variants. See the package README for limits and commands.

--- a/packages/native-tls-prototype/examples/catalog/gitea/Launchfile
+++ b/packages/native-tls-prototype/examples/catalog/gitea/Launchfile
@@ -1,0 +1,46 @@
+# Proposed RFC #445 input for the private native-TLS prototype only.
+# Derived from catalog/apps/gitea/Launchfile; this optional syntax is unaccepted.
+version: launch/v1
+name: gitea
+description: Lightweight self-hosted Git service
+repository: https://github.com/go-gitea/gitea
+logo: https://raw.githubusercontent.com/go-gitea/gitea/main/assets/logo.svg
+image: gitea/gitea:latest
+provides:
+  - protocol: http
+    port: 3000
+    exposed: true
+    tls: server-cert
+  - name: ssh
+    protocol: tcp
+    port: 22
+    exposed: true
+requires:
+  - type: postgres
+    set_env:
+      GITEA__database__DB_TYPE: postgres
+      GITEA__database__HOST: $host
+      GITEA__database__NAME: $name
+      GITEA__database__USER: $user
+      GITEA__database__PASSWD: $password
+env:
+  GITEA__database__DB_TYPE:
+    default: postgres
+  GITEA__server__ROOT_URL:
+    default: $app.url
+    description: Public base URL Gitea builds clone and web links from
+  GITEA__server__PROTOCOL: http
+  GITEA__server__HTTP_PORT: "3000"
+storage:
+  data:
+    path: /data
+    persistent: true
+restart: always
+supports:
+  - name: server-cert
+    type: certificate
+    set_env:
+      GITEA__server__PROTOCOL: https
+      GITEA__server__HTTP_PORT: $listener.port
+      GITEA__server__CERT_FILE: $cert_file
+      GITEA__server__KEY_FILE: $key_file

--- a/packages/native-tls-prototype/examples/catalog/grafana/Launchfile
+++ b/packages/native-tls-prototype/examples/catalog/grafana/Launchfile
@@ -1,0 +1,37 @@
+# Proposed RFC #445 input for the private native-TLS prototype only.
+# Derived from catalog/apps/grafana/Launchfile; this optional syntax is unaccepted.
+version: launch/v1
+name: grafana
+description: Observability and data visualization platform for metrics and logs
+repository: https://github.com/grafana/grafana
+logo: https://raw.githubusercontent.com/grafana/grafana/main/public/img/grafana_icon.svg
+image: grafana/grafana:latest
+provides:
+  - protocol: http
+    port: 3000
+    exposed: true
+    tls: server-cert
+env:
+  GF_SECURITY_ADMIN_PASSWORD:
+    generator: secret
+    sensitive: true
+    description: Admin password
+  GF_SERVER_ROOT_URL:
+    default: $app.url
+    description: Public URL Grafana builds links and redirects from
+  GF_SERVER_PROTOCOL: http
+  GF_SERVER_HTTP_PORT: "3000"
+health: /api/health
+storage:
+  data:
+    path: /var/lib/grafana
+    persistent: true
+restart: always
+supports:
+  - name: server-cert
+    type: certificate
+    set_env:
+      GF_SERVER_PROTOCOL: https
+      GF_SERVER_HTTP_PORT: $listener.port
+      GF_SERVER_CERT_FILE: $cert_file
+      GF_SERVER_CERT_KEY: $key_file

--- a/packages/native-tls-prototype/examples/catalog/miniflux/Launchfile
+++ b/packages/native-tls-prototype/examples/catalog/miniflux/Launchfile
@@ -1,0 +1,45 @@
+# Proposed RFC #445 input for the private native-TLS prototype only.
+# Derived from catalog/apps/miniflux/Launchfile; this optional syntax is unaccepted.
+version: launch/v1
+name: miniflux
+description: Minimalist and opinionated feed reader
+repository: https://github.com/miniflux/v2
+logo: https://raw.githubusercontent.com/miniflux/v2/main/internal/ui/static/bin/icon-512.png
+image: miniflux/miniflux:latest
+provides:
+  - protocol: http
+    port: 8080
+    exposed: true
+    tls: server-cert
+requires:
+  - type: postgres
+    set_env:
+      DATABASE_URL: $url
+env:
+  RUN_MIGRATIONS:
+    default: "1"
+    description: Run database migrations on startup
+  CREATE_ADMIN:
+    default: "1"
+    description: Create admin user on first run
+  ADMIN_USERNAME:
+    default: admin
+    description: Admin username
+  ADMIN_PASSWORD:
+    required: true
+    sensitive: true
+    description: Admin password
+    generator: secret
+  BASE_URL:
+    default: $app.url
+    description: Public-facing URL; miniflux uses it for absolute links and feed URLs
+  PORT: "8080"
+health: /healthcheck
+restart: always
+supports:
+  - name: server-cert
+    type: certificate
+    set_env:
+      PORT: $listener.port
+      CERT_FILE: $cert_file
+      KEY_FILE: $key_file

--- a/packages/native-tls-prototype/examples/catalog/vaultwarden/Launchfile
+++ b/packages/native-tls-prototype/examples/catalog/vaultwarden/Launchfile
@@ -1,0 +1,40 @@
+# Proposed RFC #445 input for the private native-TLS prototype only.
+# Derived from catalog/apps/vaultwarden/Launchfile; this optional syntax is unaccepted.
+version: launch/v1
+name: vaultwarden
+description: Self-hosted password manager — works with all Bitwarden apps and
+  browser extensions
+repository: https://github.com/dani-garcia/vaultwarden
+logo: https://raw.githubusercontent.com/dani-garcia/vaultwarden/main/resources/vaultwarden-icon.svg
+image: vaultwarden/server:latest
+provides:
+  - protocol: http
+    port: 80
+    exposed: true
+    tls: server-cert
+supports:
+  - type: postgres
+    set_env:
+      DATABASE_URL: $url
+  - name: server-cert
+    type: certificate
+    set_env:
+      ROCKET_PORT: $listener.port
+      ROCKET_TLS: '{certs="${cert_file}",key="${key_file}"}'
+env:
+  ADMIN_TOKEN:
+    generator: secret
+    sensitive: true
+    description: Token for accessing the admin panel
+  SIGNUPS_ALLOWED:
+    default: "true"
+    description: Whether new user signups are allowed
+  DOMAIN:
+    default: $app.url
+    description: Public URL vaultwarden is served from (required for WebAuthn/U2F)
+  ROCKET_PORT: "80"
+storage:
+  data:
+    path: /data
+    persistent: true
+restart: always

--- a/packages/native-tls-prototype/examples/gitea/Launchfile
+++ b/packages/native-tls-prototype/examples/gitea/Launchfile
@@ -14,7 +14,7 @@ supports:
     type: certificate
     set_env:
       GITEA__server__PROTOCOL: https
-      GITEA__server__HTTP_PORT: $port
+      GITEA__server__HTTP_PORT: $listener.port
       GITEA__server__CERT_FILE: $cert_file
       GITEA__server__KEY_FILE: $key_file
 

--- a/packages/native-tls-prototype/examples/gitea/Launchfile
+++ b/packages/native-tls-prototype/examples/gitea/Launchfile
@@ -1,0 +1,34 @@
+# Experimental issue #314 syntax; use this package's planner, not the v1 CLI.
+name: gitea-tls-prototype
+image: gitea/gitea:latest
+
+provides:
+  - name: web
+    protocol: http
+    port: 3000
+    exposed: true
+    tls: server-cert
+
+supports:
+  - name: server-cert
+    type: certificate
+    set_env:
+      GITEA__server__PROTOCOL: https
+      GITEA__server__HTTP_PORT: $port
+      GITEA__server__CERT_FILE: $cert_file
+      GITEA__server__KEY_FILE: $key_file
+
+env:
+  GITEA__database__DB_TYPE: sqlite3
+  GITEA__security__INSTALL_LOCK: "true"
+  GITEA__server__DISABLE_SSH: "true"
+  GITEA__server__PROTOCOL: http
+  GITEA__server__HTTP_PORT: "3000"
+  GITEA__server__ROOT_URL: $app.url
+
+storage:
+  data:
+    path: /data
+    persistent: true
+
+health: /api/healthz

--- a/packages/native-tls-prototype/package.json
+++ b/packages/native-tls-prototype/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@launchfile/native-tls-prototype",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "plan": "bun run src/cli.ts",
+    "prove": "bun run scripts/prove.ts",
+    "build:dependencies": "bun run --cwd ../../sdk build && bun run --cwd ../../providers/docker build",
+    "verify": "bun run build:dependencies && bun run typecheck && bun run test"
+  },
+  "dependencies": {
+    "@launchfile/docker": "workspace:*",
+    "@launchfile/sdk": "workspace:*",
+    "yaml": "^2.9.0"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.4.2",
+    "typescript": "^7.0.2",
+    "vitest": "^5.0.0"
+  }
+}

--- a/packages/native-tls-prototype/scripts/certificates.ts
+++ b/packages/native-tls-prototype/scripts/certificates.ts
@@ -1,0 +1,84 @@
+import { execFile } from 'node:child_process';
+import { chmod, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { X509Certificate } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+
+const execute = promisify(execFile);
+
+export interface CertificateFiles {
+  certFile: string;
+  keyFile: string;
+  caFile: string;
+  fingerprint: string;
+}
+
+/** Ephemeral test PKI: one trusted CA, two termination identities, and an untrusted CA. */
+export async function createCertificates(directory: string): Promise<{
+  caFile: string;
+  wrongCaFile: string;
+  edge: CertificateFiles;
+  backend: CertificateFiles;
+  wrongHost: CertificateFiles;
+  clientOnly: CertificateFiles;
+}> {
+  async function openssl(args: string[]): Promise<void> {
+    await execute('openssl', args, { timeout: 30_000, maxBuffer: 128 * 1024 });
+  }
+
+  async function authority(name: string): Promise<{ certFile: string; keyFile: string }> {
+    const keyFile = join(directory, `${name}.key`);
+    const certFile = join(directory, `${name}.pem`);
+    // Pre-create keys with restrictive permissions, including during generation.
+    await writeFile(keyFile, '', { mode: 0o600, flag: 'wx' });
+    await openssl([
+      'req', '-x509', '-newkey', 'rsa:2048', '-nodes', '-sha256', '-days', '2',
+      '-subj', `/CN=Launchfile prototype ${name}`,
+      '-addext', 'basicConstraints=critical,CA:TRUE',
+      '-addext', 'keyUsage=critical,keyCertSign,cRLSign',
+      '-keyout', keyFile, '-out', certFile,
+    ]);
+    await chmod(keyFile, 0o600);
+    return { certFile, keyFile };
+  }
+
+  const ca = await authority('root');
+  const wrongCa = await authority('untrusted-root');
+
+  async function leaf(name: string, alternativeNames: string, purpose = 'serverAuth'): Promise<CertificateFiles> {
+    const keyFile = join(directory, `${name}.key`);
+    const csrFile = join(directory, `${name}.csr`);
+    const certFile = join(directory, `${name}.pem`);
+    const extensionsFile = join(directory, `${name}.ext`);
+    await writeFile(keyFile, '', { mode: 0o600, flag: 'wx' });
+    await writeFile(extensionsFile, [
+      'basicConstraints=critical,CA:FALSE',
+      'keyUsage=critical,digitalSignature,keyEncipherment',
+      `extendedKeyUsage=${purpose}`,
+      `subjectAltName=${alternativeNames}`,
+      '',
+    ].join('\n'), { mode: 0o600 });
+    await openssl([
+      'req', '-newkey', 'rsa:2048', '-nodes', '-sha256', '-subj', `/CN=${name}`,
+      '-keyout', keyFile, '-out', csrFile,
+    ]);
+    await openssl([
+      'x509', '-req', '-sha256', '-days', '2', '-in', csrFile,
+      '-CA', ca.certFile, '-CAkey', ca.keyFile, '-CAcreateserial',
+      '-extfile', extensionsFile, '-out', certFile,
+    ]);
+    await chmod(keyFile, 0o600);
+    const fingerprint = new X509Certificate(await readFile(certFile)).fingerprint256;
+    return { certFile, keyFile, caFile: ca.certFile, fingerprint };
+  }
+
+  return {
+    caFile: ca.certFile,
+    wrongCaFile: wrongCa.certFile,
+    edge: await leaf('edge', 'DNS:localhost,IP:127.0.0.1'),
+    backend: await leaf('backend', 'DNS:localhost,IP:127.0.0.1'),
+    wrongHost: await leaf('wrong-host', 'DNS:wrong.invalid'),
+    clientOnly: await leaf('client-only', 'DNS:localhost,IP:127.0.0.1', 'clientAuth'),
+  };
+}

--- a/packages/native-tls-prototype/scripts/prove.ts
+++ b/packages/native-tls-prototype/scripts/prove.ts
@@ -1,3 +1,4 @@
+import { validateCertificate } from "../src/certificate-verification.js";
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
@@ -232,16 +233,18 @@ try {
   const certificateBindings = { 'server-cert': certificates.backend };
   const unsupported = structuredClone(fixture);
   delete unsupported.provides.find((endpoint: { name: string }) => endpoint.name === 'web').tls;
+  unsupported.supports = unsupported.supports.filter((entry: { type: string }) => entry.type !== 'certificate');
   await compilationRejects('Unsupported native TLS is rejected before Docker starts', stringify(unsupported), {
     ...baseOptions, mode: 'native', publicUrl: `https://localhost:${backendPort}`, certificates: certificateBindings,
   }, /does not declare native TLS support/);
   await compilationRejects('Missing certificate material is rejected before Docker starts', yaml, {
     ...baseOptions, mode: 'native', publicUrl: `https://localhost:${backendPort}`,
   }, /requires supplied certificate material|Missing certificate material/);
-  await compilationRejects('Client-only certificate is rejected before Docker starts', yaml, {
-    ...baseOptions, mode: 'native', publicUrl: `https://localhost:${backendPort}`,
-    certificates: { 'server-cert': certificates.clientOnly },
-  }, /TLS server certificate verification failed/);
+  await Promise.all([validateCertificate(certificates.backend, "localhost"), validateCertificate(certificates.edge, "localhost")]);
+  let consumerError = "";
+  try { await validateCertificate(certificates.clientOnly, "localhost"); } catch(error) { consumerError = cleanError(error); }
+  verify("Supplying consumer rejects a client-only certificate before Docker starts",
+    /TLS server certificate verification failed/.test(consumerError) && !startedDocker, consumerError);
   const image = JSON.parse(await docker(['image', 'inspect', fixture.image]))[0];
   report.image = { reference: fixture.image, id: image.Id, digests: image.RepoDigests ?? [] };
   const marker = randomUUID();

--- a/packages/native-tls-prototype/scripts/prove.ts
+++ b/packages/native-tls-prototype/scripts/prove.ts
@@ -1,0 +1,369 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, mkdir, readdir, readFile, rmdir, stat, unlink, writeFile } from 'node:fs/promises';
+import * as http from 'node:http';
+import * as https from 'node:https';
+import * as net from 'node:net';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as delay } from 'node:timers/promises';
+import type { TLSSocket } from 'node:tls';
+import { promisify } from 'node:util';
+import { parse, stringify } from 'yaml';
+import { compileDockerTls } from '../src/docker';
+import { createCertificates, type CertificateFiles } from './certificates';
+
+type Mode = 'off' | 'edge' | 'native' | 'passthrough' | 'reencrypt';
+type RunningServer = { port: number; close: () => Promise<void> };
+type Probe = { status: number; body: string; fingerprint?: string };
+type Assertion = { name: string; passed: boolean; detail?: string };
+
+const execute = promisify(execFile);
+const packageDirectory = fileURLToPath(new URL('../', import.meta.url));
+const evidenceFile = join(packageDirectory, 'evidence/live-proof.json');
+const projectName = `launchfile-tls-proof-${randomUUID().slice(0, 12)}`;
+const assertions: Assertion[] = [];
+const servers = new Set<RunningServer>();
+const report: {
+  timestamp: string;
+  runtime: string;
+  image: { reference: string; id?: string; digests?: string[] };
+  assertions: Assertion[];
+  deployments: Array<{ mode: string; status: string; listenerPort: number; certificateIdentity: string }>;
+  cleanup: { containersRemoved: boolean; volumesRemoved: boolean; temporaryFilesRemoved: boolean };
+  passed: boolean;
+  failure?: string;
+} = {
+  timestamp: new Date().toISOString(),
+  runtime: `Bun ${Bun.version}`,
+  image: { reference: 'gitea/gitea:latest' },
+  assertions,
+  deployments: [],
+  cleanup: { containersRemoved: false, volumesRemoved: false, temporaryFilesRemoved: false },
+  passed: false,
+};
+
+let temporaryDirectory = '';
+let composeFile = '';
+let startedDocker = false;
+let failure: unknown;
+
+function cleanError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.replaceAll(temporaryDirectory || '\0', '[temporary-directory]').slice(0, 1500);
+}
+
+function verify(name: string, condition: unknown, detail?: string): void {
+  assertions.push({ name, passed: Boolean(condition), ...(detail ? { detail } : {}) });
+  assert.ok(condition, name);
+  console.log(`PASS ${name}`);
+}
+
+async function docker(args: string[], timeout = 30_000): Promise<string> {
+  const { stdout } = await execute('docker', args, { timeout, maxBuffer: 1024 * 1024 });
+  return stdout.trim();
+}
+
+async function compose(args: string[], timeout = 120_000): Promise<string> {
+  return docker(['compose', '-p', projectName, '-f', composeFile, ...args], timeout);
+}
+
+async function listen(server: net.Server): Promise<RunningServer> {
+  const sockets = new Set<net.Socket>();
+  server.on('connection', (socket) => {
+    sockets.add(socket);
+    socket.once('close', () => sockets.delete(socket));
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  assert.ok(address && typeof address !== 'string');
+  const running = {
+    port: address.port,
+    async close(): Promise<void> {
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => error ? reject(error) : resolve());
+      });
+      servers.delete(running);
+    },
+  };
+  servers.add(running);
+  return running;
+}
+
+async function availablePort(): Promise<number> {
+  const temporary = await listen(net.createServer());
+  const port = temporary.port;
+  await temporary.close();
+  // Docker cannot inherit this socket. A collision is a deployment failure, never a fallback.
+  return port;
+}
+
+async function probe(port: number, options?: { ca: Buffer; servername?: string }): Promise<Probe> {
+  return new Promise((resolve, reject) => {
+    const transport = options ? https : http;
+    const request = transport.request({
+      hostname: '127.0.0.1', port, path: '/api/v1/version', method: 'GET',
+      agent: false, timeout: 5000,
+      ...(options ? { ca: options.ca, servername: options.servername ?? 'localhost', rejectUnauthorized: true } : {}),
+    }, (response) => {
+      let body = '';
+      const socket = response.socket as TLSSocket;
+      const fingerprint = options ? socket.getPeerCertificate().fingerprint256 : undefined;
+      response.setEncoding('utf8');
+      response.on('data', (chunk: string) => { body += chunk; });
+      response.once('error', reject);
+      response.once('end', () => resolve({ status: response.statusCode ?? 0, body, fingerprint }));
+    });
+    request.once('timeout', () => request.destroy(new Error('HTTP probe timed out')));
+    request.once('error', reject);
+    request.end();
+  });
+}
+
+async function expectTlsRejection(name: string, action: () => Promise<unknown>, expected: 'trust' | 'hostname'): Promise<void> {
+  let code = '';
+  try { await action(); } catch (error) {
+    code = String((error as NodeJS.ErrnoException).code ?? '');
+  }
+  const trustErrors = ['UNABLE_TO_VERIFY_LEAF_SIGNATURE', 'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+    'SELF_SIGNED_CERT_IN_CHAIN', 'DEPTH_ZERO_SELF_SIGNED_CERT', 'CERT_SIGNATURE_FAILURE'];
+  verify(name, expected === 'hostname' ? code === 'ERR_TLS_CERT_ALTNAME_INVALID' : trustErrors.includes(code), code || 'TLS connection unexpectedly accepted');
+}
+
+async function tlsProxy(
+  identity: CertificateFiles,
+  backendPort: number,
+  backendTls?: { ca: Buffer; servername?: string },
+): Promise<RunningServer & { upstreamFingerprints: Set<string>; upstreamErrors: Set<string> }> {
+  const upstreamFingerprints = new Set<string>();
+  const upstreamErrors = new Set<string>();
+  const server = https.createServer({
+    cert: await readFile(identity.certFile), key: await readFile(identity.keyFile),
+  }, (request, response) => {
+    const transport = backendTls ? https : http;
+    const upstream = transport.request({
+      hostname: '127.0.0.1', port: backendPort, path: request.url,
+      method: request.method, headers: { ...request.headers, host: 'localhost' },
+      agent: false, timeout: 5000,
+      ...(backendTls ? { ca: backendTls.ca, servername: backendTls.servername ?? 'localhost', rejectUnauthorized: true } : {}),
+    }, (upstreamResponse) => {
+      if (backendTls) {
+        const fingerprint = (upstreamResponse.socket as TLSSocket).getPeerCertificate().fingerprint256;
+        if (fingerprint) upstreamFingerprints.add(fingerprint);
+      }
+      response.writeHead(upstreamResponse.statusCode ?? 502, upstreamResponse.headers);
+      upstreamResponse.pipe(response);
+    });
+    upstream.once('error', (error: NodeJS.ErrnoException) => {
+      upstreamErrors.add(error.code ?? 'UNKNOWN');
+      if (!response.headersSent) response.writeHead(502, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ error: 'Backend TLS verification or connection failed' }));
+    });
+    upstream.once('timeout', () => upstream.destroy(new Error('Upstream timed out')));
+    response.once('close', () => upstream.destroy());
+    request.pipe(upstream);
+  });
+  return { ...await listen(server), upstreamFingerprints, upstreamErrors };
+}
+
+async function passthrough(backendPort: number): Promise<RunningServer> {
+  return listen(net.createServer((client) => {
+    const backend = net.connect({ host: '127.0.0.1', port: backendPort });
+    client.pipe(backend).pipe(client);
+    client.once('error', () => backend.destroy());
+    backend.once('error', () => client.destroy());
+    client.once('close', () => backend.destroy());
+    backend.once('close', () => client.destroy());
+  }));
+}
+
+async function waitHealthy(service: string): Promise<string> {
+  const deadline = Date.now() + 120_000;
+  let lastState = 'not-created';
+  while (Date.now() < deadline) {
+    const containerId = await compose(['ps', '-q', service], 10_000);
+    if (containerId) {
+      const state = JSON.parse(await docker(['inspect', '--format', '{{json .State}}', containerId], 10_000));
+      lastState = `${state.Status}/${state.Health?.Status ?? 'no-healthcheck'}`;
+      if (state.Health?.Status === 'healthy') return containerId;
+      if (state.Status === 'exited' || state.Status === 'dead') throw new Error(`Owned Gitea container stopped: ${lastState}`);
+    }
+    await delay(1500);
+  }
+  throw new Error(`Owned Gitea container did not become healthy within 120 seconds: ${lastState}`);
+}
+
+async function compilationRejects(name: string, yaml: string, options: Parameters<typeof compileDockerTls>[1], reason: RegExp): Promise<void> {
+  let message = '';
+  try { await compileDockerTls(yaml, options); } catch (error) { message = cleanError(error); }
+  verify(name, reason.test(message) && !startedDocker, message || 'Compilation unexpectedly accepted');
+}
+
+try {
+  temporaryDirectory = await mkdtemp(join(tmpdir(), 'launchfile-tls-proof-$literal-'));
+  composeFile = join(temporaryDirectory, 'compose.yaml');
+  const certificates = await createCertificates(temporaryDirectory);
+  const ca = await readFile(certificates.caFile);
+  const wrongCa = await readFile(certificates.wrongCaFile);
+  verify('Edge and backend use distinct certificate identities', certificates.edge.fingerprint !== certificates.backend.fingerprint);
+  const keyPermissions = await Promise.all([certificates.edge, certificates.backend, certificates.wrongHost]
+    .map(async (certificate) => (await stat(certificate.keyFile)).mode & 0o777));
+  verify('Private leaf keys have mode 0600', keyPermissions.every((mode) => mode === 0o600));
+
+  const source = await readFile(join(packageDirectory, 'examples/gitea/Launchfile'), 'utf8');
+  const fixture = parse(source);
+  fixture.env = {
+    ...fixture.env,
+    USER_UID: String(process.getuid?.() ?? 1000),
+    USER_GID: String(process.getgid?.() ?? 1000),
+  };
+  const yaml = stringify(fixture);
+  const backendPort = await availablePort();
+  const baseOptions = { endpoint: 'web', hostPort: backendPort, projectName, serverName: 'localhost' };
+  const certificateBindings = { 'server-cert': certificates.backend };
+  const unsupported = structuredClone(fixture);
+  delete unsupported.provides.find((endpoint: { name: string }) => endpoint.name === 'web').tls;
+  await compilationRejects('Unsupported native TLS is rejected before Docker starts', stringify(unsupported), {
+    ...baseOptions, mode: 'native', publicUrl: `https://localhost:${backendPort}`, certificates: certificateBindings,
+  }, /does not declare native TLS support/);
+  await compilationRejects('Missing certificate material is rejected before Docker starts', yaml, {
+    ...baseOptions, mode: 'native', publicUrl: `https://localhost:${backendPort}`,
+  }, /requires supplied certificate material|Missing certificate material/);
+  await compilationRejects('Client-only certificate is rejected before Docker starts', yaml, {
+    ...baseOptions, mode: 'native', publicUrl: `https://localhost:${backendPort}`,
+    certificates: { 'server-cert': certificates.clientOnly },
+  }, /TLS server certificate verification failed/);
+  const image = JSON.parse(await docker(['image', 'inspect', fixture.image]))[0];
+  report.image = { reference: fixture.image, id: image.Id, digests: image.RepoDigests ?? [] };
+  const marker = randomUUID();
+  let initialVolumes: string[] = [];
+  const scenarios: Array<{ mode: Mode; label: string; port: number; expanded?: boolean }> = [
+    { mode: 'off', label: 'off', port: 3000 },
+    { mode: 'edge', label: 'edge', port: 3000 },
+    { mode: 'native', label: 'native', port: 3000 },
+    { mode: 'passthrough', label: 'passthrough', port: 3000 },
+    { mode: 'reencrypt', label: 'reencrypt', port: 3000 },
+    { mode: 'native', label: 'native-expanded-port', port: 3443, expanded: true },
+    { mode: 'off', label: 'return-to-http', port: 3000 },
+  ];
+
+  for (const scenario of scenarios) {
+    console.log(`Deploying owned fixture: ${scenario.label}`);
+    const native = ['native', 'passthrough', 'reencrypt'].includes(scenario.mode);
+    let front: RunningServer | undefined;
+    let reencryptProxy: Awaited<ReturnType<typeof tlsProxy>> | undefined;
+    if (scenario.mode === 'edge') front = await tlsProxy(certificates.edge, backendPort);
+    if (scenario.mode === 'passthrough') front = await passthrough(backendPort);
+    if (scenario.mode === 'reencrypt') front = reencryptProxy = await tlsProxy(certificates.edge, backendPort, { ca });
+    const publicPort = front?.port ?? backendPort;
+    const publicUrl = `${scenario.mode === 'off' ? 'http' : 'https'}://localhost:${publicPort}`;
+    const selected = structuredClone(fixture);
+    if (scenario.expanded) selected.provides.find((endpoint: { name: string }) => endpoint.name === 'web').tls = { certificate: 'server-cert', port: 3443 };
+    const compiled = await compileDockerTls(stringify(selected), {
+      ...baseOptions, mode: scenario.mode, publicUrl,
+      ...(native ? { certificates: certificateBindings } : {}),
+    });
+    verify(`${scenario.label}: plan selects expected listener port`, compiled.plan.port === scenario.port);
+    await writeFile(composeFile, compiled.compose, { mode: 0o600 });
+    startedDocker = true;
+    await compose(['up', '--detach', '--no-build']);
+    const containerId = await waitHealthy(compiled.service);
+    const portBindings = JSON.parse(await docker(['inspect', '--format', '{{json .HostConfig.PortBindings}}', containerId]));
+    const selectedBindings = portBindings[`${scenario.port}/tcp`];
+    verify(`${scenario.label}: selected listener is published only on loopback`,
+      Object.keys(portBindings).length === 1 && selectedBindings?.length === 1 &&
+      selectedBindings[0].HostIp === '127.0.0.1' && selectedBindings[0].HostPort === String(backendPort));
+    const volumeNames = JSON.parse(await docker(['inspect', '--format', '{{json .Mounts}}', containerId]))
+      .filter((mount: { Type: string }) => mount.Type === 'volume')
+      .map((mount: { Name: string }) => mount.Name).sort();
+    if (scenario.label === 'off') {
+      initialVolumes = volumeNames;
+      verify('Gitea has persistent named data volume', initialVolumes.length > 0);
+      await docker(['exec', containerId, 'sh', '-c', 'printf %s "$1" > /data/.tls-prototype-proof', 'proof', marker]);
+    } else {
+      verify(`${scenario.label}: same named data volume retained`, JSON.stringify(volumeNames) === JSON.stringify(initialVolumes));
+      verify(`${scenario.label}: data survives configuration switch`, await docker(['exec', containerId, 'cat', '/data/.tls-prototype-proof']) === marker);
+    }
+
+    const result = await probe(publicPort, scenario.mode === 'off' ? undefined : { ca });
+    verify(`${scenario.label}: real Gitea responds with its version`, result.status === 200 && typeof JSON.parse(result.body).version === 'string');
+    const expectedIdentity = scenario.mode === 'off' ? 'none' : ['edge', 'reencrypt'].includes(scenario.mode) ? 'edge' : 'backend';
+    if (expectedIdentity !== 'none') {
+      verify(`${scenario.label}: client sees ${expectedIdentity} certificate`, result.fingerprint === certificates[expectedIdentity].fingerprint);
+    }
+    if (reencryptProxy) {
+      verify('Re-encryption independently authenticates backend certificate', reencryptProxy.upstreamFingerprints.has(certificates.backend.fingerprint));
+      verify('Re-encryption has no upstream verification failures', reencryptProxy.upstreamErrors.size === 0);
+    }
+    verify(`${scenario.label}: Docker health check passes`, true);
+    report.deployments.push({ mode: scenario.label, status: 'healthy', listenerPort: scenario.port, certificateIdentity: expectedIdentity });
+
+    if (scenario.mode === 'native' && !scenario.expanded) {
+      await expectTlsRejection('Native client rejects an untrusted CA', () => probe(backendPort, { ca: wrongCa }), 'trust');
+      await expectTlsRejection('Native client rejects a mismatched backend hostname', () => probe(backendPort, { ca, servername: 'wrong.invalid' }), 'hostname');
+    }
+    if (scenario.mode === 'reencrypt') {
+      const wrongTrustProxy = await tlsProxy(certificates.edge, backendPort, { ca: wrongCa });
+      verify('Re-encryption fails closed when backend CA is untrusted', (await probe(wrongTrustProxy.port, { ca })).status === 502 && wrongTrustProxy.upstreamErrors.size > 0);
+      await wrongTrustProxy.close();
+      const impostor = await listen(https.createServer({
+        cert: await readFile(certificates.wrongHost.certFile), key: await readFile(certificates.wrongHost.keyFile),
+      }, (_request, response) => response.end('Impostor must never be accepted')));
+      const wrongLeafProxy = await tlsProxy(certificates.edge, impostor.port, { ca });
+      verify('Re-encryption rejects a trusted leaf with the wrong backend identity',
+        (await probe(wrongLeafProxy.port, { ca })).status === 502 && wrongLeafProxy.upstreamErrors.has('ERR_TLS_CERT_ALTNAME_INVALID'));
+      await wrongLeafProxy.close();
+      await impostor.close();
+    }
+    if (front) await front.close();
+  }
+  report.passed = true;
+} catch (error) {
+  failure = error;
+  report.failure = cleanError(error);
+  console.error(report.failure);
+} finally {
+  for (const server of [...servers]) {
+    try { await server.close(); } catch (error) { failure ??= error; }
+  }
+  try {
+    if (startedDocker) await compose(['down', '--volumes', '--remove-orphans', '--timeout', '10'], 60_000);
+    const containers = await docker(['ps', '-aq', '--filter', `label=com.docker.compose.project=${projectName}`]);
+    const volumes = await docker(['volume', 'ls', '-q', '--filter', `label=com.docker.compose.project=${projectName}`]);
+    report.cleanup.containersRemoved = containers === '';
+    report.cleanup.volumesRemoved = volumes === '';
+    verify('Only this proof project was cleaned; no owned containers or volumes remain', containers === '' && volumes === '');
+  } catch (error) {
+    failure ??= error;
+    report.failure ??= cleanError(error);
+  }
+  try {
+    if (temporaryDirectory) {
+      // The proof creates a flat, private directory. Refuse unexpected directories.
+      const files = await readdir(temporaryDirectory, { withFileTypes: true });
+      assert.ok(files.every((file) => file.isFile() || file.isSymbolicLink()), 'Unexpected directory in proof scratch space');
+      for (const file of files) await unlink(join(temporaryDirectory, file.name));
+      await rmdir(temporaryDirectory);
+    }
+    report.cleanup.temporaryFilesRemoved = true;
+  } catch (error) {
+    failure ??= error;
+    report.failure ??= cleanError(error);
+  }
+  report.passed = report.passed && !failure && Object.values(report.cleanup).every(Boolean);
+  await mkdir(dirname(evidenceFile), { recursive: true });
+  await writeFile(evidenceFile, `${JSON.stringify(report, null, 2)}\n`);
+  console.log(`Evidence: ${evidenceFile}`);
+  console.log(report.passed ? 'Live Docker TLS proof passed.' : 'Live Docker TLS proof failed.');
+}
+
+if (!report.passed) process.exitCode = 1;

--- a/packages/native-tls-prototype/src/__tests__/catalog.test.ts
+++ b/packages/native-tls-prototype/src/__tests__/catalog.test.ts
@@ -1,0 +1,46 @@
+import { readFile } from "node:fs/promises";
+import { readLaunch, resolveExpression } from "@launchfile/sdk";
+import { parse, stringify } from "yaml";
+import { describe, expect, test } from "vitest";
+import { planTls, type TlsMode } from "../planner.js";
+
+const certificate = { certFile: "/run/tls/server.pem", keyFile: "/run/tls/server-key.pem", caFile: "/run/tls/probe-ca.pem" };
+const cases = [
+  ["gitea", "GITEA__server__HTTP_PORT", "GITEA__server__CERT_FILE", "GITEA__server__KEY_FILE"],
+  ["grafana", "GF_SERVER_HTTP_PORT", "GF_SERVER_CERT_FILE", "GF_SERVER_CERT_KEY"],
+  ["miniflux", "PORT", "CERT_FILE", "KEY_FILE"],
+  ["vaultwarden", "ROCKET_PORT", "ROCKET_TLS", "ROCKET_TLS"],
+] as const;
+
+describe.each(cases)("source-backed catalog candidate: %s", (app, portKey, certKey, keyKey) => {
+  const source = () => readFile(new URL(`../../examples/catalog/${app}/Launchfile`, import.meta.url), "utf8");
+  test("preserves the shipped database, storage, identity, and listener baseline", async () => {
+    const shipped = readLaunch(await readFile(new URL(`../../../../catalog/apps/${app}/Launchfile`, import.meta.url), "utf8"));
+    const baseline = planTls(await source(), { mode: "off", publicUrl: "http://example.test" }).launch;
+    expect(baseline.name).toBe(shipped.name);
+    for (const field of ["image", "provides", "requires", "storage", "health", "restart"] as const) {
+      expect(baseline.components.default![field]).toEqual(shipped.components.default![field]);
+    }
+    expect(baseline.components.default!.env).toMatchObject(shipped.components.default!.env ?? {});
+  });
+  test("plans all five arrangements without mistaking source evidence for a live deployment", async () => {
+    for (const mode of ["off", "edge", "native", "passthrough", "reencrypt"] as TlsMode[]) {
+      const plan = planTls(await source(), { mode, publicUrl: `${mode === "off" ? "http" : "https"}://example.test`, certificates: { "server-cert": certificate } });
+      const native = ["native", "passthrough", "reencrypt"].includes(mode);
+      expect(plan.protocol).toBe(native ? "https" : "http");
+      expect(plan.certificate).toBe(native ? "server-cert" : undefined);
+    }
+  });
+  test("coordinates an explicit native port with documented app settings and container certificate paths", async () => {
+    const raw = parse(await source());
+    raw.provides.find((entry: any) => entry.tls).tls = { certificate: "server-cert", port: 3443 };
+    const plan = planTls(stringify(raw), { mode: "native", publicUrl: "https://example.test", certificates: { "server-cert": certificate } });
+    const binding = plan.launch.components.default!.supports!.find((entry) => entry.name === "server-cert")!;
+    const env = Object.fromEntries(Object.entries(binding.set_env!).map(([key, value]) =>
+      [key, resolveExpression(value, { resource: plan.resources["server-cert"]!.properties })]));
+    expect(env[portKey]).toBe("3443");
+    expect(env[certKey]).toContain(certificate.certFile);
+    expect(env[keyKey]).toContain(certificate.keyFile);
+    expect(plan.port).toBe(3443);
+  });
+});

--- a/packages/native-tls-prototype/src/__tests__/cli.test.ts
+++ b/packages/native-tls-prototype/src/__tests__/cli.test.ts
@@ -1,0 +1,45 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, readdir, rmdir, stat, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, test } from "vitest";
+
+const execute = promisify(execFile);
+const cwd = fileURLToPath(new URL("../../", import.meta.url));
+const directories: string[] = [];
+afterEach(async () => {
+  for (const directory of directories.splice(0)) {
+    for (const file of await readdir(directory)) await unlink(join(directory, file));
+    await rmdir(directory);
+  }
+});
+
+describe("prototype CLI", () => {
+  test("does not print malformed YAML source containing a secret", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "tls-prototype-secret-"));
+    directories.push(directory);
+    const file = join(directory, "Launchfile");
+    await writeFile(file, 'name: test\nimage: nginx\nenv:\n  API_TOKEN: "secret-sentinel-never-print\n');
+    const result = await execute("bun", ["src/cli.ts", file], { cwd }).catch(error => error);
+    expect(result.stderr).toContain("Invalid Launchfile YAML");
+    expect(`${result.stdout}${result.stderr}`).not.toContain("secret-sentinel-never-print");
+  });
+
+  test("prints an honest public/listener plan without claiming deployment", async () => {
+    const { stdout } = await execute("bun", ["src/cli.ts", "examples/gitea/Launchfile", "--tls=edge", "--url=https://localhost:3443", "--json"], { cwd });
+    expect(JSON.parse(stdout)).toMatchObject({ listener: "http:3000", publicUrl: "https://localhost:3443", certificate: null, status: "planned; material and routing not verified" });
+  });
+  test("creates Compose privately and refuses to overwrite an existing file", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "tls-prototype-cli-"));
+    directories.push(directory);
+    const artifact = join(directory, "compose.yaml");
+    const args = ["src/cli.ts", "examples/gitea/Launchfile", "--compose-file", artifact];
+    await execute("bun", args, { cwd });
+    expect((await stat(artifact)).mode & 0o777).toBe(0o600);
+    await writeFile(artifact, "existing user content");
+    await expect(execute("bun", args, { cwd })).rejects.toThrow();
+    expect(await readFile(artifact, "utf8")).toBe("existing user content");
+  });
+});

--- a/packages/native-tls-prototype/src/__tests__/docker.test.ts
+++ b/packages/native-tls-prototype/src/__tests__/docker.test.ts
@@ -1,0 +1,106 @@
+import { mkdtemp, readFile, readdir, rmdir, unlink } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { parse } from "yaml";
+import { compileDockerTls, validateCertificate } from "../docker.js";
+import { createCertificates } from "../../scripts/certificates.js";
+
+const fixture = await readFile(new URL("../../examples/gitea/Launchfile", import.meta.url), "utf8");
+
+describe("existing Docker provider integration", () => {
+  test("edge publication keeps HTTP inside and supplies the public HTTPS ROOT_URL", async () => {
+    const result = await compileDockerTls(fixture, {
+      mode: "edge", publicUrl: "https://localhost:34000", hostPort: 34001, projectName: "tls-edge-test",
+    });
+    const compose = parse(result.compose);
+    const app = compose.services[result.service];
+    expect(app.environment.GITEA__server__PROTOCOL).toBe("http");
+    expect(app.environment.GITEA__server__ROOT_URL).toBe("https://localhost:34000");
+    expect(app.environment.GITEA__server__CERT_FILE).toBeUndefined();
+    expect(app.ports).toEqual(["127.0.0.1:34001:3000"]);
+    expect(app.healthcheck.test[1]).toContain("http://127.0.0.1:3000/api/healthz");
+    expect(app.healthcheck.test[1]).toContain("curl --disable --noproxy '*'");
+    expect(app.volumes.every((volume: unknown) => typeof volume === "string")).toBe(true);
+  });
+
+  test("supplied certificate availability does not activate HTTP app TLS or read unused files", async () => {
+    const result = await compileDockerTls(fixture, {
+      mode: "off", publicUrl: "http://localhost:34000", hostPort: 34000, projectName: "tls-off-test",
+      certificates: { "server-cert": { certFile: "/nonexistent/cert", keyFile: "/nonexistent/key", caFile: "/nonexistent/ca" } },
+    });
+    expect(result.plan.protocol).toBe("http");
+    expect(result.plan.resources).toEqual({});
+  });
+
+  test("native mode refuses nonexistent material before generating artifacts", async () => {
+    await expect(compileDockerTls(fixture, {
+      mode: "native", publicUrl: "https://localhost:34000", hostPort: 34000, projectName: "tls-native-test",
+      certificates: { "server-cert": { certFile: "/nonexistent/cert", keyFile: "/nonexistent/key", caFile: "/nonexistent/ca" } },
+    })).rejects.toThrow();
+  });
+
+  test("preserves provider warnings without adding an operator strictness policy", async () => {
+    const scheduled = `${fixture}\nschedule: '0 * * * *'\n`;
+    const opts = { mode: "off" as const, publicUrl: "http://localhost:34000", hostPort: 34000, projectName: "tls-strict-test" };
+    expect((await compileDockerTls(scheduled, opts)).warnings.join(" ")).toContain("schedule");
+  });
+
+  test("does not emit a partial app when a sibling's mandatory host capability is refused", async () => {
+    const source = `name: partial\ncomponents:\n  web:\n    image: nginx\n    provides:\n      - name: web\n        protocol: http\n        port: 80\n        exposed: true\n  worker:\n    image: alpine\n    requires:\n      - host: { network: host }\n`;
+    await expect(compileDockerTls(source, {
+      mode: "off", publicUrl: "http://localhost:34000", hostPort: 34000, projectName: "tls-required-host-test",
+    })).rejects.toThrow(/cannot emit a partial application/);
+  });
+
+  test("retains the existing required-environment failure floor", async () => {
+    const source = `name: required-env\nimage: nginx\nprovides:\n  - name: web\n    protocol: http\n    port: 80\n    exposed: true\nenv:\n  API_TOKEN: { required: true, sensitive: true }\n`;
+    await expect(compileDockerTls(source, {
+      mode: "off", publicUrl: "http://localhost:34000", hostPort: 34000, projectName: "tls-required-env-test",
+    })).rejects.toThrow(/unsatisfied environment/);
+  });
+});
+
+describe("certificate delivery and authenticated probes", () => {
+  let directory: string;
+  let certificates: Awaited<ReturnType<typeof createCertificates>>;
+  beforeAll(async () => {
+    directory = await mkdtemp(join(tmpdir(), "tls-prototype-$literal-"));
+    certificates = await createCertificates(directory);
+  }, 30_000);
+  afterAll(async () => {
+    if (!directory) return;
+    for (const file of await readdir(directory)) await unlink(join(directory, file));
+    await rmdir(directory);
+  });
+
+  test("native selection mounts read-only material, escapes Compose interpolation and authenticates probe", async () => {
+    const result = await compileDockerTls(fixture, {
+      mode: "native", publicUrl: "https://localhost:34000", hostPort: 34000, projectName: "tls-material-test",
+      certificates: { "server-cert": certificates.backend },
+    });
+    const service = parse(result.compose).services[result.service];
+    const mounts = service.volumes.filter((volume: unknown) => typeof volume === "object");
+    expect(mounts).toHaveLength(3);
+    expect(mounts.every((volume: { source: string; read_only: boolean }) => volume.source.includes("$$literal") && volume.read_only)).toBe(true);
+    expect(service.environment.GITEA__server__PROTOCOL).toBe("https");
+    expect(service.environment.GITEA__server__HTTP_PORT).toBe("3000");
+    expect(service.healthcheck.test[1]).toContain("--cacert");
+    expect(service.healthcheck.test[1]).toContain("--resolve 'localhost:3000:127.0.0.1'");
+    expect(service.healthcheck.test[1]).toContain("https://localhost:3000/api/healthz");
+    expect(service.healthcheck.test[1]).not.toMatch(/--insecure| -k /);
+  });
+
+  test("rejects certificate/private-key mismatch", async () => {
+    await expect(validateCertificate({ ...certificates.backend, keyFile: certificates.edge.keyFile }, "localhost")).rejects.toThrow("Invalid certificate/private key pair");
+  });
+  test("rejects a leaf signed by a different CA", async () => {
+    await expect(validateCertificate({ ...certificates.backend, caFile: certificates.wrongCaFile }, "localhost")).rejects.toThrow("not signed");
+  });
+  test("rejects a trusted certificate for the wrong hostname", async () => {
+    await expect(validateCertificate(certificates.wrongHost, "localhost")).rejects.toThrow("does not authenticate");
+  });
+  test("rejects a correctly signed and named certificate restricted to TLS client use", async () => {
+    await expect(validateCertificate(certificates.clientOnly, "localhost")).rejects.toThrow("TLS server certificate verification failed");
+  });
+});

--- a/packages/native-tls-prototype/src/__tests__/docker.test.ts
+++ b/packages/native-tls-prototype/src/__tests__/docker.test.ts
@@ -3,7 +3,10 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { parse } from "yaml";
-import { compileDockerTls, validateCertificate } from "../docker.js";
+import { compileDockerTls } from "../docker.js";
+import { validateCertificate } from "../certificate-verification.js";
+import { redactSecrets } from "@launchfile/docker";
+import { isCredentialProperty, registerBindingProperties } from "../redaction.js";
 import { createCertificates } from "../../scripts/certificates.js";
 
 const fixture = await readFile(new URL("../../examples/gitea/Launchfile", import.meta.url), "utf8");
@@ -33,11 +36,34 @@ describe("existing Docker provider integration", () => {
     expect(result.plan.resources).toEqual({});
   });
 
-  test("native mode refuses nonexistent material before generating artifacts", async () => {
-    await expect(compileDockerTls(fixture, {
+  test("native compilation accepts supplied paths without inspecting existence or certificate contents", async () => {
+    const result = await compileDockerTls(fixture, {
       mode: "native", publicUrl: "https://localhost:34000", hostPort: 34000, projectName: "tls-native-test",
       certificates: { "server-cert": { certFile: "/nonexistent/cert", keyFile: "/nonexistent/key", caFile: "/nonexistent/ca" } },
-    })).rejects.toThrow();
+    });
+    expect(result.plan.protocol).toBe("https");
+    expect(result.compose).toContain("/nonexistent/cert");
+    expect(redactSecrets("missing /nonexistent/key")).toBe("missing [REDACTED]");
+    expect(result.warnings.join(" ")).not.toContain("/nonexistent/key");
+  });
+
+  test.each(["certFile", "keyFile", "caFile"])("refuses an unsupplied %s without inspecting other paths", async (field) => {
+    await expect(compileDockerTls(fixture, {
+      mode: "native", publicUrl: "https://localhost:34000", hostPort: 34000, projectName: "tls-missing-test",
+      certificates: { "server-cert": { certFile: "/not-read/cert", keyFile: "/not-read/key", caFile: "/not-read/ca", [field]: "" } },
+    })).rejects.toThrow(`Certificate binding server-cert.${field} requires an absolute file path`);
+  });
+
+  test("registered key vocabulary cannot disable redaction of supplied values", () => {
+    const properties = { key_file: "/private/key-sentinel", signing_key: "private-material-sentinel", client_key_file: "/private/client-sentinel" };
+    const vocabulary = Object.keys(properties);
+    registerBindingProperties(properties, vocabulary);
+    for (const [name, value] of Object.entries(properties)) {
+      expect(isCredentialProperty(name, vocabulary)).toBe(true);
+      expect(redactSecrets(`diagnostic: ${value}`)).toBe("diagnostic: [REDACTED]");
+    }
+    expect(isCredentialProperty("cert_file", ["cert_file"])).toBe(false);
+    expect(isCredentialProperty("unknown_extension", [])).toBe(true);
   });
 
   test("preserves provider warnings without adding an operator strictness policy", async () => {

--- a/packages/native-tls-prototype/src/__tests__/planner.test.ts
+++ b/packages/native-tls-prototype/src/__tests__/planner.test.ts
@@ -1,0 +1,348 @@
+import { readLaunch, resolveExpression } from "@launchfile/sdk";
+import { describe, expect, it } from "vitest";
+import { stringify } from "yaml";
+import { planTls, type CertificateInput, type TlsMode, type TlsOptions } from "../planner.js";
+
+const material: CertificateInput = {
+	certFile: "/run/launchfile/server.crt",
+	keyFile: "/run/launchfile/server.key",
+	caFile: "/run/launchfile/ca.crt",
+};
+
+function document() {
+	return {
+		name: "gitea",
+		image: "gitea/gitea:latest",
+		provides: [
+			{ name: "web", protocol: "http", port: 3000, exposed: true, tls: "server-cert" as unknown },
+		],
+		supports: [{
+			name: "server-cert", type: "certificate",
+			set_env: { PROTOCOL: "https", CERT: "$cert_file", KEY: "$key_file", HTTP_PORT: "$port" },
+		}],
+		env: { PROTOCOL: "http", ROOT_URL: "$app.url" },
+		health: "/api/healthz",
+	};
+}
+
+function options(mode: TlsMode = "native", extra: Partial<TlsOptions> = {}): TlsOptions {
+	return { mode, publicUrl: `${mode === "off" ? "http" : "https"}://gitea.example.test`,
+		certificates: { "server-cert": material }, ...extra };
+}
+
+describe("TLS plans", () => {
+	it.each([
+		["off", "http", false], ["edge", "http", false], ["native", "https", true],
+		["passthrough", "https", true], ["reencrypt", "https", true],
+	] as const)("%s selects the correct app listener and certificate wiring", (mode, protocol, active) => {
+		const plan = planTls(stringify(document()), options(mode));
+		expect(plan).toMatchObject({ mode, protocol, port: 3000, component: "default", endpoint: "web" });
+		expect(plan.launch.components.default!.provides).toEqual([
+			{ name: "web", protocol, port: 3000, exposed: true },
+		]);
+		expect(plan.certificate).toBe(active ? "server-cert" : undefined);
+		const component = plan.launch.components.default!;
+		const effective = Object.fromEntries(Object.entries(component.env!).map(([key, value]) => [key, value.default]));
+		for (const dependency of component.supports ?? []) {
+			for (const [key, value] of Object.entries(dependency.set_env ?? {})) {
+				effective[key] = resolveExpression(value, { resource: plan.resources[dependency.name!]!.properties });
+			}
+		}
+		expect(effective.PROTOCOL).toBe(active ? "https" : "http");
+		expect(effective.CERT).toBe(active ? material.certFile : undefined);
+		expect(effective.HTTP_PORT).toBe(active ? "3000" : undefined);
+		expect(component.health).toEqual(readLaunch(stringify(document())).components.default!.health);
+		expect(plan.resources).toEqual(active ? { "server-cert": { properties: {
+			cert_file: material.certFile, key_file: material.keyFile, ca_file: material.caFile, port: "3000",
+		} } } : {});
+	});
+
+	it("preserves an ordinary HTTP Launchfile and unrelated optional resources", () => {
+		const source = `name: ordinary\nimage: nginx\nprovides:\n  - protocol: http\n    port: 80\n    exposed: true\nsupports:\n  - redis\nhealth: /\n`;
+		const plan = planTls(source, options("off"));
+		expect(plan.launch).toEqual(readLaunch(source));
+		expect(plan.endpoint).toBe("80");
+	});
+
+	it("does not activate or inspect unused certificate material in HTTP modes", () => {
+		const plan = planTls(stringify(document()), options("edge", {
+			certificates: { "server-cert": { certFile: "invalid", keyFile: "", caFile: "" } },
+		}));
+		expect(plan.protocol).toBe("http");
+		expect(plan.resources).toEqual({});
+		expect(plan.launch.components.default!.supports).toEqual([]);
+	});
+
+	it("changes the endpoint and supplied port together without adding a second listener", () => {
+		const app = document();
+		app.provides[0]!.tls = { certificate: "server-cert", port: 3443 };
+		const plan = planTls(stringify(app), options());
+		expect(plan.port).toBe(3443);
+		expect(plan.launch.components.default!.provides).toHaveLength(1);
+		expect(plan.launch.components.default!.provides![0]!.port).toBe(3443);
+		expect(plan.resources["server-cert"]!.properties.port).toBe("3443");
+		expect(planTls(stringify(app), options("off")).port).toBe(3000);
+	});
+
+	it("supports unnamed legacy endpoints with a consistent resolved identifier", () => {
+		const app = document();
+		const { name: _name, ...endpoint } = app.provides[0]!;
+		const plan = planTls(stringify({ ...app, provides: [{ ...endpoint, tls: { certificate: "server-cert", port: 3443 } }] }), options());
+		expect(plan.endpoint).toBe("3443");
+	});
+
+	it("keeps unrelated endpoints unchanged", () => {
+		const app = document();
+		const other = { name: "ssh", protocol: "tcp", port: 22, exposed: true };
+		const plan = planTls(stringify({ ...app, provides: [...app.provides, other] }), options());
+		expect(plan.launch.components.default!.provides![1]).toEqual(other);
+	});
+
+	it("normalizes a public URL while retaining a deployment subpath", () => {
+		expect(planTls(stringify(document()), options("native", { publicUrl: "https://GITEA.example.test:443/" })).publicUrl)
+			.toBe("https://gitea.example.test");
+		expect(planTls(stringify(document()), options("native", { publicUrl: "https://gitea.example.test/git/" })).publicUrl)
+			.toBe("https://gitea.example.test/git/");
+	});
+
+	it("does not mutate caller options and can compile the same document back to HTTP", () => {
+		const input = Object.freeze({ mode: "native" as const, publicUrl: "https://gitea.example.test",
+			certificates: Object.freeze({ "server-cert": Object.freeze({ ...material }) }) });
+		const source = stringify(document());
+		const plan = planTls(source, input);
+		plan.resources["server-cert"]!.properties.cert_file = "/elsewhere";
+		plan.warnings.push("changed");
+		expect(input.certificates["server-cert"].certFile).toBe(material.certFile);
+		expect(planTls(source, input).warnings).toEqual([]);
+		expect(planTls(source, options("off")).protocol).toBe("http");
+	});
+});
+
+describe("fail closed before legacy normalization", () => {
+	it.each([true, null, [], {}, { certificate: "server-cert", verify: false },
+		{ certificate: "server-cert", port: 0 }, { certificate: "server-cert", port: 65536 },
+		{ certificate: "server-cert", port: 3.5 }, { certificate: "server-cert", port: "3443" },
+		{ certificate: "server-cert", ports: [3443] }])("rejects unsupported TLS syntax %j", (tls) => {
+		const app = document(); app.provides[0]!.tls = tls;
+		expect(() => planTls(stringify(app), options("off"))).toThrow();
+	});
+
+	it.each(["root", "component"])("rejects %s variants explicitly", (scope) => {
+		const app = document();
+		const source = scope === "root" ? { ...app, variants: {} }
+			: { name: app.name, components: { app: { ...app, variants: {} } } };
+		expect(() => planTls(stringify(source), options())).toThrow(/variants.*separate proposal/);
+	});
+
+	it.each(["tls", "public"])("rejects misplaced %s on a component", (field) => {
+		expect(() => planTls(stringify({ ...document(), [field]: {} }), options())).toThrow(/belongs/);
+	});
+
+	it.each(["tcp", "udp", "grpc", "ws"])("refuses extending %s through this HTTP TLS shorthand", (protocol) => {
+		const app = document(); app.provides[0]!.protocol = protocol;
+		expect(() => planTls(stringify(app), options())).toThrow(/only HTTP\/HTTPS/);
+	});
+
+	it.each(["missing", "wrong-type", "duplicate"])("rejects a %s certificate dependency even in HTTP mode", (kind) => {
+		const app = document();
+		if (kind === "missing") app.supports = [];
+		if (kind === "wrong-type") app.supports[0]!.type = "postgres";
+		if (kind === "duplicate") app.supports.push({ ...app.supports[0]! });
+		expect(() => planTls(stringify(app), options("off"))).toThrow(/exactly one certificate dependency/);
+	});
+
+	it.each(["requires", "supports"])("refuses separate public contracts in %s before SDK normalization", (field) => {
+		expect(() => planTls(stringify({ ...document(), [field]: [{ public: { endpoint: "web", scheme: "https" } }] }), options("edge")))
+			.toThrow(/Public HTTPS requirements are a separate prototype/);
+	});
+
+	it("rejects TLS defaults that the SDK would ignore in multi-component files", () => {
+		expect(() => planTls(stringify({ ...document(), components: { app: document() } }), options()))
+			.toThrow(/not inherited/);
+	});
+
+	it("checks a dangling binding on an endpoint that was not selected", () => {
+		const app = document();
+		app.provides.push({ name: "admin", protocol: "http", port: 3001, exposed: false, tls: "absent" });
+		expect(() => planTls(stringify(app), options())).toThrow(/admin.tls.*absent/);
+	});
+});
+
+describe("explicit deployment contracts", () => {
+	it.each(["off", "edge"] as const)("a required certificate rejects %s", (mode) => {
+		const { supports, ...app } = document();
+		expect(() => planTls(stringify({ ...app, requires: supports }), options(mode)))
+			.toThrow(/requires native TLS certificate/);
+		expect(planTls(stringify({ ...app, requires: supports }), options()).launch.components.default!.requires)
+			.toHaveLength(1);
+	});
+
+	it("rejects an unsupported explicit provider mode without operator strictness", () => {
+		expect(() => planTls(stringify(document()), options("reencrypt", { supportedModes: ["off", "edge"] })))
+			.toThrow(/does not support explicitly selected/);
+	});
+
+	it("refuses policy options belonging to the strictness RFC", () => {
+		expect(() => planTls(stringify(document()), { ...options(), strict: true } as TlsOptions)).toThrow(/Operator strictness is a separate prototype/);
+	});
+
+	it.each(["native", "passthrough", "reencrypt"] as const)("%s refuses missing material instead of falling back to HTTP", (mode) => {
+		expect(() => planTls(stringify(document()), options(mode, { certificates: {} }))).toThrow(/supplied certificate material/);
+	});
+
+	it.each(["certFile", "keyFile", "caFile"] as const)("requires an absolute %s container path", (key) => {
+		for (const value of ["", "relative.pem", "/", "/cert/../key.pem", "/cert/./key.pem", "/cert/key\n.pem"]) {
+			expect(() => planTls(stringify(document()), options("native", {
+				certificates: { "server-cert": { ...material, [key]: value } },
+			}))).toThrow(new RegExp(key));
+		}
+	});
+
+	it.each(["http://gitea.example.test", "https://user:secret@gitea.example.test", "https://gitea.example.test?q=1",
+		"https://gitea.example.test#fragment", "file:///tmp/app", "https:gitea.example.test", "not a url"])
+	("rejects invalid or inconsistent native public URL %s", (publicUrl) => {
+		expect(() => planTls(stringify(document()), options("native", { publicUrl }))).toThrow(/publicUrl/);
+	});
+
+	it("rejects HTTPS public URL in off mode", () => {
+		expect(() => planTls(stringify(document()), options("off", { publicUrl: "https://gitea.example.test" })))
+			.toThrow(/requires an http/);
+	});
+
+	it("refuses native mode when an app has no native TLS binding", () => {
+		const app = document();
+		const { tls: _tls, ...web } = app.provides[0]!;
+		expect(() => planTls(stringify({ ...app, provides: [web] }), options())).toThrow(/does not declare native TLS/);
+	});
+
+	it("cannot infer an HTTP configuration from an HTTPS base listener", () => {
+		const app = document(); app.provides[0]!.protocol = "https";
+		expect(() => planTls(stringify(app), options("edge"))).toThrow(/cannot downgrade/);
+		expect(planTls(stringify(app), options()).protocol).toBe("https");
+	});
+
+	it("refuses a port replacement that collides with another listener", () => {
+		const app = document(); app.provides[0]!.tls = { certificate: "server-cert", port: 3443 };
+		const source = stringify({ ...app, provides: [...app.provides, { name: "metrics", protocol: "http", port: 3443 }] });
+		expect(() => planTls(source, options())).toThrow(/conflicts.*port 3443/);
+	});
+
+	it("refuses conflicting certificate and backing-service environment wiring", () => {
+		const source = stringify({ ...document(), requires: [{ type: "postgres", set_env: { PROTOCOL: "postgres" } }] });
+		expect(() => planTls(source, options())).toThrow(/conflicting set_env wiring/);
+	});
+
+	it("refuses misspelled certificate resource properties", () => {
+		const app = document(); app.supports[0]!.set_env.CERT = "$cert_fil";
+		expect(() => planTls(stringify(app), options())).toThrow(/unknown certificate property cert_fil/);
+	});
+
+	it("does not silently empty an inactive certificate reference outside conditional wiring", () => {
+		const app = document();
+		const source = stringify({ ...app, env: { ...app.env, CERT: "$server-cert.cert_file" } });
+		expect(() => planTls(source, options("off"))).toThrow(/references inactive certificate/);
+	});
+
+	it("checks named certificate properties referenced from ordinary environment variables", () => {
+		const app = document();
+		const source = stringify({ ...app, env: { ...app.env, CERT: "$server-cert.cert_fil" } });
+		expect(() => planTls(source, options())).toThrow(/unknown certificate property cert_fil/);
+	});
+});
+
+describe("endpoint and component scope", () => {
+	function multi() {
+		const app = document();
+		return { name: "multi", components: {
+			api: { image: "api", provides: [{ name: "web", protocol: "http", port: 8080, exposed: true }] },
+			gitea: { ...app, env: { PROTOCOL: "http" } },
+		} };
+	}
+
+	it("requires qualification when a selector is ambiguous", () => {
+		const source = stringify(multi());
+		expect(() => planTls(source, options())).toThrow(/not unambiguous/);
+		expect(() => planTls(source, options("native", { endpoint: "web" }))).toThrow(/ambiguous/);
+		const plan = planTls(source, options("native", { endpoint: "gitea.web" }));
+		expect(plan.component).toBe("gitea");
+		expect(plan.launch.components.api!.provides![0]!.protocol).toBe("http");
+	});
+
+	it("refuses unknown and unexposed endpoints", () => {
+		const app = document(); app.provides[0]!.exposed = false;
+		expect(() => planTls(stringify(document()), options("native", { endpoint: "nope" }))).toThrow(/does not exist/);
+		expect(() => planTls(stringify(app), options("native", { endpoint: "web" }))).toThrow(/must be exposed/);
+	});
+
+	it("does not repurpose $app for a selected secondary endpoint", () => {
+		const app = multi();
+		const source = stringify({ ...app, components: { ...app.components, gitea: document() } });
+		expect(() => planTls(source, options("native", { endpoint: "gitea.web" }))).toThrow(/primary \$app publication context/);
+	});
+
+	it("refuses native activation when two endpoints share one certificate", () => {
+		const app = document();
+		app.provides.push({ name: "admin", protocol: "http", port: 3001, exposed: false, tls: "server-cert" });
+		expect(() => planTls(stringify(app), options())).toThrow(/shared by multiple endpoints/);
+		expect(planTls(stringify(app), options("off")).protocol).toBe("http");
+	});
+
+	it("refuses cross-component collisions in the provider's global resource map", () => {
+		const app = multi();
+		const source = stringify({ ...app, components: { ...app.components,
+			api: { ...app.components.api, requires: [{ name: "server-cert", type: "postgres" }] },
+		} });
+		expect(() => planTls(source, options("native", { endpoint: "gitea.web" }))).toThrow(/collides with another resource/);
+	});
+
+	it("does not lose an aliased TLS declaration while sanitizing another component", () => {
+		const source = `name: aliases\ncomponents:\n  first: &app\n    image: gitea/gitea:latest\n    provides:\n      - name: web\n        protocol: http\n        port: 3000\n        exposed: true\n        tls: server-cert\n    supports:\n      - name: server-cert\n        type: certificate\n  second: *app\n`;
+		expect(() => planTls(source, options("native", { endpoint: "second.web" }))).toThrow(/shared by multiple endpoints/);
+	});
+
+	it.each(["native", "passthrough", "reencrypt"] as const)("rejects canonical Docker sibling HTTP URL wiring in %s mode", (mode) => {
+		for (const reference of ["$components.backend.url", "$components.backend.web.url",
+			"origin=${components.backend.url}", "${components.backend.web.url:-https://fallback.example.test}",
+			"${components.backend.url|base64}"]) {
+			const source = stringify({ name: "siblings", components: {
+				backend: document(), worker: { image: "alpine", env: { ORIGIN: reference } },
+			} });
+			expect(() => planTls(source, options(mode))).toThrow(/canonical Docker sibling URL transport is not supported/);
+		}
+	});
+
+	it("also checks sibling URL references in dependency set_env", () => {
+		const source = stringify({ name: "siblings", components: {
+			backend: document(), worker: { image: "alpine", requires: [
+				{ type: "redis", set_env: { ORIGIN: "$components.backend.web.url" } },
+			] },
+		} });
+		expect(() => planTls(source, options())).toThrow(/worker.set_env.ORIGIN.*canonical Docker sibling URL transport/);
+	});
+
+	it.each(["off", "edge"] as const)("preserves sibling URL references when %s leaves the app on HTTP", (mode) => {
+		const reference = "$components.backend.web.url";
+		const source = stringify({ name: "siblings", components: {
+			backend: document(), worker: { image: "alpine", env: { ORIGIN: reference }, requires: [
+				{ type: "redis", set_env: { CALLBACK: "$components.backend.url" } },
+			] },
+		} });
+		const plan = planTls(source, options(mode));
+		expect(plan.launch.components.worker!.env!.ORIGIN!.default).toBe(reference);
+		expect(plan.launch.components.worker!.requires![0]!.set_env!.CALLBACK).toBe("$components.backend.url");
+	});
+
+	it("preserves unrelated sibling references and escaped dollar literals in native mode", () => {
+		const env = {
+			OTHER: "$components.worker.url", HOST: "$components.backend.host", PORT: "$components.backend.port",
+			LITERAL: "$$components.backend.url",
+		};
+		const source = stringify({ name: "siblings", components: {
+			backend: document(), worker: { image: "alpine", env, provides: [{ protocol: "http", port: 8080 }] },
+		} });
+		const plan = planTls(source, options());
+		expect(plan.launch.components.worker!.env).toEqual(Object.fromEntries(
+			Object.entries(env).map(([key, value]) => [key, { default: value }]),
+		));
+	});
+});

--- a/packages/native-tls-prototype/src/__tests__/planner.test.ts
+++ b/packages/native-tls-prototype/src/__tests__/planner.test.ts
@@ -18,7 +18,7 @@ function document() {
 		],
 		supports: [{
 			name: "server-cert", type: "certificate",
-			set_env: { PROTOCOL: "https", CERT: "$cert_file", KEY: "$key_file", HTTP_PORT: "$port" },
+			set_env: { PROTOCOL: "https", CERT: "$cert_file", KEY: "$key_file", HTTP_PORT: "$listener.port" },
 		}],
 		env: { PROTOCOL: "http", ROOT_URL: "$app.url" },
 		health: "/api/healthz",
@@ -53,7 +53,7 @@ describe("TLS plans", () => {
 		expect(effective.HTTP_PORT).toBe(active ? "3000" : undefined);
 		expect(component.health).toEqual(readLaunch(stringify(document())).components.default!.health);
 		expect(plan.resources).toEqual(active ? { "server-cert": { properties: {
-			cert_file: material.certFile, key_file: material.keyFile, ca_file: material.caFile, port: "3000",
+			cert_file: material.certFile, key_file: material.keyFile,
 		} } } : {});
 	});
 
@@ -80,7 +80,8 @@ describe("TLS plans", () => {
 		expect(plan.port).toBe(3443);
 		expect(plan.launch.components.default!.provides).toHaveLength(1);
 		expect(plan.launch.components.default!.provides![0]!.port).toBe(3443);
-		expect(plan.resources["server-cert"]!.properties.port).toBe("3443");
+		expect(plan.launch.components.default!.supports![0]!.set_env!.HTTP_PORT).toBe("3443");
+		expect(plan.resources["server-cert"]!.properties).not.toHaveProperty("port");
 		expect(planTls(stringify(app), options("off")).port).toBe(3000);
 	});
 
@@ -169,6 +170,43 @@ describe("fail closed before legacy normalization", () => {
 });
 
 describe("explicit deployment contracts", () => {
+	it.each(["native", "off"] as const)("rejects legacy overloaded $port even when %s is selected", (mode) => {
+		const app = document(); app.supports[0]!.set_env.HTTP_PORT = "$port";
+		expect(() => planTls(stringify(app), options(mode))).toThrow(/\$port belongs to the resource; use \$listener.port/);
+	});
+
+	it.each(["$listener.host", "$listener.port.extra", "$listener"])("refuses unsupported listener reference %s", (reference) => {
+		const app = document(); app.supports[0]!.set_env.HTTP_PORT = reference;
+		expect(() => planTls(stringify(app), options("off"))).toThrow(/valid only inside/);
+	});
+
+	it.each(["native", "off"] as const)("refuses the listener namespace in ordinary env in %s mode", (mode) => {
+		const app = document();
+		const source = stringify({ ...app, env: { ...app.env, PORT: "$listener.port" } });
+		expect(() => planTls(source, options(mode))).toThrow(/valid only inside/);
+	});
+
+	it("does not let another resource borrow the certificate's listener namespace", () => {
+		const source = stringify({ ...document(), requires: [{ type: "redis", set_env: { REDIS_PORT: "$listener.port" } }] });
+		expect(() => planTls(source, options())).toThrow(/valid only inside/);
+	});
+
+	it("resolves the listener namespace while preserving ordinary resource references, transforms, and escaped dollars", () => {
+		const app = document();
+		app.provides[0]!.tls = { certificate: "server-cert", port: 3443 };
+		app.supports[0]!.set_env.HTTP_PORT = "$$literal:${listener.port}:${cert_file}:${listener.port|base64}";
+		const plan = planTls(stringify(app), options());
+		const value = plan.launch.components.default!.supports![0]!.set_env!.HTTP_PORT!;
+		expect(resolveExpression(value, { resource: plan.resources["server-cert"]!.properties }))
+			.toBe(`$literal:3443:${material.certFile}:${Buffer.from("3443", "hex").toString("base64")}`);
+	});
+
+	it("keeps $port as the ordinary backing resource port", () => {
+		const source = stringify({ ...document(), requires: [{ type: "postgres", set_env: { PG_PORT: "$port" } }] });
+		const plan = planTls(source, options());
+		expect(plan.launch.components.default!.requires![0]!.set_env!.PG_PORT).toBe("$port");
+	});
+
 	it.each(["off", "edge"] as const)("a required certificate rejects %s", (mode) => {
 		const { supports, ...app } = document();
 		expect(() => planTls(stringify({ ...app, requires: supports }), options(mode)))
@@ -212,7 +250,7 @@ describe("explicit deployment contracts", () => {
 	it("refuses native mode when an app has no native TLS binding", () => {
 		const app = document();
 		const { tls: _tls, ...web } = app.provides[0]!;
-		expect(() => planTls(stringify({ ...app, provides: [web] }), options())).toThrow(/does not declare native TLS/);
+		expect(() => planTls(stringify({ ...app, provides: [web], supports: [] }), options())).toThrow(/does not declare native TLS/);
 	});
 
 	it("cannot infer an HTTP configuration from an HTTPS base listener", () => {
@@ -284,7 +322,7 @@ describe("endpoint and component scope", () => {
 		const app = document();
 		app.provides.push({ name: "admin", protocol: "http", port: 3001, exposed: false, tls: "server-cert" });
 		expect(() => planTls(stringify(app), options())).toThrow(/shared by multiple endpoints/);
-		expect(planTls(stringify(app), options("off")).protocol).toBe("http");
+		expect(() => planTls(stringify(app), options("off"))).toThrow(/shared by multiple endpoints/);
 	});
 
 	it("refuses cross-component collisions in the provider's global resource map", () => {

--- a/packages/native-tls-prototype/src/certificate-verification.ts
+++ b/packages/native-tls-prototype/src/certificate-verification.ts
@@ -1,0 +1,61 @@
+import { createPrivateKey, X509Certificate } from "node:crypto";
+import { execFile } from "node:child_process";
+import { readFile, stat } from "node:fs/promises";
+import { isIP } from "node:net";
+import { isAbsolute } from "node:path";
+import { promisify } from "node:util";
+import type { CertificateInput } from "./planner.js";
+
+const execute = promisify(execFile);
+
+async function readMaterial(path: string): Promise<string> {
+  if (!isAbsolute(path)) throw new Error("Certificate material paths must be absolute");
+  try {
+    const metadata = await stat(path);
+    if (!metadata.isFile() || metadata.size > 1_048_576) throw new Error("invalid file");
+    return await readFile(path, "utf8");
+  } catch {
+    throw new Error("Cannot read certificate material: require regular files smaller than 1 MiB");
+  }
+}
+
+/** Optional supplying-consumer preflight, never called by the provider compiler.
+ * This proof helper supports one root CA and one directly signed leaf. */
+export async function validateCertificate(input: CertificateInput, serverName: string): Promise<void> {
+  const [certPem, keyPem, caPem] = await Promise.all([
+    readMaterial(input.certFile), readMaterial(input.keyFile), readMaterial(input.caFile),
+  ]);
+  if ((certPem.match(/BEGIN CERTIFICATE/g) ?? []).length !== 1 ||
+      (caPem.match(/BEGIN CERTIFICATE/g) ?? []).length !== 1) {
+    throw new Error("Prototype certificate validation supports one leaf and one root CA, without intermediates");
+  }
+  let leaf: X509Certificate;
+  let ca: X509Certificate;
+  try {
+    leaf = new X509Certificate(certPem);
+    ca = new X509Certificate(caPem);
+    if (!leaf.checkPrivateKey(createPrivateKey(keyPem))) throw new Error("mismatch");
+  } catch {
+    throw new Error("Invalid certificate/private key pair");
+  }
+  const now = Date.now();
+  for (const cert of [leaf, ca]) {
+    if (Date.parse(cert.validFrom) > now || Date.parse(cert.validTo) <= now) {
+      throw new Error("Certificate is expired or not yet valid");
+    }
+  }
+  if (!ca.ca || !leaf.checkIssued(ca) || !leaf.verify(ca.publicKey)) {
+    throw new Error("Certificate is not signed by the supplied trust root");
+  }
+  if (!(isIP(serverName) ? leaf.checkIP(serverName) : leaf.checkHost(serverName))) {
+    throw new Error(`Certificate does not authenticate server name ${serverName}`);
+  }
+  // A valid signature and hostname do not authorize server use: a client-only
+  // leaf can pass both. Delegate purpose/key-usage checks to the TLS verifier.
+  try {
+    await execute("openssl", ["verify", "-purpose", "sslserver", "-CAfile", input.caFile, input.certFile],
+      { timeout: 10_000, maxBuffer: 64 * 1024 });
+  } catch {
+    throw new Error("TLS server certificate verification failed; check certificate purpose and OpenSSL availability");
+  }
+}

--- a/packages/native-tls-prototype/src/cli.ts
+++ b/packages/native-tls-prototype/src/cli.ts
@@ -1,0 +1,88 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { parseArgs } from "node:util";
+import { compileDockerTls } from "./docker.js";
+import { planTls, type CertificateInput, type TlsMode } from "./planner.js";
+
+const help = `Experimental Launchfile native TLS planner (RFC #445)
+
+bun run plan <Launchfile> --tls=<mode> --url=<public URL>
+
+Modes: off, edge, native, passthrough, reencrypt
+
+  --endpoint <name>       Select a named endpoint (component.name if needed)
+  --cert <path>           PEM server certificate
+  --key <path>            PEM private key
+  --ca <path>             PEM issuing root CA (prototype: no intermediates)
+  --resource <name>       Certificate resource name (default server-cert)
+  --host-port <port>      Loopback host port for Compose output (default 33000)
+  --compose-file <path>   Write an isolated Compose file; validates certificates
+  --json                 Machine-readable plan summary
+
+This planner does not start containers or configure public routing.
+Run bun run prove for the isolated real-Gitea proof and automatic teardown.
+`;
+
+async function main(): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args: process.argv.slice(2), allowPositionals: true, strict: true,
+    options: {
+      tls: { type: "string", default: "off" },
+      url: { type: "string", default: "http://localhost:33000" },
+      endpoint: { type: "string" },
+      cert: { type: "string" }, key: { type: "string" }, ca: { type: "string" },
+      resource: { type: "string", default: "server-cert" },
+      "host-port": { type: "string", default: "33000" },
+      "compose-file": { type: "string" },
+      json: { type: "boolean", default: false },
+      help: { type: "boolean", short: "h", default: false },
+    },
+  });
+  if (values.help) { console.log(help); return; }
+  if (positionals.length !== 1) throw new Error("Supply one Launchfile path. Use --help for examples.");
+  const modes: TlsMode[] = ["off", "edge", "native", "passthrough", "reencrypt"];
+  if (!modes.includes(values.tls as TlsMode)) throw new Error(`Unsupported TLS mode: ${values.tls}`);
+  const suppliedPaths = [values.cert, values.key, values.ca].filter(Boolean);
+  if (suppliedPaths.length !== 0 && suppliedPaths.length !== 3) throw new Error("Supply --cert, --key, and --ca together");
+  const certificates: Record<string, CertificateInput> = {};
+  if (values.cert && values.key && values.ca) {
+    certificates[values.resource] = { certFile: resolve(values.cert), keyFile: resolve(values.key), caFile: resolve(values.ca) };
+  }
+  const source = await readFile(resolve(positionals[0]!), "utf8");
+  const options = {
+    mode: values.tls as TlsMode, publicUrl: values.url,
+    endpoint: values.endpoint, certificates,
+  };
+  const compiled = values["compose-file"]
+    ? await compileDockerTls(source, { ...options, hostPort: Number(values["host-port"]), projectName: "launchfile-tls-preview" })
+    : undefined;
+  const plan = compiled?.plan ?? planTls(source, options);
+  const summary = {
+    experimental: true,
+    mode: plan.mode,
+    publicUrl: plan.publicUrl,
+    endpoint: `${plan.component}.${plan.endpoint}`,
+    listener: `${plan.protocol}:${plan.port}`,
+    certificate: plan.certificate ?? null,
+    warnings: compiled?.warnings ?? plan.warnings,
+    status: compiled ? "compiled; deployment not executed" : "planned; material and routing not verified",
+  };
+  if (compiled && values["compose-file"]) {
+    await writeFile(resolve(values["compose-file"]), compiled.compose, { mode: 0o600, flag: "wx" });
+  }
+  if (values.json) console.log(JSON.stringify(summary, null, 2));
+  else {
+    console.log(`Experimental plan: ${summary.mode}`);
+    console.log(`  Public URL:  ${summary.publicUrl}`);
+    console.log(`  Endpoint:    ${summary.endpoint}`);
+    console.log(`  App listens: ${summary.listener}`);
+    console.log(`  Certificate: ${summary.certificate ?? "not activated"}`);
+    for (const warning of summary.warnings) console.log(`  Gap: ${warning}`);
+    console.log(`  ${summary.status}`);
+  }
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : "TLS planning failed");
+  process.exitCode = 1;
+});

--- a/packages/native-tls-prototype/src/cli.ts
+++ b/packages/native-tls-prototype/src/cli.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { parseArgs } from "node:util";
+import { redactSecrets, registerDeclaredSecret } from "@launchfile/docker";
 import { compileDockerTls } from "./docker.js";
 import { planTls, type CertificateInput, type TlsMode } from "./planner.js";
 
@@ -16,7 +17,7 @@ Modes: off, edge, native, passthrough, reencrypt
   --ca <path>             PEM issuing root CA (prototype: no intermediates)
   --resource <name>       Certificate resource name (default server-cert)
   --host-port <port>      Loopback host port for Compose output (default 33000)
-  --compose-file <path>   Write an isolated Compose file; validates certificates
+  --compose-file <path>   Write an isolated Compose file; does not inspect material
   --json                 Machine-readable plan summary
 
 This planner does not start containers or configure public routing.
@@ -47,6 +48,7 @@ async function main(): Promise<void> {
   const certificates: Record<string, CertificateInput> = {};
   if (values.cert && values.key && values.ca) {
     certificates[values.resource] = { certFile: resolve(values.cert), keyFile: resolve(values.key), caFile: resolve(values.ca) };
+    registerDeclaredSecret(certificates[values.resource]!.keyFile);
   }
   const source = await readFile(resolve(positionals[0]!), "utf8");
   const options = {
@@ -65,7 +67,7 @@ async function main(): Promise<void> {
     listener: `${plan.protocol}:${plan.port}`,
     certificate: plan.certificate ?? null,
     warnings: compiled?.warnings ?? plan.warnings,
-    status: compiled ? "compiled; deployment not executed" : "planned; material and routing not verified",
+    status: compiled ? "compiled; material and routing not verified; deployment not executed" : "planned; material and routing not verified",
   };
   if (compiled && values["compose-file"]) {
     await writeFile(resolve(values["compose-file"]), compiled.compose, { mode: 0o600, flag: "wx" });
@@ -83,6 +85,6 @@ async function main(): Promise<void> {
 }
 
 main().catch(error => {
-  console.error(error instanceof Error ? error.message : "TLS planning failed");
+  console.error(redactSecrets(error instanceof Error ? error.message : "TLS planning failed"));
   process.exitCode = 1;
 });

--- a/packages/native-tls-prototype/src/docker.ts
+++ b/packages/native-tls-prototype/src/docker.ts
@@ -1,14 +1,7 @@
-import { createPrivateKey, X509Certificate } from "node:crypto";
-import { execFile } from "node:child_process";
-import { readFile, stat } from "node:fs/promises";
-import { isIP } from "node:net";
-import { isAbsolute } from "node:path";
-import { promisify } from "node:util";
-import { launchToCompose } from "@launchfile/docker";
+import { launchToCompose, redactSecrets } from "@launchfile/docker";
 import { parse, stringify } from "yaml";
 import { planTls, type CertificateInput, type TlsMode, type TlsPlan } from "./planner.js";
-
-const execute = promisify(execFile);
+import { registerBindingProperties } from "./redaction.js";
 
 export interface DockerTlsOptions {
   mode: TlsMode;
@@ -27,61 +20,23 @@ export interface DockerTlsResult {
   warnings: string[];
 }
 
-async function readMaterial(path: string): Promise<string> {
-  if (!isAbsolute(path)) throw new Error("Certificate material paths must be absolute");
-  const metadata = await stat(path);
-  if (!metadata.isFile() || metadata.size > 1_048_576) {
-    throw new Error("Certificate material must be a regular file smaller than 1 MiB");
-  }
-  return readFile(path, "utf8");
-}
-
-/** This prototype deliberately supports one root CA and one directly signed leaf. */
-export async function validateCertificate(input: CertificateInput, serverName: string): Promise<void> {
-  const [certPem, keyPem, caPem] = await Promise.all([
-    readMaterial(input.certFile), readMaterial(input.keyFile), readMaterial(input.caFile),
-  ]);
-  if ((certPem.match(/BEGIN CERTIFICATE/g) ?? []).length !== 1 ||
-      (caPem.match(/BEGIN CERTIFICATE/g) ?? []).length !== 1) {
-    throw new Error("Prototype certificate validation supports one leaf and one root CA, without intermediates");
-  }
-  let leaf: X509Certificate;
-  let ca: X509Certificate;
-  try {
-    leaf = new X509Certificate(certPem);
-    ca = new X509Certificate(caPem);
-    if (!leaf.checkPrivateKey(createPrivateKey(keyPem))) throw new Error("mismatch");
-  } catch {
-    throw new Error("Invalid certificate/private key pair");
-  }
-  const now = Date.now();
-  for (const cert of [leaf, ca]) {
-    if (Date.parse(cert.validFrom) > now || Date.parse(cert.validTo) <= now) {
-      throw new Error("Certificate is expired or not yet valid");
-    }
-  }
-  if (!ca.ca || !leaf.checkIssued(ca) || !leaf.verify(ca.publicKey)) {
-    throw new Error("Certificate is not signed by the supplied trust root");
-  }
-  if (!(isIP(serverName) ? leaf.checkIP(serverName) : leaf.checkHost(serverName))) {
-    throw new Error(`Certificate does not authenticate server name ${serverName}`);
-  }
-  // A valid signature and hostname do not authorize server use: a client-only
-  // leaf can pass both. Delegate purpose/key-usage checks to the TLS verifier.
-  try {
-    await execute("openssl", ["verify", "-purpose", "sslserver", "-CAfile", input.caFile, input.certFile],
-      { timeout: 10_000, maxBuffer: 64 * 1024 });
-  } catch {
-    throw new Error("TLS server certificate verification failed; check certificate purpose and OpenSSL availability");
-  }
-}
-
 const shellQuote = (value: string): string => `'${value.replaceAll("'", "'\\''")}'`;
 // Replacement strings interpret $$ themselves; a callback preserves both dollars for Compose.
 const composeLiteral = (value: string): string => value.replaceAll("$", () => "$$");
 
-/** Compile proposed syntax to the existing provider, then attach validated material and a TLS-aware probe. */
+/** Compile proposed syntax to the existing provider, then attach supplied paths and a TLS-aware app health check, without reading certificate bytes. */
 export async function compileDockerTls(yaml: string, options: DockerTlsOptions): Promise<DockerTlsResult> {
+  // Register supplied values before the provider can emit anything. Even if a
+  // future registry knows key_file, the explicit credential rule still wins.
+  for (const input of Object.values(options.certificates ?? {})) {
+    registerBindingProperties({ cert_file: input.certFile, key_file: input.keyFile, ca_file: input.caFile },
+      ["cert_file", "key_file", "ca_file"]);
+  }
+  try { return await compileSuppliedPaths(yaml, options); }
+  catch (error) { throw new Error(redactSecrets(error instanceof Error ? error.message : "TLS compilation failed")); }
+}
+
+async function compileSuppliedPaths(yaml: string, options: DockerTlsOptions): Promise<DockerTlsResult> {
   if (!Number.isInteger(options.hostPort) || options.hostPort < 1 || options.hostPort > 65535) {
     throw new Error("hostPort must be an integer from 1 to 65535");
   }
@@ -93,11 +48,21 @@ export async function compileDockerTls(yaml: string, options: DockerTlsOptions):
     containerInputs[name] = { certFile: `${directory}/cert.pem`, keyFile: `${directory}/key.pem`, caFile: `${directory}/ca.pem` };
   }
   const plan = planTls(yaml, { ...options, certificates: containerInputs });
+  for (const resource of Object.values(plan.resources)) {
+    registerBindingProperties(resource.properties, ["cert_file", "key_file", "ca_file"]);
+  }
   const serverName = options.serverName ?? new URL(plan.publicUrl).hostname;
   if (plan.certificate) {
     const certificate = options.certificates?.[plan.certificate];
     if (!certificate) throw new Error(`Missing certificate material for ${plan.certificate}`);
-    await validateCertificate(certificate, serverName);
+    // Contents, existence, and readiness are the supplying consumer’s responsibility (D-56).
+    for (const key of ["certFile", "keyFile", "caFile"] as const) {
+      const path = certificate[key];
+      if (typeof path !== "string" || !path.startsWith("/") || path.endsWith("/") || /[\u0000-\u001f\u007f]/.test(path) ||
+          path.split("/").some(part => part === "." || part === "..")) {
+        throw new Error(`Certificate binding ${plan.certificate}.${key} requires an absolute file path without traversal`);
+      }
+    }
   }
 
   const launch = structuredClone(plan.launch);
@@ -122,7 +87,7 @@ export async function compileDockerTls(yaml: string, options: DockerTlsOptions):
   if (Object.keys(launch.components).some((name) => !generated.services[name])) {
     throw new Error("The provider refused a component; this prototype cannot emit a partial application");
   }
-  const warnings = [...plan.warnings, ...generated.warnings];
+  const warnings = [...plan.warnings, ...generated.warnings].map(redactSecrets);
   const serviceName = generated.services[plan.component];
   if (!serviceName) throw new Error("The provider refused the selected component");
   const compose = parse(generated.yaml) as {

--- a/packages/native-tls-prototype/src/docker.ts
+++ b/packages/native-tls-prototype/src/docker.ts
@@ -1,0 +1,158 @@
+import { createPrivateKey, X509Certificate } from "node:crypto";
+import { execFile } from "node:child_process";
+import { readFile, stat } from "node:fs/promises";
+import { isIP } from "node:net";
+import { isAbsolute } from "node:path";
+import { promisify } from "node:util";
+import { launchToCompose } from "@launchfile/docker";
+import { parse, stringify } from "yaml";
+import { planTls, type CertificateInput, type TlsMode, type TlsPlan } from "./planner.js";
+
+const execute = promisify(execFile);
+
+export interface DockerTlsOptions {
+  mode: TlsMode;
+  publicUrl: string;
+  endpoint?: string;
+  certificates?: Record<string, CertificateInput>;
+  hostPort: number;
+  projectName: string;
+  serverName?: string;
+}
+
+export interface DockerTlsResult {
+  plan: TlsPlan;
+  compose: string;
+  service: string;
+  warnings: string[];
+}
+
+async function readMaterial(path: string): Promise<string> {
+  if (!isAbsolute(path)) throw new Error("Certificate material paths must be absolute");
+  const metadata = await stat(path);
+  if (!metadata.isFile() || metadata.size > 1_048_576) {
+    throw new Error("Certificate material must be a regular file smaller than 1 MiB");
+  }
+  return readFile(path, "utf8");
+}
+
+/** This prototype deliberately supports one root CA and one directly signed leaf. */
+export async function validateCertificate(input: CertificateInput, serverName: string): Promise<void> {
+  const [certPem, keyPem, caPem] = await Promise.all([
+    readMaterial(input.certFile), readMaterial(input.keyFile), readMaterial(input.caFile),
+  ]);
+  if ((certPem.match(/BEGIN CERTIFICATE/g) ?? []).length !== 1 ||
+      (caPem.match(/BEGIN CERTIFICATE/g) ?? []).length !== 1) {
+    throw new Error("Prototype certificate validation supports one leaf and one root CA, without intermediates");
+  }
+  let leaf: X509Certificate;
+  let ca: X509Certificate;
+  try {
+    leaf = new X509Certificate(certPem);
+    ca = new X509Certificate(caPem);
+    if (!leaf.checkPrivateKey(createPrivateKey(keyPem))) throw new Error("mismatch");
+  } catch {
+    throw new Error("Invalid certificate/private key pair");
+  }
+  const now = Date.now();
+  for (const cert of [leaf, ca]) {
+    if (Date.parse(cert.validFrom) > now || Date.parse(cert.validTo) <= now) {
+      throw new Error("Certificate is expired or not yet valid");
+    }
+  }
+  if (!ca.ca || !leaf.checkIssued(ca) || !leaf.verify(ca.publicKey)) {
+    throw new Error("Certificate is not signed by the supplied trust root");
+  }
+  if (!(isIP(serverName) ? leaf.checkIP(serverName) : leaf.checkHost(serverName))) {
+    throw new Error(`Certificate does not authenticate server name ${serverName}`);
+  }
+  // A valid signature and hostname do not authorize server use: a client-only
+  // leaf can pass both. Delegate purpose/key-usage checks to the TLS verifier.
+  try {
+    await execute("openssl", ["verify", "-purpose", "sslserver", "-CAfile", input.caFile, input.certFile],
+      { timeout: 10_000, maxBuffer: 64 * 1024 });
+  } catch {
+    throw new Error("TLS server certificate verification failed; check certificate purpose and OpenSSL availability");
+  }
+}
+
+const shellQuote = (value: string): string => `'${value.replaceAll("'", "'\\''")}'`;
+// Replacement strings interpret $$ themselves; a callback preserves both dollars for Compose.
+const composeLiteral = (value: string): string => value.replaceAll("$", () => "$$");
+
+/** Compile proposed syntax to the existing provider, then attach validated material and a TLS-aware probe. */
+export async function compileDockerTls(yaml: string, options: DockerTlsOptions): Promise<DockerTlsResult> {
+  if (!Number.isInteger(options.hostPort) || options.hostPort < 1 || options.hostPort > 65535) {
+    throw new Error("hostPort must be an integer from 1 to 65535");
+  }
+  if (!/^[a-z][a-z0-9-]{0,62}$/.test(options.projectName)) throw new Error("Invalid isolated Docker project name");
+  const containerInputs: Record<string, CertificateInput> = {};
+  for (const name of Object.keys(options.certificates ?? {})) {
+    if (!/^[a-z][a-z0-9-]{0,62}$/.test(name)) throw new Error("Invalid certificate resource name");
+    const directory = `/run/launchfile-certificates/${name}`;
+    containerInputs[name] = { certFile: `${directory}/cert.pem`, keyFile: `${directory}/key.pem`, caFile: `${directory}/ca.pem` };
+  }
+  const plan = planTls(yaml, { ...options, certificates: containerInputs });
+  const serverName = options.serverName ?? new URL(plan.publicUrl).hostname;
+  if (plan.certificate) {
+    const certificate = options.certificates?.[plan.certificate];
+    if (!certificate) throw new Error(`Missing certificate material for ${plan.certificate}`);
+    await validateCertificate(certificate, serverName);
+  }
+
+  const launch = structuredClone(plan.launch);
+  // The demonstrator publishes only the endpoint it owns; unrelated host ports stay untouched.
+  for (const [componentName, component] of Object.entries(launch.components)) {
+    for (const endpoint of component.provides ?? []) {
+      const selected = componentName === plan.component &&
+        (endpoint.name === plan.endpoint || (!endpoint.name && String(endpoint.port) === plan.endpoint));
+      endpoint.exposed = selected;
+      if (selected) endpoint.bind = "127.0.0.1";
+    }
+  }
+  const generated = launchToCompose(launch, {
+    appUrl: plan.publicUrl,
+    networkName: options.projectName,
+    hostPorts: { [plan.component]: options.hostPort },
+    resources: plan.resources,
+  });
+  if (generated.unsuppliedRequired.length || generated.unboundOperatorVolumes.length) {
+    throw new Error("The app has unsatisfied environment or operator storage requirements");
+  }
+  if (Object.keys(launch.components).some((name) => !generated.services[name])) {
+    throw new Error("The provider refused a component; this prototype cannot emit a partial application");
+  }
+  const warnings = [...plan.warnings, ...generated.warnings];
+  const serviceName = generated.services[plan.component];
+  if (!serviceName) throw new Error("The provider refused the selected component");
+  const compose = parse(generated.yaml) as {
+    services: Record<string, { volumes?: unknown[]; healthcheck?: Record<string, unknown>; [key: string]: unknown }>;
+    [key: string]: unknown;
+  };
+  const service = compose.services[serviceName];
+  if (!service) throw new Error("Missing selected service in generated Compose");
+  if (plan.certificate) {
+    const host = options.certificates![plan.certificate]!;
+    const container = containerInputs[plan.certificate]!;
+    service.volumes ??= [];
+    for (const key of ["certFile", "keyFile", "caFile"] as const) {
+      service.volumes.push({ type: "bind", source: composeLiteral(host[key]), target: container[key], read_only: true });
+    }
+  }
+  const health = launch.components[plan.component]!.health;
+  if (health && !health.command) {
+    const path = health.path ?? "/";
+    if (!path.startsWith("/") || /[\r\n]/.test(path)) throw new Error("Health path must be an absolute path without line breaks");
+    const host = plan.protocol === "https" ? serverName : "127.0.0.1";
+    const url = `${plan.protocol}://${host}:${plan.port}${path}`;
+    const certificate = plan.certificate ? containerInputs[plan.certificate] : undefined;
+    const tlsArgs = certificate
+      ? ` --cacert ${shellQuote(certificate.caFile)} --resolve ${shellQuote(`${serverName}:${plan.port}:127.0.0.1`)}`
+      : "";
+    service.healthcheck = {
+      ...service.healthcheck,
+      test: ["CMD-SHELL", composeLiteral(`curl --disable --noproxy '*' --fail --silent --show-error --max-time 5${tlsArgs} ${shellQuote(url)} > /dev/null`)],
+    };
+  }
+  return { plan, compose: stringify(compose), service: serviceName, warnings };
+}

--- a/packages/native-tls-prototype/src/listener.ts
+++ b/packages/native-tls-prototype/src/listener.ts
@@ -1,0 +1,19 @@
+import { parseExpression, resolveExpression } from "@launchfile/sdk";
+
+/** Resolve only this proposed namespace; leave every ordinary reference for the provider. */
+export function bindListenerPort(value: string, port: number): string {
+  const expression = parseExpression(value);
+  if (expression.kind === "literal") return value;
+  const refs = expression.kind === "reference" ? [expression]
+    : expression.parts.filter((part) => part.kind === "ref");
+  if (!refs.some((ref) => ref.path[0] === "listener")) return value;
+  const literal = (text: string): string => text.replaceAll("$", () => "$$");
+  const reference = (ref: (typeof refs)[number]): string => {
+    const source = "${" + ref.path.join(".") + (ref.transforms?.length ? "|" + ref.transforms.join("|") : "") +
+      (ref.fallback === undefined ? "" : ":-" + ref.fallback) + "}";
+    return ref.path[0] === "listener"
+      ? literal(resolveExpression(source, { resources: { listener: { port } } })) : source;
+  };
+  return expression.kind === "reference" ? reference(expression)
+    : expression.parts.map((part) => part.kind === "text" ? literal(part.value) : reference(part)).join("");
+}

--- a/packages/native-tls-prototype/src/planner.ts
+++ b/packages/native-tls-prototype/src/planner.ts
@@ -6,6 +6,7 @@ import {
 	type NormalizedRequirement,
 	type Provides,
 } from "@launchfile/sdk";
+import { bindListenerPort } from "./listener.js";
 
 export type TlsMode = "off" | "edge" | "native" | "passthrough" | "reencrypt";
 
@@ -93,7 +94,7 @@ function normalizePublicUrl(value: string, mode: TlsMode): string {
 	return `${url.protocol}//${url.host}${url.pathname === "/" ? "" : url.pathname}`;
 }
 
-function certificateProperties(input: CertificateInput | undefined, name: string, port: number) {
+function certificateProperties(input: CertificateInput | undefined, name: string) {
 	if (!input) throw new Error(`Native TLS requires supplied certificate material for ${name}`);
 	for (const key of ["certFile", "keyFile", "caFile"] as const) {
 		const path = input[key];
@@ -102,7 +103,8 @@ function certificateProperties(input: CertificateInput | undefined, name: string
 			throw new Error(`Certificate ${name}.${key} must be an absolute container file path without traversal`);
 		}
 	}
-	return { cert_file: input.certFile, key_file: input.keyFile, ca_file: input.caFile, port: String(port) };
+	// The trust root belongs to the consumer's probe, not server presentation.
+	return { cert_file: input.certFile, key_file: input.keyFile };
 }
 
 function label(endpoint: Endpoint): string {
@@ -132,8 +134,9 @@ function choose(endpoints: Endpoint[], selector: string | undefined, component?:
 
 /**
  * Compile the proposed TLS syntax to today's SDK representation, without I/O.
- * A successful plan states the routing contract; the deploying adapter must
- * validate certificate bytes, provision that route, and verify its handshake.
+ * A successful plan states a configuration, not successful deployment. The
+ * owning consumer can verify material and routing separately; D-56 does not
+ * assign supplied-resource verification to the translating provider.
  */
 export function planTls(yaml: string, options: TlsOptions): TlsPlan {
 	if (!MODES.includes(options.mode)) throw new Error(`Unsupported TLS mode: ${options.mode}`);
@@ -219,6 +222,33 @@ export function planTls(yaml: string, options: TlsOptions): TlsPlan {
 		}
 		resolvedDependencies.set(endpoint, matches[0]!);
 	}
+	const boundCertificates = new Set<string>();
+	for (const endpoint of resolvedDependencies.keys()) {
+		const name = endpoint.binding!.certificate;
+		if (boundCertificates.has(name)) throw new Error(`Certificate ${name} is shared by multiple endpoints; one binding must have one listener`);
+		boundCertificates.add(name);
+	}
+	// Check namespace scope before inactive capabilities are removed. Selecting
+	// HTTP must not hide invalid wiring in an author's optional TLS declaration.
+	for (const [component, scope] of Object.entries(launch.components)) {
+		const expressions = [
+			...Object.entries(scope.env ?? {}).flatMap(([key, value]) => typeof value.default === "string"
+				? [{ label: `${component}.env.${key}`, value: value.default, entry: undefined }] : []),
+			...[...(scope.requires ?? []), ...(scope.supports ?? [])].flatMap((entry) =>
+				Object.entries(entry.set_env ?? {}).map(([key, value]) => ({ label: `${component}.set_env.${key}`, value, entry }))),
+		];
+		for (const expression of expressions) {
+			const bound = [...resolvedDependencies.values()].some(({ entry }) => entry === expression.entry);
+			for (const ref of references(expression.value)) {
+				if (ref.path[0] === "listener" && (!bound || ref.path.length !== 2 || ref.path[1] !== "port")) {
+					throw new Error(`${expression.label}: $listener.port is valid only inside a bound certificate's set_env`);
+				}
+				if (bound && ref.path.length === 1 && ref.path[0] === "port") {
+					throw new Error(`${expression.label}: $port belongs to the resource; use $listener.port for the bound listener`);
+				}
+			}
+		}
+	}
 
 	const native = ["native", "passthrough", "reencrypt"].includes(options.mode);
 	if (!native && selected.value.protocol !== "http") {
@@ -228,9 +258,6 @@ export function planTls(yaml: string, options: TlsOptions): TlsPlan {
 	const certificate = native ? selected.binding!.certificate : undefined;
 	const active = native ? resolvedDependencies.get(selected) : undefined;
 	if (certificate) {
-		if (endpoints.some((endpoint) => endpoint !== selected && endpoint.binding?.certificate === certificate)) {
-			throw new Error(`Certificate ${certificate} is shared by multiple endpoints; coordinated activation is outside this prototype`);
-		}
 		// Resources are supplied to today's provider by global name. Refuse a
 		// collision even across components instead of accidentally satisfying it.
 		for (const [component, scope] of Object.entries(launch.components)) {
@@ -272,8 +299,12 @@ export function planTls(yaml: string, options: TlsOptions): TlsPlan {
 		throw new Error(`Resolved listener ${label(selected)} conflicts with another endpoint on port ${port}`);
 	}
 	const resources: TlsPlan["resources"] = certificate
-		? { [certificate]: { properties: certificateProperties(options.certificates?.[certificate], certificate, port) } }
+		? { [certificate]: { properties: certificateProperties(options.certificates?.[certificate], certificate) } }
 		: {};
+	if (active?.entry.set_env) {
+		active.entry.set_env = Object.fromEntries(Object.entries(active.entry.set_env).map(([key, value]) =>
+			[key, bindListenerPort(value, port)]));
+	}
 	for (const [component, scope] of Object.entries(launch.components)) {
 		const expressions = [
 			...Object.entries(scope.env ?? {}).flatMap(([key, value]) => typeof value.default === "string"

--- a/packages/native-tls-prototype/src/planner.ts
+++ b/packages/native-tls-prototype/src/planner.ts
@@ -1,0 +1,314 @@
+import {
+	parseLaunchYaml,
+	parseExpression,
+	validateLaunch,
+	type NormalizedLaunch,
+	type NormalizedRequirement,
+	type Provides,
+} from "@launchfile/sdk";
+
+export type TlsMode = "off" | "edge" | "native" | "passthrough" | "reencrypt";
+
+/** Files already materialized inside the application container by the caller. */
+export interface CertificateInput {
+	certFile: string;
+	keyFile: string;
+	caFile: string;
+}
+
+export interface TlsOptions {
+	mode: TlsMode;
+	publicUrl: string;
+	endpoint?: string;
+	certificates?: Record<string, CertificateInput>;
+	supportedModes?: TlsMode[];
+}
+
+export interface TlsPlan {
+	launch: NormalizedLaunch;
+	mode: TlsMode;
+	publicUrl: string;
+	component: string;
+	/** Unnamed legacy endpoints use their resolved container port as an identifier. */
+	endpoint: string;
+	protocol: "http" | "https";
+	port: number;
+	certificate?: string;
+	resources: Record<string, { properties: Record<string, string> }>;
+	warnings: string[];
+}
+
+type ObjectValue = Record<string, unknown>;
+interface Binding { certificate: string; port?: number }
+interface Endpoint {
+	component: string;
+	index: number;
+	value: Provides;
+	binding?: Binding;
+}
+
+const MODES: TlsMode[] = ["off", "edge", "native", "passthrough", "reencrypt"];
+const NAME = /^[a-z][a-z0-9-]{0,62}$/;
+const own = (value: object, key: string): boolean => Object.hasOwn(value, key);
+
+function object(value: unknown, label: string): ObjectValue {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		throw new Error(`${label} must be an object`);
+	}
+	return value as ObjectValue;
+}
+
+function keys(value: ObjectValue, allowed: string[], label: string): void {
+	for (const key of Object.keys(value)) {
+		if (!allowed.includes(key)) throw new Error(`Unknown ${label} field: ${key}`);
+	}
+}
+
+function binding(value: unknown, label: string): Binding {
+	const expanded = typeof value === "string" ? { certificate: value } : object(value, label);
+	keys(expanded, ["certificate", "port"], label);
+	if (typeof expanded.certificate !== "string" || !NAME.test(expanded.certificate)) {
+		throw new Error(`${label}.certificate must name a certificate dependency`);
+	}
+	if (expanded.port !== undefined &&
+		(typeof expanded.port !== "number" || !Number.isInteger(expanded.port) ||
+			expanded.port < 1 || expanded.port > 65535)) {
+		throw new Error(`${label}.port must be an integer between 1 and 65535`);
+	}
+	return { certificate: expanded.certificate, port: expanded.port as number | undefined };
+}
+
+function normalizePublicUrl(value: string, mode: TlsMode): string {
+	let url: URL;
+	try { url = new URL(value); } catch { throw new Error("publicUrl must be an absolute HTTP(S) URL"); }
+	// Do not echo invalid input: it may contain credentials.
+	if (!/^https?:\/\//i.test(value) || url.username || url.password || url.search || url.hash ||
+		/[\u0000-\u0020\u007f]/.test(value) || !["http:", "https:"].includes(url.protocol)) {
+		throw new Error("publicUrl must be an absolute HTTP(S) URL without credentials, query, or fragment");
+	}
+	const expected = mode === "off" ? "http:" : "https:";
+	if (url.protocol !== expected) {
+		throw new Error(`TLS mode ${mode} requires an ${expected}// publicUrl`);
+	}
+	return `${url.protocol}//${url.host}${url.pathname === "/" ? "" : url.pathname}`;
+}
+
+function certificateProperties(input: CertificateInput | undefined, name: string, port: number) {
+	if (!input) throw new Error(`Native TLS requires supplied certificate material for ${name}`);
+	for (const key of ["certFile", "keyFile", "caFile"] as const) {
+		const path = input[key];
+		if (typeof path !== "string" || !path.startsWith("/") || path.endsWith("/") ||
+			/[\u0000-\u001f\u007f]/.test(path) || path.split("/").some((part) => part === "." || part === "..")) {
+			throw new Error(`Certificate ${name}.${key} must be an absolute container file path without traversal`);
+		}
+	}
+	return { cert_file: input.certFile, key_file: input.keyFile, ca_file: input.caFile, port: String(port) };
+}
+
+function label(endpoint: Endpoint): string {
+	return `${endpoint.component}.${endpoint.value.name ?? endpoint.value.port}`;
+}
+
+function references(expression: string): Array<{ path: string[]; fallback?: string }> {
+	const parsed = parseExpression(expression);
+	return parsed.kind === "reference" ? [parsed]
+		: parsed.kind === "template" ? parsed.parts.filter((part) => part.kind === "ref") : [];
+}
+
+function choose(endpoints: Endpoint[], selector: string | undefined, component?: string): Endpoint {
+	const candidates = endpoints.filter((entry) => {
+		if (component !== undefined && entry.component !== component) return false;
+		return selector === undefined
+			? entry.value.exposed === true && ["http", "https"].includes(entry.value.protocol)
+			: entry.value.name === selector || label(entry) === selector;
+	});
+	if (candidates.length !== 1) {
+		throw new Error(selector === undefined
+			? "Choose --endpoint component.endpoint: the published HTTP(S) endpoint is not unambiguous"
+			: `Endpoint ${selector} ${candidates.length ? "is ambiguous; use component.endpoint" : "does not exist in its declared scope"}`);
+	}
+	return candidates[0]!;
+}
+
+/**
+ * Compile the proposed TLS syntax to today's SDK representation, without I/O.
+ * A successful plan states the routing contract; the deploying adapter must
+ * validate certificate bytes, provision that route, and verify its handshake.
+ */
+export function planTls(yaml: string, options: TlsOptions): TlsPlan {
+	if (!MODES.includes(options.mode)) throw new Error(`Unsupported TLS mode: ${options.mode}`);
+	if (options.supportedModes && !options.supportedModes.includes(options.mode)) {
+		throw new Error(`Provider does not support explicitly selected TLS mode ${options.mode}`);
+	}
+	if (own(options, "strict") || own(options, "gaps")) throw new Error("Operator strictness is a separate prototype (#444)");
+	const warnings: string[] = [];
+	const publicUrl = normalizePublicUrl(options.publicUrl, options.mode);
+	let raw: ObjectValue;
+	try { raw = object(parseLaunchYaml(yaml), "Launchfile"); }
+	catch { throw new Error("Invalid Launchfile YAML; source content omitted from diagnostics"); }
+	const bindings = new Map<string, Map<number, Binding>>();
+
+	// Inspect before the permissive legacy reader can discard security contracts.
+	// Copy only the objects we rewrite, so YAML aliases cannot erase another
+	// component's TLS declaration as a side effect of sanitizing the first one.
+	function preprocess(source: ObjectValue, component: string, ignoredDefaults = false): ObjectValue {
+		if (own(source, "variants")) throw new Error("Generic variants are a separate proposal and are not supported by this TLS prototype");
+		if (own(source, "tls") || own(source, "public")) {
+			throw new Error(`${component}: tls belongs on provides entries; public belongs in requires`);
+		}
+		const result = { ...source };
+		const localBindings = new Map<number, Binding>();
+		if (Array.isArray(source.provides)) {
+			result.provides = source.provides.map((entry: unknown, index: number) => {
+				const endpoint = object(entry, `${component}.provides[${index}]`);
+				if (!own(endpoint, "tls")) return endpoint;
+				if (ignoredDefaults) throw new Error("Top-level TLS bindings are not inherited by components; declare them on the component");
+				if (endpoint.protocol !== "http" && endpoint.protocol !== "https") {
+					throw new Error(`${component}.provides[${index}].tls supports only HTTP/HTTPS listeners`);
+				}
+				localBindings.set(index, binding(endpoint.tls, `${component}.provides[${index}].tls`));
+				const { tls: _tls, ...ordinary } = endpoint;
+				return ordinary;
+			});
+		}
+		for (const field of ["requires", "supports"] as const) {
+			if (!Array.isArray(source[field])) continue;
+			result[field] = source[field].filter((entry: unknown) => {
+				if (ignoredDefaults && (entry === "certificate" || (typeof entry === "object" && entry !== null &&
+					"type" in entry && entry.type === "certificate"))) {
+					throw new Error("Top-level certificate dependencies are not inherited by components; declare them on the component");
+				}
+				if (typeof entry !== "object" || entry === null || !own(entry, "public")) return true;
+				throw new Error("Public HTTPS requirements are a separate prototype (#446)");
+			});
+		}
+		if (!ignoredDefaults) bindings.set(component, localBindings);
+		return result;
+	}
+
+	const components = raw.components === undefined ? undefined : object(raw.components, "components");
+	const multi = components !== undefined && Object.keys(components).length > 0;
+	const ordinary = preprocess(raw, "default", multi);
+	if (multi) {
+		ordinary.components = Object.fromEntries(Object.entries(components).map(([name, value]) =>
+			[name, preprocess(object(value, `components.${name}`), name)]));
+	}
+	let launch: NormalizedLaunch;
+	try { launch = validateLaunch(ordinary); }
+	catch { throw new Error("Invalid Launchfile fields; source content omitted from diagnostics"); }
+	const endpoints = Object.entries(launch.components).flatMap(([component, value]) =>
+		(value.provides ?? []).map((endpoint, index): Endpoint => ({
+			component, index, value: endpoint, binding: bindings.get(component)?.get(index),
+		})));
+	const selected = choose(endpoints, options.endpoint);
+	if (selected.value.exposed !== true) throw new Error(`Selected endpoint ${label(selected)} must be exposed`);
+	if (selected.value.protocol !== "http" && selected.value.protocol !== "https") {
+		throw new Error(`Selected endpoint ${label(selected)} must use HTTP or HTTPS`);
+	}
+
+	const resolvedDependencies = new Map<Endpoint, { entry: NormalizedRequirement; required: boolean }>();
+	for (const endpoint of endpoints) {
+		if (!endpoint.binding) continue;
+		const scope = launch.components[endpoint.component]!;
+		const matches = [
+			...(scope.requires ?? []).map((entry) => ({ entry, required: true })),
+			...(scope.supports ?? []).map((entry) => ({ entry, required: false })),
+		].filter(({ entry }) => (entry.name ?? entry.type) === endpoint.binding!.certificate);
+		if (matches.length !== 1 || matches[0]!.entry.type !== "certificate" || matches[0]!.entry.host) {
+			throw new Error(`${label(endpoint)}.tls must resolve to exactly one certificate dependency named ${endpoint.binding.certificate} in component ${endpoint.component}`);
+		}
+		resolvedDependencies.set(endpoint, matches[0]!);
+	}
+
+	const native = ["native", "passthrough", "reencrypt"].includes(options.mode);
+	if (!native && selected.value.protocol !== "http") {
+		throw new Error(`TLS mode ${options.mode} requires an author-declared HTTP base listener; cannot downgrade ${label(selected)}`);
+	}
+	if (native && !selected.binding) throw new Error(`${label(selected)} does not declare native TLS support`);
+	const certificate = native ? selected.binding!.certificate : undefined;
+	const active = native ? resolvedDependencies.get(selected) : undefined;
+	if (certificate) {
+		if (endpoints.some((endpoint) => endpoint !== selected && endpoint.binding?.certificate === certificate)) {
+			throw new Error(`Certificate ${certificate} is shared by multiple endpoints; coordinated activation is outside this prototype`);
+		}
+		// Resources are supplied to today's provider by global name. Refuse a
+		// collision even across components instead of accidentally satisfying it.
+		for (const [component, scope] of Object.entries(launch.components)) {
+			for (const entry of [...(scope.requires ?? []), ...(scope.supports ?? [])]) {
+				if (entry !== active?.entry && (entry.name ?? entry.type) === certificate) {
+					throw new Error(`Certificate ${certificate} collides with another resource in component ${component}`);
+				}
+			}
+		}
+		const activeKeys = new Set(Object.keys(active?.entry.set_env ?? {}));
+		const scope = launch.components[selected.component]!;
+		for (const entry of [...(scope.requires ?? []), ...(scope.supports ?? [])]) {
+			if (entry !== active?.entry && Object.keys(entry.set_env ?? {}).some((key) => activeKeys.has(key))) {
+				throw new Error(`Certificate ${certificate} has conflicting set_env wiring with ${entry.name ?? entry.type}`);
+			}
+		}
+	}
+
+	const inactiveCertificates = new Set<string>();
+	for (const [component, scope] of Object.entries(launch.components)) {
+		for (const entry of scope.requires ?? []) {
+			if (entry.type === "certificate" && entry !== active?.entry) {
+				throw new Error(`${component} requires native TLS certificate ${entry.name ?? entry.type}; the selected deployment does not activate it`);
+			}
+		}
+		// Certificate availability must never activate an unselected listener.
+		// Retain all other optional resources and their existing SDK behavior.
+		if (scope.supports) scope.supports = scope.supports.filter((entry) => {
+			const retain = entry.type !== "certificate" || entry === active?.entry;
+			if (!retain) inactiveCertificates.add(entry.name ?? entry.type);
+			return retain;
+		});
+	}
+
+	const protocol = native ? "https" : "http";
+	const port = native ? (selected.binding!.port ?? selected.value.port) : selected.value.port;
+	if (native && endpoints.some((entry) => entry !== selected && entry.component === selected.component &&
+		entry.value.port === port && entry.value.protocol !== "udp")) {
+		throw new Error(`Resolved listener ${label(selected)} conflicts with another endpoint on port ${port}`);
+	}
+	const resources: TlsPlan["resources"] = certificate
+		? { [certificate]: { properties: certificateProperties(options.certificates?.[certificate], certificate, port) } }
+		: {};
+	for (const [component, scope] of Object.entries(launch.components)) {
+		const expressions = [
+			...Object.entries(scope.env ?? {}).flatMap(([key, value]) => typeof value.default === "string"
+				? [{ label: `${component}.env.${key}`, value: value.default, entry: undefined }] : []),
+			...[...(scope.requires ?? []), ...(scope.supports ?? [])].flatMap((entry) =>
+				Object.entries(entry.set_env ?? {}).map(([key, value]) => ({ label: `${component}.set_env.${key}`, value, entry }))),
+		];
+		for (const expression of expressions) {
+			for (const ref of references(expression.value)) {
+				// Docker currently registers an HTTP URL per component, and the
+				// SDK falls back to it even for named endpoint URL references.
+				// Replacing the listener cannot repair those sibling addresses.
+				if (native && ref.path[0] === "components" && ref.path[1] === selected.component &&
+					ref.path.length >= 3 && ref.path.at(-1) === "url") {
+					throw new Error(`${expression.label}: canonical Docker sibling URL transport is not supported in this prototype for native TLS component ${selected.component}; its HTTP URL cannot describe the selected HTTPS listener`);
+				}
+				if (ref.path.length > 1 && inactiveCertificates.has(ref.path[0]!) && ref.fallback === undefined) {
+					throw new Error(`${expression.label} references inactive certificate ${ref.path[0]}; put TLS wiring in its certificate set_env`);
+				}
+				if (certificate) {
+					const property = ref.path.length === 1 && expression.entry === active?.entry ? ref.path[0]
+						: ref.path.length === 2 && ref.path[0] === certificate ? ref.path[1] : undefined;
+					if (property !== undefined && !own(resources[certificate]!.properties, property)) {
+						throw new Error(`${expression.label} references unknown certificate property ${property}`);
+					}
+				}
+				const primary = endpoints.find((endpoint) => endpoint.value.exposed === true);
+				if (ref.path[0] === "app" && primary !== selected) {
+					throw new Error(`${expression.label} uses the primary $app publication context; selecting ${label(selected)} needs a separate endpoint URL context`);
+				}
+			}
+		}
+	}
+	selected.value.protocol = protocol;
+	selected.value.port = port;
+	return { launch, mode: options.mode, publicUrl, component: selected.component,
+		endpoint: selected.value.name ?? String(selected.value.port), protocol, port, certificate, resources, warnings };
+}

--- a/packages/native-tls-prototype/src/redaction.ts
+++ b/packages/native-tls-prototype/src/redaction.ts
@@ -1,0 +1,14 @@
+import { registerDeclaredSecret } from "@launchfile/docker";
+
+/** Proposed D-56 credential classification, demonstrated without registering a production type. */
+export function isCredentialProperty(name: string, vocabulary: readonly string[] = []): boolean {
+  if (["password", "secret_key", "access_key", "key_file"].includes(name) || /_key(?:_file)?$/.test(name)) return true;
+  if (["host", "port", "name", "user", "url", "bucket", "region"].includes(name)) return false;
+  return !vocabulary.includes(name);
+}
+
+export function registerBindingProperties(properties: Record<string, string>, vocabulary: readonly string[] = []): void {
+  for (const [name, value] of Object.entries(properties)) {
+    if (isCredentialProperty(name, vocabulary)) registerDeclaredSecret(value);
+  }
+}

--- a/packages/native-tls-prototype/tsconfig.json
+++ b/packages/native-tls-prototype/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUncheckedIndexedAccess": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["bun", "vitest/globals"],
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "scripts/**/*.ts"]
+}


### PR DESCRIPTION
## What

Draft demonstration for [native TLS RFC A #445](https://github.com/launchfile/launchfile/issues/445), under #314. A private `@launchfile/native-tls-prototype` package makes proposed certificate-bound listener activation runnable through the existing SDK and Docker translator. The ordinary parser, schema, providers, and CLI remain unchanged.

The author declares an HTTP baseline and optional certificate wiring. The consumer chooses HTTP, edge termination, native HTTPS, passthrough, or authenticated re-encryption. Selection coordinates environment, effective listener protocol/port, supplied paths, and app health checks. The CLI reports an unverified plan or writes a private Compose artifact; a separate supplying-consumer proof starts real Gitea and verifies TLS behavior.

## Steward follow-up

This revision addresses [the five review gaps](https://github.com/launchfile/launchfile/issues/445#issuecomment-5603792992):

- **Scoped port:** `$listener.port` resolves only within a bound certificate's `set_env`. Resource-local `$port` keeps its existing meaning and certificates gain no synthetic port. Invalid namespace use is checked before inactive capabilities are removed.
- **Redaction:** a private rule demonstrates `key_file` and every `*_key`/`*_key_file` value staying credential-bearing even when registered. Values go through the provider redactor before diagnostics. The production registry is unchanged; a future registry addition must include the D-56 credential-list extension in the same change.
- **Effective protocol:** normalized selected listeners carry HTTPS and the selected port. Every listener-derived URL must use this effective representation; the prototype refuses affected sibling URL expressions pending #391 rather than emitting an incorrect HTTP URL.
- **D-56 boundary:** provider compilation checks supplied paths syntactically but does not inspect certificate contents, existence, validity, or readiness. `src/certificate-verification.ts` is a separate supplying-consumer helper, called explicitly by the live proof. A compiled artifact is not an authenticated deployment. Probe trust roots are separate from server-presentation properties.
- **Catalog capability evidence:** `catalog/TLS-CAPABILITIES.md` audits upstream settings for Gitea, Grafana, Miniflux, Vaultwarden, and the ntfy boundary case. Gitea/Grafana/Miniflux supply three documented selected-listener motivations; Vaultwarden adds a caveated fourth. Absent unsupported syntax is not evidence of absent app capability. Current HTTP catalog declarations remain correct for their configured defaults.

Four candidate files in `examples/catalog/` preserve the shipped database/storage/listener baselines while demonstrating proposed optional wiring. They retain the unnamed catalog HTTP endpoints: the containing entry determines the binding, and a certificate used by two entries is rejected in every mode. The original live Gitea fixture intentionally uses SQLite to isolate TLS switching; the catalog-derived Gitea candidate preserves its PostgreSQL requirement.

## PR review follow-up

The README now groups the four choices made by the revised RFC, lists every live Gitea fixture difference from the shipped catalog entry, and documents manual verification and removal ownership. The stale review suggestions were reconciled against the current implementation rather than copied over it. The catalog audit is explicitly an additional documentation change outside the package and still needs current-head review.

No CI job builds or tests this prototype; green repository checks cover the production packages, not these experiments. The RFC/PR author owns re-verification and submitting removal when the Authors decide #445 in either direction. Remove the private package and regenerate the lockfile; retire its proposal-specific audit links, with any lasting catalog findings reviewed separately. Production adoption requires a separate implementation PR.

## Review status and scope

**Demonstration only; not ready to merge as a production feature.** D-59 landed in #443, while A remains unaccepted. Delivery already fits D-53 mode 1 via D-56 with D-46's open resource type. The Authors must decide whether an explicitly opted-in optional binding may change a sibling listener declaration. Feature negotiation, vocabulary/redaction adoption, and provider integration remain outstanding.

Public HTTPS requirements (#446), strictness (#444), and variants (#447) remain independent and their experimental contracts are refused here. One selected public HTTP(S) endpoint is demonstrated. The consumer verification helper handles a directly issued leaf/root pair only. No intermediate-chain proof, ACME/renewal/reload, mTLS, non-HTTP TLS, shared certificates, simultaneous listeners, or general routing engine is claimed. The catalog audit is a bounded source review, not a prevalence census or four additional live deployments.

## Try it

From the repository root, `bun install --frozen-lockfile`. Then in `packages/native-tls-prototype`:

```sh
bun run verify
bun run plan examples/gitea/Launchfile --tls=edge --url=https://localhost:3443
bun run plan examples/catalog/grafana/Launchfile --tls=edge --url=https://grafana.example
bun run prove
```

Planning and compilation perform no material/network verification. Consumer-verification tests need OpenSSL; the live proof also needs Docker and the cached official Gitea image. It owns an isolated Docker project, loopback ports, disposable certificates, and one data volume, and verifies cleanup. No private certificate material is committed.

## Validation

- This documentation follow-up re-ran SDK/Docker dependency builds, strict TypeScript, and **115 prototype tests** successfully on **Bun 1.4.0 / Node.js 24.14.1**, SDK 0.7.0, Docker provider 0.7.1.
- The previous implementation revision recorded **seven real Gitea deployment configurations / 58 assertions**; this documentation-only follow-up did not re-run the live proof: HTTP, edge, native, passthrough, re-encryption, changed native port, and return to HTTP. Persistent data survives every switch and owned resources are removed.
- Tests cover binding refusal, unchanged resource-local references, future-vocabulary key redaction, pure compilation of supplied paths, explicit consumer certificate verification, partial-app refusal, mandatory environment failures, and secret-safe diagnostics.
- Existing SDK **425 tests** and Docker provider **352 tests** passed during the original extraction; no production source changed in this follow-up.
- Catalog documentation and private examples are separate from shipping app declarations. The original Bun-generated lockfile update remains; this follow-up adds no dependency.

## Principle assessment

- **P-1/P-11:** App capability/wiring versus consumer arrangement/fulfillment; the new decision is coordinated listener activation.
- **P-2/P-4/P-7:** HTTP stays simple; optional TLS has a scalar shorthand and one expansion.
- **P-3/P-6/P-8/P-9:** Statically validated ordinary YAML, explicit scoped references, and effective listener metadata.
- **P-5:** One adapter proves mechanics; unsupported behavior refuses rather than claiming portability.
- **P-10/P-12:** Configuration wiring stays on the supplied resource, with attached material and separately owned probe trust.
- **P-13/P-14:** Canonical behavior remains unchanged. Old-reader stripping still requires a real incompatible-tooling boundary before adoption.

Related to #445 and #314; neither issue is closed by this demonstration.
