### PR TITLE
providers: one derivation of a published endpoint address in @launchfile/docker (closes #473)

### DIFF
--- a/.changeset/published-address-docker.md
+++ b/.changeset/published-address-docker.md
@@ -1,5 +1,5 @@
 ---
-"@launchfile/docker": patch
+"@launchfile/docker": minor
 ---
 
 One derivation of a published endpoint's address (#473).

--- a/.changeset/published-address-docker.md
+++ b/.changeset/published-address-docker.md
@@ -1,0 +1,11 @@
+---
+"@launchfile/docker": patch
+---
+
+One derivation of a published endpoint's address (#473).
+
+Three places used to mint the address of a host-published endpoint independently, and they had drifted. An entry declaring `protocol: https` with no certificate binding resolved `$app.url` to `http://localhost:<port>` while `status` and `up` printed `https://localhost:<port>` for that same entry — so the app was configured with one origin and the operator was told another. An active certificate binding on a declared-`http` entry drifted the other way.
+
+`publishedAddress(effectiveProtocol, hostPort, appUrl?)` is now the single derivation, exported from the package. It returns the `host`/`port`/`url`/`authority`/`scheme`/`tls` set with the rules already ratified: the scheme is `https` exactly when the listener's **effective** protocol is `https` (D-61 rule 2), `ws` and `grpc` keep the http origin (D-60 rule 4), and a supplied `appUrl` wins outright (D-58 rules 2 and 5). `$app.*`, `endpointAddress`, and the endpoint metadata the compose generator persists all read it, so the primary endpoint's `$app.url` and its printed address are now byte-identical.
+
+The persisted endpoint protocol is the effective one, not the declared one. Output is unchanged for every Launchfile that declares neither `protocol: https` nor `tls:`.

--- a/providers/docker/src/__tests__/published-address.test.ts
+++ b/providers/docker/src/__tests__/published-address.test.ts
@@ -1,0 +1,239 @@
+/**
+ * One derivation of a published endpoint's address (#473).
+ *
+ * `$app.*` and the `status`/`up` printout are two surfaces onto the same
+ * address. Every case here asserts they agree byte for byte, because they
+ * used to drift: the `$app.*` path read only whether a certificate binding
+ * was active, while the printout switched on the declared protocol.
+ */
+
+import { readLaunch } from "@launchfile/sdk";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import {
+	computeAppProperties,
+	publishedAddress,
+	publishedEndpointAddresses,
+} from "../app-url.js";
+import { type ComposeOpts, launchToCompose } from "../compose-generator.js";
+import { endpointAddress } from "../provider.js";
+
+/** The #473 fixture: a component that terminates TLS itself, no binding. */
+const SELF_TLS = `
+name: selftls
+image: acme/selftls:1
+provides:
+  - name: web
+    protocol: https
+    port: 8443
+    exposed: true
+env:
+  APP_URL: $app.url
+  APP_SCHEME: $app.scheme
+  APP_TLS: $app.tls
+`;
+
+/** The same listener declared http, with TLS arriving from a binding (D-61). */
+const BOUND_CERT = `
+name: boundcert
+image: acme/boundcert:1
+provides:
+  - name: web
+    protocol: http
+    port: 3000
+    exposed: true
+    tls: server-cert
+supports:
+  - name: server-cert
+    type: certificate
+env:
+  APP_URL: $app.url
+`;
+
+const ACTIVE: ComposeOpts["resources"] = {
+	"server-cert": { properties: { cert_file: "/tls/c.pem", key_file: "/tls/k.pem" } },
+};
+
+/** Non-HTTP listener protocols, which D-60 rule 4 keeps on the http origin. */
+const WS_AND_GRPC = `
+name: wsgrpc
+components:
+  socket:
+    image: acme/socket:1
+    provides:
+      - name: live
+        protocol: ws
+        port: 9000
+        exposed: true
+    env:
+      APP_URL: $app.url
+  rpc:
+    image: acme/rpc:1
+    provides:
+      - name: api
+        protocol: grpc
+        port: 50051
+        exposed: true
+`;
+
+/** An `https-origin` naming a non-first endpoint as the primary (D-60 rule 3). */
+const NAMED_PRIMARY = `
+name: openclaw
+image: ghcr.io/openclaw/openclaw:latest
+provides:
+  - name: gateway
+    protocol: http
+    port: 18789
+    exposed: true
+  - name: bridge
+    protocol: https
+    port: 18790
+    exposed: true
+supports:
+  - type: https-origin
+    endpoint: bridge
+env:
+  APP_URL: $app.url
+`;
+
+function envOf(yaml: string, service: string): Record<string, string> {
+	const doc = parse(yaml) as {
+		services: Record<string, { environment?: Record<string, string> }>;
+	};
+	return doc.services[service]!.environment ?? {};
+}
+
+/** What `status` / `up` print for one ports-map key. */
+function printedAddress(result: ReturnType<typeof launchToCompose>, key: string): string {
+	return endpointAddress(result.ports[key]!, result.endpoints[key]?.protocol);
+}
+
+describe("a declared `protocol: https` listener with no certificate binding (#473)", () => {
+	const opts: ComposeOpts = { hostPorts: { default: 18443 } };
+
+	it("gives $app.url the https scheme the entry declares", () => {
+		const env = envOf(launchToCompose(readLaunch(SELF_TLS), opts).yaml, "selftls");
+		expect(env.APP_URL).toBe("https://localhost:18443");
+		expect(env.APP_SCHEME).toBe("https");
+		expect(env.APP_TLS).toBe("true");
+	});
+
+	it("prints the same address it wrote into the app's config", () => {
+		const result = launchToCompose(readLaunch(SELF_TLS), opts);
+		expect(printedAddress(result, "default")).toBe("https://localhost:18443");
+		expect(printedAddress(result, "default")).toBe(
+			envOf(result.yaml, "selftls").APP_URL,
+		);
+	});
+});
+
+describe("an active certificate binding on a declared `http` listener (D-61 rule 2)", () => {
+	const opts: ComposeOpts = { hostPorts: { default: 13000 }, resources: ACTIVE };
+
+	it("moves both surfaces to https together", () => {
+		const result = launchToCompose(readLaunch(BOUND_CERT), opts);
+		expect(envOf(result.yaml, "boundcert").APP_URL).toBe("https://localhost:13000");
+		expect(printedAddress(result, "default")).toBe("https://localhost:13000");
+	});
+
+	it("keeps both on http while the binding is unselected (D-8)", () => {
+		const result = launchToCompose(readLaunch(BOUND_CERT), {
+			hostPorts: { default: 13000 },
+		});
+		expect(envOf(result.yaml, "boundcert").APP_URL).toBe("http://localhost:13000");
+		expect(printedAddress(result, "default")).toBe("http://localhost:13000");
+	});
+});
+
+describe("non-HTTP listener protocols (D-60 rule 4)", () => {
+	const result = launchToCompose(readLaunch(WS_AND_GRPC), {
+		hostPorts: { socket: 19000, rpc: 50051 },
+	});
+
+	it("keeps $app.url on the http origin for a ws primary", () => {
+		expect(envOf(result.yaml, "wsgrpc-socket").APP_URL).toBe("http://localhost:19000");
+	});
+
+	it("derives http for a grpc listener too", () => {
+		const [api] = publishedEndpointAddresses("rpc", readLaunch(WS_AND_GRPC).components.rpc!.provides, {
+			rpc: 50051,
+		});
+		expect(api!.address.url).toBe("http://localhost:50051");
+		expect(api!.address.scheme).toBe("http");
+	});
+
+	it("still prints ws and grpc endpoints in their own readable form", () => {
+		// The printout is a rendering choice, not a second scheme derivation:
+		// an `http://` link to a gRPC port would be wrong to click.
+		expect(printedAddress(result, "socket")).toBe("ws://localhost:19000");
+		expect(printedAddress(result, "rpc")).toBe("localhost:50051 (grpc)");
+	});
+});
+
+describe("a supplied publication context (D-58 rules 2 and 5)", () => {
+	const opts: ComposeOpts = {
+		hostPorts: { default: 18443 },
+		appUrl: "https://notes.example.com",
+	};
+
+	it("wins over the listener for $app.*", () => {
+		const env = envOf(launchToCompose(readLaunch(SELF_TLS), opts).yaml, "selftls");
+		expect(env.APP_URL).toBe("https://notes.example.com");
+		expect(env.APP_SCHEME).toBe("https");
+	});
+
+	it("leaves the printed host address alone (#386 is a separate question)", () => {
+		const result = launchToCompose(readLaunch(SELF_TLS), opts);
+		expect(printedAddress(result, "default")).toBe("https://localhost:18443");
+	});
+});
+
+describe("an `https-origin` naming the primary endpoint (D-60 rule 3)", () => {
+	const opts: ComposeOpts = { hostPorts: { default: 18789, "default:bridge": 18790 } };
+
+	it("resolves $app.* from the named endpoint, not the first one", () => {
+		const env = envOf(launchToCompose(readLaunch(NAMED_PRIMARY), opts).yaml, "openclaw");
+		expect(env.APP_URL).toBe("https://localhost:18790");
+	});
+
+	it("prints every published endpoint from the same derivation", () => {
+		const result = launchToCompose(readLaunch(NAMED_PRIMARY), opts);
+		expect(printedAddress(result, "default")).toBe("http://localhost:18789");
+		expect(printedAddress(result, "default:bridge")).toBe("https://localhost:18790");
+		expect(printedAddress(result, "default:bridge")).toBe(
+			envOf(result.yaml, "openclaw").APP_URL,
+		);
+	});
+});
+
+describe("publishedAddress", () => {
+	it("gives no address at all when the app publishes nothing", () => {
+		const address = publishedAddress(undefined, 0);
+		expect(address).toEqual({
+			host: "localhost",
+			port: 0,
+			url: "",
+			authority: "",
+			scheme: "",
+			tls: "",
+		});
+	});
+
+	it("reads the scheme default from a supplied URL with no explicit port", () => {
+		expect(publishedAddress("http", 8080, "https://notes.example.com")).toEqual({
+			host: "notes.example.com",
+			port: 443,
+			url: "https://notes.example.com",
+			authority: "notes.example.com",
+			scheme: "https",
+			tls: "true",
+		});
+	});
+
+	it("is the only place $app.* and the printout get their scheme", () => {
+		const launch = readLaunch(SELF_TLS);
+		const app = computeAppProperties(launch, { default: 18443 });
+		expect(app.url).toBe(publishedAddress("https", 18443).url);
+		expect(endpointAddress(18443, "https")).toBe(String(app.url));
+	});
+});

--- a/providers/docker/src/app-url.ts
+++ b/providers/docker/src/app-url.ts
@@ -7,6 +7,13 @@
  * resolves identical `$app.*` everywhere. The `authority`/`scheme`/`tls`
  * trio always comes from the SDK's `deriveAppUrlProperties`; no second copy
  * of that derivation exists here.
+ *
+ * {@link publishedAddress} is the provider's ONE derivation of a published
+ * endpoint's host-side address. `$app.*` (here), the `status`/`up` printout
+ * (`endpointAddress` in `provider.ts`) and the endpoint metadata the compose
+ * generator persists all read it, so the address a deployment writes into an
+ * app's config and the address it prints to the operator cannot disagree
+ * (#473).
  */
 
 import {
@@ -15,7 +22,7 @@ import {
 	type NormalizedLaunch,
 	type Provides,
 } from "@launchfile/sdk";
-import { publishedEndpoints } from "./port-allocator.js";
+import { type PublishedEndpoint, publishedEndpoints } from "./port-allocator.js";
 
 /** The backing-service type that declares the app's public HTTPS origin (D-60). */
 export const HTTPS_ORIGIN = "https-origin";
@@ -180,27 +187,167 @@ export function normalizeAppUrl(value: string): string {
 }
 
 /**
+ * The host-side address of one published endpoint, in the parts D-35 names.
+ * `scheme`, `authority` and `tls` are derived from `url`, so the six fields
+ * can never describe two different addresses.
+ */
+export interface PublishedAddress {
+	/** Hostname the endpoint is reached at. */
+	host: string;
+	/** Port of the public address — the published host port, or the supplied URL's. */
+	port: number;
+	/** The full address, or `""` when there is none to give. */
+	url: string;
+	/** Hostname plus port, port omitted when it is the scheme default. */
+	authority: string;
+	/** `http` or `https`, `""` when there is no address. */
+	scheme: string;
+	/** `"true"` when the scheme is https, else `"false"` (`""` with no address). */
+	tls: string;
+}
+
+/**
+ * Derive a published endpoint's address — the provider's single definition.
+ *
+ * Two inputs, in priority order:
+ *
+ * 1. `appUrl`, the orchestrator-supplied publication context (#290). The
+ *    routing strategy has moved upstream, so the supplied URL answers and the
+ *    listener is not consulted at all (D-58 rules 2 and 5).
+ * 2. Otherwise the provider publishes the listener itself on `hostPort`, and
+ *    the scheme is `https` exactly when the listener's **effective** protocol
+ *    is `https` (D-61 rule 2) — either because the entry declares it or
+ *    because a certificate bound to it is active. `ws` and `grpc` keep `http`:
+ *    D-60 rule 4 fixes the HTTP-family origin as an http/https URL.
+ *
+ * `hostPort` of 0 means the app publishes nothing, which yields the empty URL
+ * (and empty authority/scheme/tls) every unresolved `$app.*` property degrades
+ * to.
+ *
+ * @param effectiveProtocol the listener's effective protocol, never the declared one
+ * @throws InvalidAppUrlError when `appUrl` is supplied and malformed
+ */
+export function publishedAddress(
+	effectiveProtocol: string | undefined,
+	hostPort: number,
+	appUrl?: string,
+): PublishedAddress {
+	if (appUrl !== undefined) {
+		const url = normalizeAppUrl(appUrl);
+		const u = new URL(url);
+		return {
+			host: u.hostname,
+			// $app.port is the port of the public address (SPEC.md: the external
+			// port the platform exposes) — explicit, else the scheme default.
+			port: u.port !== "" ? Number(u.port) : u.protocol === "https:" ? 443 : 80,
+			url,
+			...deriveAppUrlProperties(url),
+		};
+	}
+	const scheme = effectiveProtocol === "https" ? "https" : "http";
+	const url = hostPort > 0 ? `${scheme}://localhost:${hostPort}` : "";
+	return {
+		host: "localhost",
+		port: hostPort,
+		url,
+		...deriveAppUrlProperties(url),
+	};
+}
+
+/** A published endpoint together with the address the host reaches it at. */
+export interface PublishedEndpointAddress extends PublishedEndpoint {
+	/** Host port this endpoint was published on. */
+	hostPort: number;
+	/** The listener's effective protocol (D-61 rule 2), not the declared one. */
+	effectiveProtocol: string;
+	/** This endpoint's address, from {@link publishedAddress}. */
+	address: PublishedAddress;
+}
+
+/**
+ * Every host-published endpoint of one component, each with its address.
+ *
+ * `publishedEndpoints` stays the single answer to *which* endpoints are
+ * published and what key each is allocated under; this adds the single answer
+ * to *what address* each one has. Index alignment holds because both read the
+ * same `exposed: true` filter in declaration order.
+ *
+ * The host port is the caller's allocation for that key, falling back to the
+ * declared container port when no allocator has run.
+ */
+export function publishedEndpointAddresses(
+	componentName: string,
+	provides: Provides[] | undefined,
+	hostPorts?: Record<string, number>,
+	activeCertificates?: ReadonlySet<string>,
+): PublishedEndpointAddress[] {
+	const entries = provides?.filter((p) => p.exposed === true) ?? [];
+	return publishedEndpoints(componentName, provides).map((endpoint, index) => {
+		const hostPort = hostPorts?.[endpoint.key] ?? endpoint.port;
+		const { protocol } = effectiveListener(entries[index]!, activeCertificates);
+		return {
+			...endpoint,
+			hostPort,
+			effectiveProtocol: protocol,
+			address: publishedAddress(protocol, hostPort),
+		};
+	});
+}
+
+/**
+ * The app's primary published endpoint: the one an `https-origin` entry names
+ * when the file declares one (D-60 rule 3), else — positionally, as before —
+ * the first `exposed: true` entry of the first component that has one.
+ * `undefined` when the app publishes nothing.
+ */
+export function primaryPublishedEndpoint(
+	launch: NormalizedLaunch,
+	hostPorts?: Record<string, number>,
+	activeCertificates?: ReadonlySet<string>,
+): PublishedEndpointAddress | undefined {
+	const declared = declaredPrimaryEndpoint(launch);
+	if (declared) {
+		// A declared `https-origin` names the primary explicitly, so the
+		// positional answer below does not run — that is the whole point of
+		// D-60 rule 3. The named endpoint carries its own allocation key,
+		// which is how a non-first endpoint (openclaw's `bridge`) gets the
+		// host port that was actually allocated for it.
+		return publishedEndpointAddresses(
+			declared.component,
+			launch.components[declared.component]?.provides,
+			hostPorts,
+			activeCertificates,
+		).find((e) => e.key === declared.key);
+	}
+	for (const [name, component] of Object.entries(launch.components)) {
+		// Only endpoints explicitly marked `exposed: true` are reachable from the
+		// host (D-27), so only they can be the app's public address.
+		const published = publishedEndpointAddresses(
+			name,
+			component.provides,
+			hostPorts,
+			activeCertificates,
+		);
+		if (published.length > 0) return published[0];
+	}
+	return undefined;
+}
+
+/**
  * Compute the full `$app.*` set (D-33, D-35) for the Docker provider.
  *
- * With no `appUrl`, the provider's own routing strategy answers. Which endpoint
- * it answers for is the app's **primary**: the one an `https-origin` entry
- * names when the file declares one (D-60 rule 3), else — positionally, as
- * before — the first `exposed: true` entry of the first component that has
- * one. Its host port becomes `$app.port` and `http://localhost:<hostPort>`
- * becomes `$app.url`. Apps with no exposed component get `port: 0` and
- * `url: ""` (and empty authority/scheme/tls).
+ * `$app.*` is the address of the app's **primary** endpoint (see
+ * {@link primaryPublishedEndpoint}), derived by {@link publishedAddress} —
+ * the same call the `status`/`up` printout makes for that endpoint, so the two
+ * surfaces always agree (#473). Apps with no exposed component get `port: 0`
+ * and `url: ""` (and empty authority/scheme/tls).
  *
  * With an `appUrl` — the orchestrator-supplied publication context (#290) —
- * the routing strategy has moved upstream, and the supplied URL answers
- * instead: `$app.url` is the normalized value, `$app.host` its hostname,
- * `$app.port` its explicit port or the scheme default (443/80). Published
- * host ports are orthogonal and still allocated; they just aren't the address
- * anyone reaches the app at.
+ * the routing strategy has moved upstream and the supplied URL answers
+ * instead. Published host ports are orthogonal and still allocated; they just
+ * aren't the address anyone reaches the app at.
  *
- * Either way the `authority`/`scheme`/`tls` trio is derived from the URL via
- * the SDK's `deriveAppUrlProperties`, so the split-field tokens (e.g.
- * HedgeDoc's `CMD_DOMAIN: $app.authority`) resolve from one definition. For
- * multi-exposed-component apps that need a specific component's URL, use
+ * For multi-exposed-component apps that need a specific component's URL, use
  * `$components.<name>.url` instead — `$app.*` always points at the primary
  * endpoint to give a single, predictable answer.
  */
@@ -210,68 +357,9 @@ export function computeAppProperties(
 	appUrl?: string,
 	activeCertificates?: ReadonlySet<string>,
 ): Record<string, string | number> {
-	if (appUrl !== undefined) {
-		const url = normalizeAppUrl(appUrl);
-		const u = new URL(url);
-		return {
-			name: launch.name,
-			host: u.hostname,
-			// $app.port is the port of the public address (SPEC.md: the external
-			// port the platform exposes) — explicit, else the scheme default.
-			port: u.port !== "" ? Number(u.port) : u.protocol === "https:" ? 443 : 80,
-			url,
-			...deriveAppUrlProperties(url),
-		};
-	}
-
-	let primaryPort = 0;
-	/**
-	 * The primary endpoint's `provides` entry, when the positional or declared
-	 * choice resolves to one — the listener `$app.url` is computed from. This
-	 * branch IS the provider computing the public address from its own direct
-	 * publication of that listener, which is the one place D-61 rule 2 has
-	 * `$app.*` read the EFFECTIVE protocol. The supplied-URL branch above never
-	 * does: a supplied publication context wins (D-58 rule 5).
-	 */
-	let primaryEntry: Provides | undefined;
-	const declared = declaredPrimaryEndpoint(launch);
-	if (declared) {
-		// A declared `https-origin` names the primary explicitly, so the
-		// positional answer below does not run — that is the whole point of
-		// D-60 rule 3. The named endpoint carries its own allocation key,
-		// which is how a non-first endpoint (openclaw's `bridge`) gets the
-		// host port that was actually allocated for it.
-		primaryPort = hostPorts?.[declared.key] ?? declared.port;
-		primaryEntry = launch.components[declared.component]?.provides?.find(
-			(p) => p.name === declared.name,
-		);
-	} else {
-		for (const [name, component] of Object.entries(launch.components)) {
-			// Only endpoints explicitly marked `exposed: true` are reachable from the
-			// host (D-27), so only they can be the app's public address.
-			const published =
-				component.provides?.filter((p) => p.exposed === true) ?? [];
-			if (published.length === 0) continue;
-			// Prefer caller-supplied host port, fall back to the declared container port.
-			primaryPort = hostPorts?.[name] ?? published[0]!.port;
-			primaryEntry = published[0];
-			break;
-		}
-	}
-
-	// `https` only when a certificate bound to that very entry is active
-	// (D-61 rule 2). Every other app keeps the localhost answer byte for byte.
-	const scheme =
-		primaryEntry !== undefined &&
-		effectiveListener(primaryEntry, activeCertificates).active
-			? "https"
-			: "http";
-	const url = primaryPort > 0 ? `${scheme}://localhost:${primaryPort}` : "";
+	const primary = primaryPublishedEndpoint(launch, hostPorts, activeCertificates);
 	return {
 		name: launch.name,
-		host: "localhost",
-		port: primaryPort,
-		url,
-		...deriveAppUrlProperties(url),
+		...publishedAddress(primary?.effectiveProtocol, primary?.hostPort ?? 0, appUrl),
 	};
 }

--- a/providers/docker/src/compose-generator.ts
+++ b/providers/docker/src/compose-generator.ts
@@ -970,11 +970,14 @@ export function launchToCompose(
 			// `exposed: false`, which speaks to the host boundary and not to the
 			// container network.
 			//
-			// The scheme is the EFFECTIVE protocol of that entry (D-61 rule
-			// 2): `https` exactly when a certificate bound to it is active,
-			// `http` for every other app — byte-identical to before for any
-			// file that declares no `tls:`. The remaining hardcoded `http://`
-			// for non-web listener protocols is #391's scope, not this one.
+			// The scheme here follows `effectiveListener(...).active` — `https`
+			// only when a certificate bound to the entry is active. That is NOT
+			// the effective protocol of D-61 rule 2, which is also `https` when
+			// the entry declares `protocol: https` with no binding; this site
+			// writes `http://` for that entry. #391 tracks the fix, along with
+			// the hardcoded `http://` for non-web listener protocols. The
+			// published-address derivation below reads
+			// `effectiveListener(...).protocol` and does not share this defect.
 			const primaryListener = effectiveListener(
 				component.provides[0]!,
 				certificates.active,

--- a/providers/docker/src/compose-generator.ts
+++ b/providers/docker/src/compose-generator.ts
@@ -24,7 +24,11 @@ import {
 	unsuppliedRequiredEnv,
 } from "@launchfile/sdk";
 import { stringify } from "yaml";
-import { computeAppProperties, HTTPS_ORIGIN } from "./app-url.js";
+import {
+	computeAppProperties,
+	HTTPS_ORIGIN,
+	publishedEndpointAddresses,
+} from "./app-url.js";
 import {
 	certificateRefusalMessage,
 	planCertificates,
@@ -34,7 +38,6 @@ import {
 	registerSuppliedEnv,
 	registerSuppliedResourceProperties,
 } from "./env-secrets.js";
-import { publishedEndpoints } from "./port-allocator.js";
 import { registerSecret } from "./redact.js";
 import type { StateEndpoint } from "./state.js";
 
@@ -994,19 +997,30 @@ export function launchToCompose(
 			// app-level check after this loop catches the case that actually
 			// leaves the user stranded.
 			declaredProvides = true;
-			const published = publishedEndpoints(componentName, component.provides);
+			// One derivation of every published endpoint's address (#473):
+			// `status`/`up` print `endpointAddress(hostPort, protocol)` from
+			// this metadata, and `$app.*` reads the same derivation for the
+			// primary, so the persisted protocol is the EFFECTIVE one (D-61
+			// rule 2). The compose port mapping below still reads the DECLARED
+			// protocol — `/udp` is a wire-level fact a certificate cannot move.
+			const published = publishedEndpointAddresses(
+				componentName,
+				component.provides,
+				opts.hostPorts,
+				certificates.active,
+			);
 			if (published.length > 0) {
 				const seen = new Set<string>();
 				const mappings: string[] = [];
 				for (const endpoint of published) {
-					const hostPort = opts.hostPorts?.[endpoint.key] ?? endpoint.port;
+					const hostPort = endpoint.hostPort;
 					ports[endpoint.key] = hostPort;
 					endpoints[endpoint.key] = {
 						component: componentName,
 						name: endpoint.name,
 						containerPort: endpoint.port,
 						hostPort,
-						protocol: endpoint.protocol,
+						protocol: endpoint.effectiveProtocol,
 					};
 					const bind =
 						endpoint.bind && endpoint.bind !== "0.0.0.0"

--- a/providers/docker/src/index.ts
+++ b/providers/docker/src/index.ts
@@ -17,7 +17,14 @@ export {
 	type DockerUpOpts,
 	type DockerUpResult,
 } from "./provider.js";
-export { computeAppProperties, InvalidAppUrlError, normalizeAppUrl } from "./app-url.js";
+export {
+	computeAppProperties,
+	InvalidAppUrlError,
+	normalizeAppUrl,
+	// The provider's one derivation of a published endpoint's address (#473).
+	publishedAddress,
+	type PublishedAddress,
+} from "./app-url.js";
 export {
 	declaredEnvKeys,
 	DOCKER_PROVIDER,

--- a/providers/docker/src/provider.ts
+++ b/providers/docker/src/provider.ts
@@ -12,7 +12,7 @@ import {
 	selectionClosure,
 	UnboundOperatorStorageError,
 } from "@launchfile/sdk";
-import { normalizeAppUrl } from "./app-url.js";
+import { normalizeAppUrl, publishedAddress } from "./app-url.js";
 import { checkPrereqs, composeSupportsIgnoreBuildable } from "./prereqs.js";
 import { resolveSource } from "./source-resolver.js";
 import {
@@ -896,11 +896,16 @@ export function componentOfPortKey(
  * because an `http://` link to an SMTP or DNS port would be wrong. Keys with
  * no endpoint metadata (state files written by older versions) keep the
  * legacy `http://` form.
+ *
+ * The http/https choice is NOT made here: `publishedAddress` makes it, the
+ * same call `$app.url` goes through, so the address printed to the operator
+ * and the address written into the app's own config are one derivation
+ * (#473). `protocol` is the endpoint's EFFECTIVE protocol as persisted in
+ * state (D-61 rule 2), which is why an active certificate needs no second
+ * branch here.
  */
 export function endpointAddress(port: number, protocol?: string): string {
 	switch (protocol) {
-		case "https":
-			return `https://localhost:${port}`;
 		case "ws":
 			return `ws://localhost:${port}`;
 		case "tcp":
@@ -908,7 +913,7 @@ export function endpointAddress(port: number, protocol?: string): string {
 		case "grpc":
 			return `localhost:${port} (${protocol})`;
 		default:
-			return `http://localhost:${port}`;
+			return publishedAddress(protocol, port).url;
 	}
 }
 

--- a/providers/docker/src/state.ts
+++ b/providers/docker/src/state.ts
@@ -18,8 +18,11 @@ export type DockerSourceType = "local" | "catalog" | "url";
  * A published endpoint's metadata, keyed by the same key as its entry in
  * `DockerState.ports`. Carries what the ports map alone cannot: which
  * component the key belongs to, the endpoint's declared name (D-6), and its
- * protocol — so summary/status/list can print a protocol-correct address and
- * filter by component.
+ * EFFECTIVE protocol (D-61 rule 2) — the declared `protocol:` unless a bound
+ * certificate is active, in which case `https`. Writers persist the effective
+ * value: `status`, `up`, and `$app.url` all derive their address from it
+ * through `publishedAddress`, so persisting the declared value here splits
+ * them apart again (#473).
  */
 export interface StateEndpoint {
 	component: string;


### PR DESCRIPTION
Closes #473.

## Authority

The Author ruling on #463 ([comment](https://github.com/launchfile/launchfile/issues/463#issuecomment-5632191193)): *"Consolidate first. One derivation of a published endpoint's address in `@launchfile/docker`, folding the three sites the review names, lands as its own fix before this proposal; #473 is the evidence it is overdue."* Plus: *"Properties read the effective listener (D-61 rule 2): effective protocol and effective port, never the declared fields."*

The three sites are the ones the steward DEFER on #463 named ([comment](https://github.com/launchfile/launchfile/issues/463#issuecomment-5631899377)). **#463 ask 1 (consolidation) is satisfied by this PR** — the namespace and the D-60 rule 3 cap lift stay with #463.

No spec, schema, or resolver change. #386 and #391 are untouched (see *Out of scope* below).

## The defect

`$app.url` is what an app's own config consumes — absolute links, redirect URIs, callback URLs. It disagreed with what the operator was shown for the same endpoint, in both directions.

## The three sites, before and after

All "before" line numbers are `origin/main` @ `e7e4b9e` (post-#468).

| Site | Before | After |
|---|---|---|
| `providers/docker/src/app-url.ts` — `computeAppProperties`, the `$app.*` path | `:262-268` read only `effectiveListener(entry, active).active`, so a declared `protocol: https` entry with no certificate binding fell through to `"http"` | `:354` calls `publishedAddress` via `primaryPublishedEndpoint`; no scheme logic of its own |
| `providers/docker/src/provider.ts` — `endpointAddress`, the `status`/`up` printout | `:900-913` switched on the protocol persisted in state — the **declared** one — returning `https://` for that same entry, and `http://` for a declared-`http` entry whose binding was active | `:907` keeps only the raw-wire rendering (`ws://`, `localhost:<port> (tcp\|udp\|grpc)`); the http/https choice is `publishedAddress(protocol, port).url` |
| `providers/docker/src/port-allocator.ts` — `publishedEndpoints` | `:114-133` carried the declared protocol into state (`compose-generator.ts:1009`), which is what fed the drift downstream | unchanged as the enumerator; `publishedEndpointAddresses` (`app-url.ts:278`) pairs each entry with its address, and `compose-generator.ts:1006` persists the **effective** protocol |

### The single derivation

`publishedAddress(effectiveProtocol, hostPort, appUrl?)` (`app-url.ts:230`, exported from the package) returns `{ host, port, url, authority, scheme, tls }`. Every rule it applies is already ratified:

- scheme is `https` exactly when `effectiveListener(entry, active).protocol === "https"` — **D-61 rule 2** plus #473's fix, so the declared value carries when no certificate is bound;
- `ws` and `grpc` keep the http origin — **D-60 rule 4**;
- a supplied `appUrl` wins outright and the listener is not consulted — **D-58 rules 2 and 5**;
- the primary is the endpoint an `https-origin` entry names, else the first published one — **D-60 rule 3** (`primaryPublishedEndpoint`, `app-url.ts:303`).

`$app.*` for the primary and `endpointAddress` for that endpoint are now byte-identical by construction.

## Verified live (OBSERVED)

A fixture app built from a local Dockerfile, serving real TLS (self-signed, `python http.server` + `ssl`) on container port 8443, with `provides: [{ name: web, protocol: https, port: 8443, exposed: true }]` and `env: { APP_URL: $app.url, APP_SCHEME: $app.scheme, APP_TLS: $app.tls }`. Run against a real Docker daemon (Docker 29.7.2), same fixture, two builds. State was sandboxed to a scratch `HOME`; both deployments were destroyed and the built image removed.

**Before** — `origin/main` @ `e7e4b9e`, built from a detached worktree:

```
$ launchfile status tls473
Access URLs:
  default: https://localhost:8443

$ curl -sk https://localhost:8443/          # what the app itself received
APP_URL=http://localhost:8443 APP_SCHEME=http APP_TLS=false
```

The printout says `https://`, the app was configured with `http://`. `$app.scheme` and `$app.tls` are wrong together, as D-35 derives them from the same URL.

**After** — this branch:

```
$ launchfile up ./Launchfile
  tls473 is running at https://localhost:8443

$ launchfile status tls473
Access URLs:
  default: https://localhost:8443

$ curl -sk https://localhost:8443/
APP_URL=https://localhost:8443 APP_SCHEME=https APP_TLS=true
```

Both surfaces agree, and the URL is reachable over TLS.

## Tests

New file `providers/docker/src/__tests__/published-address.test.ts` (14 tests), asserting agreement between `$app.url` and the printed address in each case:

- **(a)** the #473 fixture — exposed `protocol: https`, no binding → both `https://localhost:<port>`, `$app.scheme` `https`, `$app.tls` `true`;
- **(b)** declared `protocol: http` + an **active** certificate binding → both `https://`; unselected → both stay `http://` (D-8);
- **(c)** `ws` and `grpc` → `$app.url` / `publishedAddress` give `http://` (D-60 rule 4), while the printout keeps `ws://localhost:<port>` and `localhost:<port> (grpc)` — a rendering choice, not a second scheme;
- **(d)** a supplied `appUrl` → `$app.*` comes from it; the printed host address is **unchanged** (#386 is a separate question and is not answered here);
- **(e)** an `https-origin` naming `bridge` (the openclaw shape) → `$app.url` resolves from the named endpoint's host port, and every published endpoint prints from the same derivation.

Regression-proved: with the two pre-fix behaviours temporarily restored (scheme from `.active`, declared protocol persisted), 6 of the 14 fail; with the fix, all pass.

```
providers/docker   bun run typecheck  ✓      bun run test   397 passed (29 files)   [383 before, +14]
sdk                bun run build      ✓      bun run test   474 passed (20 files)
catalog/test                                 bun run test    39 passed  (2 files)
providers/macos-dev                          bun run test   217 passed (10 files)
packages/launchfile bun run typecheck ✓      bun run test    96 passed (10 files)
```

`biome check` on the touched files reports only the pre-existing `noNonNullAssertion` / formatting findings that `origin/main` already reports for the same files; biome is not a CI gate for `providers/*`.

## Changeset

`@launchfile/docker` **patch** — names #473 and the consolidation.

## Notes for the reviewer

- **State now persists the effective protocol**, not the declared one (`StateEndpoint.protocol`). That is what lets `endpointAddress` stay free of a certificate branch. The compose port mapping still reads the **declared** protocol, because `/udp` is a wire-level fact a certificate cannot move. State files written by older versions are unaffected — they keep the legacy `http://` fallback.
- **`publishedAddress` is now public API** of `@launchfile/docker`. That is deliberate: #463's proposal reads from this derivation rather than adding a fourth site.
- **#391 is not made trivial by this.** `$components.<c>.<e>.url` in `compose-generator.ts` is the *in-network* address (compose service name + container port), a different address from the published one this function derives. It would want its own sibling derivation, not this one. Out of scope here, per the issue.
- **Live evidence covers case (a) only.** Case (b) needs a certificate supplied through `ComposeOpts.resources`, which the CLI does not expose; it is covered by unit tests against the generator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
