### PR TITLE
catalog: fix vaultwarden DOMAIN description to scope HTTPS correctly

### DIFF
--- a/catalog/apps/vaultwarden/Launchfile
+++ b/catalog/apps/vaultwarden/Launchfile
@@ -24,7 +24,7 @@ env:
     description: "Whether new user signups are allowed"
   DOMAIN:
     default: $app.url
-    description: "Public URL vaultwarden is served from (required for WebAuthn/U2F)"
+    description: "Public URL Vaultwarden is served from; its web vault needs HTTPS and a secure context for Web Crypto, beyond WebAuthn/U2F"
 storage:
   data:
     path: /data


### PR DESCRIPTION
Closes #454

## What changed

`catalog/apps/vaultwarden/Launchfile` — the `DOMAIN` env var description scoped HTTPS to WebAuthn/U2F only. Vaultwarden's web vault needs HTTPS and a secure context for the Web Crypto API to work at all — Web Crypto encrypts and decrypts every vault item, not only the second-factor flow. The old wording implied an HTTP-only deployment would just lose passkey login; it loses the whole web vault.

Bound shape: this is the exact fix surfaced by the steward review of #446 (comment on [#446](https://github.com/launchfile/launchfile/issues/446#issuecomment-5604103172)), already drafted at the head of draft PR #451. This PR lands only that one line, taken verbatim from #451's `catalog/apps/vaultwarden/Launchfile`:

```diff
-    description: "Public URL vaultwarden is served from (required for WebAuthn/U2F)"
+    description: "Public URL Vaultwarden is served from; its web vault needs HTTPS and a secure context for Web Crypto, beyond WebAuthn/U2F"
```

No other file or app is touched. No changeset — `catalog/` is not a published package.

#446 (mode-1 resubmission) will cite this PR's merged commit once it lands.

## Verification (OBSERVED)

- `cd sdk && bun install` — 121 packages installed, clean.
- `bun run typecheck` — clean, no errors.
- `bun run build` — clean, `tsc -p tsconfig.build.json` succeeded.
- `bun run src/cli.ts validate ../catalog/apps/vaultwarden/Launchfile`:
  ```
  ✓ vaultwarden is valid
    components: default
    warning: (top-level): builds only from a prebuilt `image:` — no `runtime`, `commands.build`, or `commands.install` (D-40)
  ```
  Exit code 0. The D-40 warning is pre-existing (image-only app, unrelated to this description change) and present on `main` too.
- `git diff` on the worktree before commit showed exactly the one-line description change — no other file touched.

`bun run test` in `catalog/test` was not run: this is a description-string-only change with no behavioral or schema impact, and the SDK's `validate` command (which exercises the schema and description field) already confirms the file parses and validates cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
