### PR TITLE
catalog: drafts — wg-easy declares its WireGuard endpoint; drop the false "no UDP" gap notes (closes #477)

### DIFF
--- a/catalog/GAPS.md
+++ b/catalog/GAPS.md
@@ -148,7 +148,7 @@ Each gap includes the apps that exposed it and a severity rating.
 | G-3 | Appwrite |
 | G-4 | Plausible |
 | G-5 | Rocket.Chat |
-| G-9 | Home Assistant |
+| G-9 | Home Assistant, Syncthing |
 | G-9b | Home Assistant |
 | G-10 | Ollama, Jellyfin, Plex, Immich |
 | G-11 | Jellyfin, Home Assistant, Diun, Calibre Web |

--- a/catalog/drafts/pihole/Launchfile
+++ b/catalog/drafts/pihole/Launchfile
@@ -3,10 +3,12 @@ version: launch/v1
 name: pihole
 description: "Network-wide ad blocking via DNS"
 
-# GAP: Pi-hole needs DNS on port 53 (both TCP and UDP). The spec can express
-# TCP via protocol: tcp but has no UDP protocol option. Pi-hole also often
+# GAP: Pi-hole needs DNS on port 53 over both TCP and UDP (upstream compose
+# publishes 53:53/tcp and 53:53/udp). Both are declared below — `udp` is in
+# the protocol enum (G-8 in ../../GAPS.md is addressed). Pi-hole also often
 # requires host network mode or specific port bindings for DNS to function
-# correctly on the host.
+# correctly on the host: clients expect the resolver on host port 53 exactly,
+# and on a bridge network upstream sets FTLCONF_dns_listeningMode=all.
 
 image: pihole/pihole:latest
 provides:
@@ -16,6 +18,9 @@ provides:
     exposed: true
   - name: dns
     protocol: tcp
+    port: 53
+  - name: dns-udp
+    protocol: udp
     port: 53
 env:
   WEBPASSWORD:

--- a/catalog/drafts/syncthing/Launchfile
+++ b/catalog/drafts/syncthing/Launchfile
@@ -3,9 +3,13 @@ version: launch/v1
 name: syncthing
 description: "Continuous peer-to-peer file synchronization"
 
-# GAP: Syncthing exposes port 22000 for its sync protocol (TCP/QUIC).
-# While we can model this via provides with protocol: tcp, the QUIC (UDP)
-# transport cannot be expressed. The spec also has no way to express UDP ports.
+# Syncthing's sync protocol listens on 22000 over both TCP and QUIC (UDP), and
+# local discovery uses 21027/UDP (docs: users/firewall.rst). All three are
+# declared below — `udp` is in the protocol enum (G-8 in ../../GAPS.md is
+# addressed). Remaining gap: QUIC is not its own protocol value, so the
+# 22000/UDP entry declares the transport, not the QUIC layer on top of it.
+# Local discovery relies on broadcast/multicast, which Docker's default bridge
+# network does not forward (upstream README-Docker.md "Discovery") — see G-9.
 
 image: syncthing/syncthing:latest
 provides:
@@ -16,6 +20,12 @@ provides:
   - name: sync
     protocol: tcp
     port: 22000
+  - name: sync-quic
+    protocol: udp
+    port: 22000
+  - name: discovery
+    protocol: udp
+    port: 21027
 storage:
   data:
     path: /var/syncthing

--- a/catalog/drafts/wg-easy/Launchfile
+++ b/catalog/drafts/wg-easy/Launchfile
@@ -5,21 +5,43 @@ version: launch/v1
 name: wg-easy
 description: "WireGuard VPN server with simple web management UI"
 repository: https://github.com/wg-easy/wg-easy
-logo: https://raw.githubusercontent.com/wg-easy/wg-easy/master/src/www/img/logo.svg
+logo: https://raw.githubusercontent.com/wg-easy/wg-easy/master/src/public/logo.png
 
-image: ghcr.io/wg-easy/wg-easy:latest
+# Pinned to the v15 major. v15 does not read the v14 env names (WG_HOST,
+# WG_PORT, PASSWORD_HASH); its unattended first-boot setup is the INIT_* group
+# (docs/content/advanced/config/unattended-setup.md). INIT_* is read on the
+# first start only — after that the settings live in /etc/wireguard.
+image: ghcr.io/wg-easy/wg-easy:15
 provides:
-  - protocol: http
+  - name: web
+    protocol: http
     port: 51821
     exposed: true
-  - protocol: udp
+  # The WireGuard endpoint every VPN client connects to.
+  - name: wg
+    protocol: udp
     port: 51820
+    exposed: true
 env:
-  WG_HOST:
-    required: true
-    description: "Public hostname or IP for WireGuard"
-  PASSWORD_HASH:
+  INIT_ENABLED:
+    default: "true"
+    description: "Enable unattended first-boot setup from the INIT_* variables"
+  INIT_USERNAME:
+    default: "admin"
+    description: "Admin username for the web UI (first boot only)"
+  INIT_PASSWORD:
     generator: secret
     sensitive: true
-    description: "bcrypt hash of admin password"
+    description: "Admin password for the web UI (first boot only)"
+  INIT_HOST:
+    required: true
+    description: "Public hostname or IP of the `wg` endpoint — what VPN clients connect to"
+  # INIT_PORT also sets WireGuard's in-container listen port, so the `wg`
+  # endpoint needs a 1:1 host publication (host port == container port).
+  INIT_PORT:
+    default: "51820"
+    description: "Public UDP port of the `wg` endpoint — must equal the port the `wg` endpoint is published on"
+  INSECURE:
+    default: "true"
+    description: "Allow the web UI over plain HTTP; set to false behind a TLS-terminating reverse proxy"
 restart: always

--- a/catalog/drafts/wg-easy/Launchfile
+++ b/catalog/drafts/wg-easy/Launchfile
@@ -34,6 +34,7 @@ env:
     sensitive: true
     description: "Admin password for the web UI (first boot only)"
   INIT_HOST:
+    default: $app.host
     required: true
     description: "Public hostname or IP of the `wg` endpoint — what VPN clients connect to"
   # INIT_PORT also sets WireGuard's in-container listen port, so the `wg`
@@ -43,5 +44,9 @@ env:
     description: "Public UDP port of the `wg` endpoint — must equal the port the `wg` endpoint is published on"
   INSECURE:
     default: "true"
-    description: "Allow the web UI over plain HTTP; set to false behind a TLS-terminating reverse proxy"
+    description: "Drops the Secure flag from the admin session cookie so login works over plain HTTP; set false when a TLS-terminating proxy fronts the `web` endpoint"
 restart: always
+storage:
+  config:
+    path: /etc/wireguard
+    persistent: true


### PR DESCRIPTION
Closes #477

Three files under `catalog/drafts/`, one `catalog:` commit. No spec, SDK, provider, or `metadata.yaml` change.

## How the issue's shape was addressed

### 1. `drafts/wg-easy/Launchfile` — pin to one major, use that major's env names

**Chose v15** (`ghcr.io/wg-easy/wg-easy:15`). It *can* be started unattended from env: upstream `docs/content/advanced/config/unattended-setup.md` documents the `INIT_*` group — `INIT_ENABLED`, then group 1 (`INIT_USERNAME`, `INIT_PASSWORD`, `INIT_HOST`, `INIT_PORT`), all of which must be set together and are read on the first start only. v14 (`WG_HOST`/`WG_PORT`/`PASSWORD_HASH`) is the frozen legacy branch (its README: "This branch is only for the v14 release"), so pinning there would trade a mixed file for a stale one. I verified v15's unattended path live (below).

- HTTP entry named `web`; UDP entry named `wg` with `exposed: true`.
- `INIT_HOST` / `INIT_PORT` descriptions say they are the public host/port **of the `wg` endpoint**, in prose only — no `$app.endpoints.*` reference (that context does not exist yet; #463).
- Inline comment: `INIT_PORT` also sets WireGuard's in-container listen port, so the `wg` endpoint needs a 1:1 host publication.
- `INIT_PASSWORD` uses `generator: secret` + `sensitive: true` (upstream checks no complexity; a generated secret is fine). `INIT_USERNAME` defaults to `admin`, `INIT_ENABLED` to `"true"`.
- `INSECURE: "true"` added: v15 refuses the web UI over plain HTTP without it (`docs/.../reverse-proxyless.md`, and the upstream `docker run` example sets it). Without it the declared `http` `web` endpoint does not work. Description says to set it false behind a TLS-terminating proxy.
- Logo URL moved to `src/public/logo.png` — the old `src/www/img/logo.svg` is HTTP 404 on both `master` and the `v14.0.0` tag (checked with `curl -sI`). Tied to the major pin; drop it if you want the diff narrower.
- Existing NET_ADMIN comment kept verbatim.

**Relation to #274:** #274 is the pending per-app `exposed: true` pass over the 20 `drafts/` endpoints that relied on accidental publication. This PR makes wg-easy's call — `wg` is the endpoint every VPN client connects to and gets `exposed: true` here. The new syncthing/pihole UDP entries deliberately take **no** `exposed:` flag, matching their existing sibling `tcp` entries; that decision stays with #274.

### 2. `drafts/syncthing/Launchfile` and 3. `drafts/pihole/Launchfile` — drop the false "no UDP" sentences

`udp` is in the `protocol` enum (`spec/schema/launchfile.schema.json:120`, `spec/SPEC.md:158`), and `catalog/GAPS.md:139` records "G-8 UDP now addressed in spec". The comments claiming otherwise are deleted; each now cites G-8 as addressed.

Kept, because still true: syncthing's note that QUIC is not its own protocol value (the `udp:22000` entry declares the transport, not the QUIC layer) plus the bridge-network discovery limit (upstream `README-Docker.md` "Discovery", cross-referenced to G-9); pihole's host-port-53 binding note (clients expect the resolver on host port 53 exactly; on a bridge network upstream sets `FTLCONF_dns_listeningMode=all`).

UDP entries declared only where upstream documents the port:

| App | New entry | Upstream source |
|-----------|----------------------------|-------------------------------------------------------------------|
| pihole | `dns-udp` `udp:53` | `docker-pi-hole` README compose: `"53:53/tcp"`, `"53:53/udp"` |
| syncthing | `sync-quic` `udp:22000` | `syncthing/docs` `users/firewall.rst`: "Port 22000/UDP: QUIC based sync protocol traffic" |
| syncthing | `discovery` `udp:21027` | same file: "Port 21027/UDP: for discovery broadcasts on IPv4 and multicasts on IPv6" |

## Verification

**Validate (SDK built in the worktree: `cd sdk && bun install --frozen-lockfile && bun run build`, then `bun run dist/cli.js validate <file>`):**

```
=== validate catalog/drafts/wg-easy/Launchfile ===
✓ wg-easy is valid
  components: default
  warning: (top-level): builds only from a prebuilt `image:` — no `runtime`, `commands.build`, or `commands.install` (D-40)
exit=0
=== validate catalog/drafts/syncthing/Launchfile ===
✓ syncthing is valid
  components: default
  warning: (top-level): builds only from a prebuilt `image:` — no `runtime`, `commands.build`, or `commands.install` (D-40)
exit=0
=== validate catalog/drafts/pihole/Launchfile ===
✓ pihole is valid
  components: default
  warning: (top-level): builds only from a prebuilt `image:` — no `runtime`, `commands.build`, or `commands.install` (D-40)
exit=0
```

(The D-40 warning is the pre-existing image-only condition on all three drafts; unchanged by this PR.)

**Harness translation (`catalog/test`, `bun run src/test-app.ts <app> --dry-run`):** syncthing and pihole translate to compose cleanly (published ports: only the `exposed: true` HTTP entry, as expected). wg-easy stops at "unsupplied required environment variable: INIT_HOST" — there is no `metadata.yaml` with `test_env` for this draft, and this PR does not add one. Not run live through the harness (needs NET_ADMIN and a `test_env`).

**Live smoke of the v15 unattended path (observed, `docker run` directly, then torn down):** ran `ghcr.io/wg-easy/wg-easy:15` with `INIT_ENABLED=true INIT_USERNAME=admin INIT_PASSWORD=<generated> INIT_HOST=vpn.example.test INIT_PORT=51820 INSECURE=true`, `--cap-add NET_ADMIN --cap-add SYS_MODULE` and the two upstream IPv4 sysctls.
- logs: `Wireguard Interface wg0 started successfully`
- `GET /` → `302 → /login` (setup wizard skipped — unattended setup took)
- `docker exec … wg show wg0 listen-port` → `51820` (INIT_PORT sets the in-container listen port, as the inline comment says)
- `POST /api/auth/password` with INIT_USERNAME/INIT_PASSWORD → `{"status":"success"}` HTTP 200
- created a client and fetched its generated config: `Endpoint = vpn.example.test:51820` — INIT_HOST:INIT_PORT is exactly the `wg` endpoint's public address.

## Notes for the reviewer

- The catalog test harness (`catalog/test/src/launch-to-compose.ts:446`) publishes exposed ports as `0:<port>` with no `/udp` suffix and an ephemeral host port. That is a harness limitation unrelated to this PR, but it means the harness cannot yet exercise `wg`'s 1:1 UDP publication. No open issue covers it (searched `udp`, `harness ports`); worth filing as a follow-up if you agree.
- pihole's `WEBPASSWORD` env: the current upstream `docker-pi-hole` README compose sets the admin password via `FTLCONF_webserver_api_password` instead. Out of scope here, left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## After steward round 1 (head `e0326d2`)

The round-1 review found four blockers, all fixed in `e0326d2`: `storage.config` persists `/etc/wireguard` (a redeploy no longer re-runs first-boot setup), `INIT_HOST` defaults to `$app.host` so the harness no longer stops on it, the `INSECURE` description now says what it does (drops the session cookie's `Secure` flag; the server answers HTTP either way), and Syncthing is listed under G-9. Round 2 ACCEPT. The harness limitation (ports published as `0:<port>` with no `/udp`, so 1:1 UDP publication cannot be exercised) is #482.
