### PR TITLE
catalog: ntfy declares its smtp endpoint (closes #476)

### DIFF
--- a/catalog/apps/ntfy/Launchfile
+++ b/catalog/apps/ntfy/Launchfile
@@ -7,13 +7,34 @@ logo: https://raw.githubusercontent.com/binwiederhier/ntfy/main/web/public/stati
 
 image: binwiederhier/ntfy:latest
 provides:
-  - protocol: http
+  - name: web
+    protocol: http
     port: 80
+    exposed: true
+  # Opt-in SMTP listener for e-mail publishing (docs/config.md "E-mail
+  # publishing"): mail to [topic]@[NTFY_SMTP_SERVER_DOMAIN] publishes to the
+  # topic. Upstream leaves the server off until NTFY_SMTP_SERVER_LISTEN is set.
+  - name: smtp
+    protocol: tcp
+    port: 25
     exposed: true
 storage:
   data:
     path: /var/lib/ntfy
     persistent: true
+env:
+  NTFY_BASE_URL:
+    default: $app.url
+    description: "Public base URL of the web endpoint (upstream `base-url`); ntfy builds attachment links and e-mail footers from it"
+  NTFY_SMTP_SERVER_LISTEN:
+    description: "Address the SMTP server listens on (upstream `smtp-server-listen`). Unset keeps the SMTP server off; set to `:25` to serve the `smtp` endpoint"
+    example: ":25"
+  NTFY_SMTP_SERVER_DOMAIN:
+    description: "Public e-mail domain of the `smtp` endpoint (upstream `smtp-server-domain`); topic addresses are `[topic]@<this domain>`, so it must match the MX record that points at the endpoint. Required once NTFY_SMTP_SERVER_LISTEN is set"
+    example: "ntfy.example.com"
+  NTFY_SMTP_SERVER_ADDR_PREFIX:
+    description: "Optional address prefix for the SMTP server (upstream `smtp-server-addr-prefix`); with `ntfy-` only mail to `ntfy-[topic]@<domain>` is accepted, which limits spam on a public listener"
+    example: "ntfy-"
 commands:
   # The image's entrypoint is bare `ntfy` with no default command; without
   # `serve` it prints usage and exits.

--- a/catalog/apps/ntfy/Launchfile
+++ b/catalog/apps/ntfy/Launchfile
@@ -14,5 +14,9 @@ storage:
   data:
     path: /var/lib/ntfy
     persistent: true
+commands:
+  # The image's entrypoint is bare `ntfy` with no default command; without
+  # `serve` it prints usage and exits.
+  start: serve
 health: /v1/health
 restart: always


### PR DESCRIPTION
Closes #476
Closes #458

## What changed

Only `catalog/apps/ntfy/Launchfile` (two `catalog:` commits; `metadata.yaml` untouched).

**Commit 2 — the issue's shape (Author-directed, no steward verdict on the thread):**

- `provides`: the HTTP entry is now `name: web`; a second entry `name: smtp`, `protocol: tcp`, `port: 25`, `exposed: true` declares the SMTP listener. Both endpoints are addressable per [D-6](https://github.com/launchfile/launchfile/blob/main/spec/DESIGN.md#d-6-named-endpoints-on-provides).
- `env`:
  - `NTFY_BASE_URL: { default: $app.url }` — upstream `base-url`, "Public facing base URL of the service" (docs/config.md L2342; "the external URL of the ntfy server", L24; needed for attachment URLs L510 and e-mail footers L1029).
  - `NTFY_SMTP_SERVER_LISTEN` — bare declaration with `example: ":25"`. Upstream: "defines the IP address and port the SMTP server will listen on, e.g. `:25`" (L1068, table L2372).
  - `NTFY_SMTP_SERVER_DOMAIN` — bare declaration with `example`. Upstream: "the e-mail domain, e.g. `ntfy.sh` (must be identical to MX record)" (L1069, table L2373). The description names it as the public e-mail domain of the `smtp` endpoint and states the MX constraint.
  - `NTFY_SMTP_SERVER_ADDR_PREFIX` — bare declaration with `example: "ntfy-"`. Upstream: optional prefix; without it "all emails to `$topic@ntfy.sh` will be accepted (which may obviously be a spam problem)" (L1070-1072, table L2374). Included because the listener is `exposed: true`.

**Why no `default:` / no `required: true` on the SMTP variables.** The schema's `envVar` has no required properties, and SPEC.md → "Value provenance" defines exactly this class: *"User-supplied (no generator, no default) — never supplied or altered by the platform, whether `required: true` or a bare declaration whose presence activates a feature."* ([D-49](https://github.com/launchfile/launchfile/blob/main/spec/DESIGN.md#d-49-env-value-provenance--four-declaration-classes-with-per-layer-obligations)). Upstream keeps the SMTP server off until `smtp-server-listen` is set (L1066), so a `default:` on `NTFY_SMTP_SERVER_LISTEN` would turn a feature on for every operator; `required: true` would make every deploy fail. A default for `NTFY_SMTP_SERVER_DOMAIN` would be a fabricated MX domain — wrong in kind ([D-52](https://github.com/launchfile/launchfile/blob/main/spec/DESIGN.md#d-52-a-required-environment-variable-is-operator-supplied--providers-must-not-fabricate-one)). Catalog precedent for bare declarations: `paperclip` (`ANTHROPIC_API_KEY`), `remote-claude-concentrator` (`DEEPGRAM_API_KEY`).

No `$app.endpoints.*` reference — that expression does not exist yet. The endpoint→domain relationship is stated in prose in `description:` only. **#463 is the consumer of this fact**: `NTFY_SMTP_SERVER_DOMAIN` is a second published endpoint whose public address the app's own config needs every start.

**Commit 1 — pre-existing breakage found during verification (not in the issue):** `commands.start: serve`. OBSERVED: `binwiederhier/ntfy:latest` (built 2026-08-27) has `Entrypoint ["ntfy"]`, `Cmd null` (`docker inspect`); upstream `Dockerfile` L16 is `ENTRYPOINT ["ntfy"]` with no `CMD`. Without a start command the container prints usage, exits 0, restart-loops (8 restarts observed), and the harness reports `FAIL — container ntfy-ntfy-1 is unhealthy`. Upstream's own compose example passes `command: serve` (docs/config.md L108). Verified in isolation: harness `PASS` with only this commit applied. Without it none of the checks below could run.

## Verification (OBSERVED)

- `cd sdk && bun run build && bun run src/cli.ts validate ../catalog/apps/ntfy/Launchfile` → `✓ ntfy is valid` (only the pre-existing D-40 image-only warning).
- `cd catalog/test && bun run src/test-app.ts ntfy` (full run, image pulled, containers started):
  ```
  Containers healthy in 6s
  === ntfy: PASS ===
  ```
  Generated compose `environment:` contains **only** `NTFY_BASE_URL: http://localhost:80`; the three SMTP variables are absent (not empty). `ports:` is `0:80`, `0:25`; `command: serve`.
- Default behaviour unchanged — SMTP stays off: `docker compose logs` → `INFO Listening on :80[http], ntfy 2.28.0` (no smtp); `grep -ic smtp` over the logs → `0`; `netstat -tln` inside the container shows only `:::80`; health `healthy`.
- Opt-in works and the `smtp` endpoint is real: `docker run … -e NTFY_SMTP_SERVER_LISTEN=:25 -e NTFY_SMTP_SERVER_DOMAIN=ntfy.example.com -e NTFY_SMTP_SERVER_ADDR_PREFIX=ntfy- binwiederhier/ntfy:latest serve` → `INFO Listening on :80[http] :25[smtp]`; `EHLO` over the mapped port → `220 ntfy.example.com ESMTP Service Ready` / `250-Hello probe.local`.
- `cd catalog/test && bun run test` → 39/39 passed (2 files).

Harness runs rewrote `metadata.yaml`; it was restored to `main`'s copy so this PR does not touch it. A reviewer may want the `last_tested` date bumped — left out per the issue's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

