### PR TITLE
packages: a boolean CLI flag refuses a value instead of ignoring it

### DIFF
--- a/.changeset/cli-boolean-flags-reject-values.md
+++ b/.changeset/cli-boolean-flags-reject-values.md
@@ -1,0 +1,5 @@
+---
+"launchfile": patch
+---
+
+Fixed boolean CLI flags silently ignoring a `--flag=<value>` spelling. `launchfile bootstrap <app> --reveal=false` printed the sensitive capture it looked like it was suppressing, and `launchfile up . --dry-run=true` ran a real deploy — neither helper behind those flags reads the text after `=`, so the value meant nothing in one direction or the other. The CLI now names every bare boolean flag in one table and refuses the valued spelling before it dispatches a command: `--reveal takes no value, e.g. --reveal`, exit code 1. The `--flag=<value>` form still works for the flags that take a value (`--name`, `--component`, `--schema-path`, `--storage`).

--- a/packages/launchfile/src/__tests__/cli-args.test.ts
+++ b/packages/launchfile/src/__tests__/cli-args.test.ts
@@ -5,15 +5,19 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+	BOOLEAN_FLAGS,
 	flagPresent,
 	getFlagValue,
 	getFlagValues,
 	getPositional,
 	hasFlag,
 	parseStoragePairs,
+	VALUE_FLAGS,
+	valuedBooleanFlag,
 } from "../cli-args.js";
 
 describe("getPositional (#248)", () => {
@@ -170,5 +174,123 @@ describe("--reveal on bootstrap (D-62): exact long form, no alias, no value", ()
 		const args = ["bootstrap", "--reveal", "ghost"];
 		expect(getPositional(args, 0)).toBe("bootstrap");
 		expect(getPositional(args, 1)).toBe("ghost");
+	});
+});
+
+describe("valuedBooleanFlag (#485)", () => {
+	it("accepts the bare form of every boolean flag", () => {
+		for (const flag of BOOLEAN_FLAGS) {
+			const args = ["up", `--${flag}`];
+			expect(valuedBooleanFlag(args)).toBeUndefined();
+			expect(hasFlag(args, flag)).toBe(true);
+			expect(flagPresent(args, flag)).toBe(true);
+		}
+	});
+
+	it("names a boolean flag written as --flag=false", () => {
+		for (const flag of BOOLEAN_FLAGS) {
+			expect(valuedBooleanFlag(["up", `--${flag}=false`])).toBe(flag);
+		}
+	});
+
+	it("names a boolean flag written as --flag=true", () => {
+		for (const flag of BOOLEAN_FLAGS) {
+			expect(valuedBooleanFlag(["up", `--${flag}=true`])).toBe(flag);
+		}
+	});
+
+	it("names a boolean flag written with an empty value", () => {
+		expect(valuedBooleanFlag(["bootstrap", "ghost", "--reveal="])).toBe(
+			"reveal",
+		);
+	});
+
+	it("leaves the =-form of a value flag alone", () => {
+		for (const flag of VALUE_FLAGS) {
+			expect(valuedBooleanFlag(["up", `--${flag}=x`])).toBeUndefined();
+		}
+		expect(valuedBooleanFlag([])).toBeUndefined();
+		expect(
+			valuedBooleanFlag(["up", "--storage", "music=/srv/music"]),
+		).toBeUndefined();
+	});
+
+	it("ignores a positional that happens to contain an =", () => {
+		expect(valuedBooleanFlag(["up", "KEY=value"])).toBeUndefined();
+		expect(valuedBooleanFlag(["up", "-json=false"])).toBeUndefined();
+	});
+
+	it("returns the first offender when several appear", () => {
+		expect(valuedBooleanFlag(["up", "--dry-run=true", "--json=false"])).toBe(
+			"dry-run",
+		);
+	});
+});
+
+describe("the flag tables cover cli.ts exactly (#485)", () => {
+	it("declares no flag in both tables", () => {
+		const both = [...BOOLEAN_FLAGS].filter((flag) => VALUE_FLAGS.has(flag));
+		expect(both).toEqual([]);
+	});
+
+	/**
+	 * A flag cli.ts reads but neither table names inherits #485's bug: an
+	 * unlisted boolean silently accepts an ignored value. Reading the source is
+	 * what makes the next flag added fail here rather than in an operator's CI log.
+	 */
+	it("names every long flag cli.ts reads in exactly one table", () => {
+		const source = readFileSync(
+			resolve(import.meta.dirname, "..", "cli.ts"),
+			"utf-8",
+		);
+		const calls =
+			/\b(?:args)?(?:[hH]asFlag|[fF]lagPresent|[gG]etFlagValues?)\(\s*(?:args,\s*)?"([^"]+)"/g;
+		const read = new Set<string>();
+		for (const [, flag] of source.matchAll(calls)) if (flag) read.add(flag);
+
+		expect(read.size).toBeGreaterThan(0);
+		const unlisted = [...read].filter(
+			(flag) => !BOOLEAN_FLAGS.has(flag) && !VALUE_FLAGS.has(flag),
+		);
+		expect(unlisted).toEqual([]);
+	});
+});
+
+describe("launchfile --flag=value on a boolean flag (built CLI, #485)", () => {
+	const CLI = join(resolve(import.meta.dirname, "..", ".."), "dist", "cli.js");
+
+	function run(cliArgs: string[]): { output: string; exitCode: number } {
+		try {
+			const output = execFileSync("node", [CLI, ...cliArgs], {
+				encoding: "utf-8",
+				stdio: ["ignore", "pipe", "pipe"],
+			});
+			return { output, exitCode: 0 };
+		} catch (err) {
+			const e = err as { stdout?: string; stderr?: string; status?: number };
+			return {
+				output: `${e.stdout ?? ""}${e.stderr ?? ""}`,
+				exitCode: e.status ?? 1,
+			};
+		}
+	}
+
+	it.each([...BOOLEAN_FLAGS])("refuses a value on --%s", (flag) => {
+		for (const value of ["false", "true"]) {
+			const { output, exitCode } = run(["up", `--${flag}=${value}`]);
+			expect(exitCode).toBe(1);
+			expect(output).toContain(`--${flag} takes no value, e.g. --${flag}`);
+		}
+	});
+
+	it("refuses before dispatch, so bootstrap never prints the sensitive capture (D-62)", () => {
+		const { output, exitCode } = run(["bootstrap", "ghost", "--reveal=false"]);
+		expect(exitCode).toBe(1);
+		expect(output).toContain("--reveal takes no value, e.g. --reveal");
+	});
+
+	it("still accepts the =-form of a value flag", () => {
+		const { output } = run(["schema", "--schema-path=/nope/schema.json"]);
+		expect(output).not.toContain("takes no value");
 	});
 });

--- a/packages/launchfile/src/cli-args.ts
+++ b/packages/launchfile/src/cli-args.ts
@@ -16,6 +16,45 @@ export const VALUE_FLAGS: ReadonlySet<string> = new Set([
 	"storage",
 ]);
 
+/**
+ * Flags that are bare booleans — present or absent, never `--flag=value`.
+ * Every long flag `cli.ts` reads is in exactly one of the two tables; a boolean
+ * flag missing from this one silently accepts an ignored value (#485).
+ */
+export const BOOLEAN_FLAGS: ReadonlySet<string> = new Set([
+	"docker",
+	"native",
+	"detach",
+	"dry-run",
+	"destroy",
+	"follow",
+	"json",
+	"quiet",
+	"detached",
+	"no-color",
+	"version",
+	"help",
+	"reveal",
+]);
+
+/**
+ * The first boolean flag written as `--flag=value`, or undefined when none is.
+ * Neither helper below reads the value after `=`: `flagPresent` counts
+ * `--reveal=false` as present and `hasFlag` counts `--dry-run=true` as absent,
+ * so the spelling means the opposite of what it says in one direction or the
+ * other. The caller rejects it rather than guessing ([D-62]).
+ */
+export function valuedBooleanFlag(args: readonly string[]): string | undefined {
+	for (const arg of args) {
+		if (!arg.startsWith("--")) continue;
+		const eq = arg.indexOf("=");
+		if (eq === -1) continue;
+		const flag = arg.slice(2, eq);
+		if (BOOLEAN_FLAGS.has(flag)) return flag;
+	}
+	return undefined;
+}
+
 export function hasFlag(args: readonly string[], flag: string): boolean {
 	return args.includes(`--${flag}`) || args.includes(`-${flag[0]}`);
 }

--- a/packages/launchfile/src/cli.ts
+++ b/packages/launchfile/src/cli.ts
@@ -31,6 +31,7 @@ import {
 	getFlagValues as argsGetFlagValues,
 	getPositional as argsGetPositional,
 	flagPresent as argsFlagPresent,
+	valuedBooleanFlag,
 	parseStoragePairs,
 } from "./cli-args.js";
 
@@ -125,6 +126,15 @@ Examples:
 `;
 
 async function main(): Promise<void> {
+	// One pass before dispatch: a boolean flag's value is never read, so
+	// `--reveal=false` would reveal and `--dry-run=true` would deploy for real.
+	// Rejecting the spelling here covers every call site of both helpers (#485).
+	const valued = valuedBooleanFlag(args);
+	if (valued !== undefined) {
+		console.error(`--${valued} takes no value, e.g. --${valued}`);
+		process.exit(1);
+	}
+
 	if (hasFlag("version")) {
 		console.log(`launchfile ${VERSION}`);
 		return;
@@ -191,8 +201,9 @@ async function main(): Promise<void> {
 		case "bootstrap":
 			await handleBootstrap(target, {
 				component: getFlagValue("component"),
-				// `flagPresent` matches `--reveal` and `--reveal=<anything>`, so
-				// `--reveal=false` also reveals — the rule for every boolean flag here (#485).
+				// D-62 spells `--reveal` as a bare boolean with no alias, so it reads
+				// through `flagPresent` (exact long form) rather than `hasFlag`, which
+				// would also match a `-r` the decision refuses by name.
 				reveal: argsFlagPresent(args, "reveal"),
 			});
 			break;


### PR DESCRIPTION
Closes #485

## What changed

**`packages:` a boolean CLI flag refuses a value instead of ignoring it** (`a88b853`)

- `BOOLEAN_FLAGS: ReadonlySet<string>` in `packages/launchfile/src/cli-args.ts`, beside the `VALUE_FLAGS` table #248 added. It names the thirteen bare booleans `cli.ts` reads: `docker`, `native`, `detach`, `dry-run`, `destroy`, `follow`, `json`, `quiet`, `detached`, `no-color`, `version`, `help`, `reveal`.
- `valuedBooleanFlag(args)` returns the first member written as `--flag=<value>`, or `undefined`. It contains no `process.exit`, so `cli-args.ts` stays testable without spawning the CLI.
- `main()` calls it once, before dispatch: stderr `--<flag> takes no value, e.g. --<flag>`, then `process.exit(1)`. One check covers every call site of both helpers.
- `--reveal` stays on `flagPresent` and no call site changes.
- The comment at `cli.ts:194-195` described the defect, so the fix made it false. It now states why `--reveal` reads through `flagPresent` rather than `hasFlag`.
- 24 new tests in `packages/launchfile/src/__tests__/cli-args.test.ts` (22 → 46): the bare form of every boolean flag, `=false` and `=true` refused for every boolean flag through the built CLI, the `=`-form of every value flag left alone, a positional containing `=`, the first-offender case, the two tables are disjoint, and every long flag `cli.ts` reads is in exactly one table.

**`chore:` changeset for the boolean-flag value rejection** (`45eca18`)

- `.changeset/cli-boolean-flags-reject-values.md` — `"launchfile": patch`. A bug fix in the CLI's own argument parsing, per `RELEASING.md`.

## Why

The steward's ACCEPT verdict on #485 bound this shape, and this PR implements it and nothing wider.

[D-62] spells the reveal act as "a bare boolean with no alias, no per-key form, and no terminal heuristic" (`spec/DESIGN.md:770`). `--reveal=false` is a per-key-looking form that reveals — the code contradicted a ratified decision. [P-11] separates intent from execution: a flag whose value is parsed and then discarded executes something the operator did not intend.

The verdict corrected two claims in the issue body, and this PR follows the verdict, not the issue:

- `down --destroy=false` does **not** destroy. `cli.ts:176` calls `hasFlag`, which matches the exact `--destroy` token or the `-d` alias only — so `--destroy=false` reads as *absent*. Same root cause, opposite direction.
- `--yes` does not exist in the shipped CLI. No table here names it.

Both the "proposed fix" bullets in the issue put the rule inside `flagPresent`, which `--destroy`, `--dry-run` and `--detached` never reach. The rule sits above both helpers instead.

No new `D-*` entry: the fix moves the code toward wording already ratified.

### Out of scope

- `hasFlag`'s `-${flag[0]}` alias collides — a single `-d` on `up` satisfies the `docker`, `detach` and `dry-run` checks at once (`cli-args.ts:19-21` with `cli.ts:152-155`). The verdict names this as deserving its own issue. Untouched here.
- The issue body's Problem table is still wrong on GitHub. Correcting it is an edit to the issue, not to the tree.
- No spec, schema, provider, doc or catalog change. A repo-wide grep for `--(docker|native|detach|dry-run|destroy|follow|json|quiet|detached|no-color|version|help|reveal)=` found no occurrence outside the files this PR touches, so no doc describes the behaviour that changed.
- `bun run lint` fails in `packages/launchfile` on `main` and still fails here. The repo ships no `biome.json`, so `biome check` runs at its 80-column default against source written to 100 — 32 pre-existing errors across 28 files. This PR adds none: the diagnostic list is byte-identical to `main`'s apart from the line numbers my insertions shift.

## Verification

Run from `/Users/ziadsawalha/code/launchfile/worktrees/issue-485`, branch at `45eca18`.

```
cd sdk && bun install && bun run build && bun run test
  → 21 test files passed, 520 tests passed

cd packages/launchfile && bun install && bun run typecheck && bun run build && bun run test
  → typecheck clean (tsc --noEmit), build clean (tsc -p tsconfig.build.json)
  → 11 test files passed, 129 tests passed

cd packages/launchfile && bunx vitest run src/__tests__/cli-args.test.ts
  → 46 tests passed (22 on main)
```

No `providers/*` file changed, so no provider suite was run. No Docker-daemon suite was skipped — the new CLI tests exit before dispatch and need no daemon.

**Observed live**, against the freshly built `packages/launchfile/dist/cli.js`:

```
$ node dist/cli.js bootstrap ghost --reveal=false
--reveal takes no value, e.g. --reveal
exit=1

$ node dist/cli.js up . --dry-run=true
--dry-run takes no value, e.g. --dry-run
exit=1

$ node dist/cli.js down ghost --destroy=false
--destroy takes no value, e.g. --destroy
exit=1

$ node dist/cli.js bootstrap no-such-app-xyz --reveal
No deployment found for "no-such-app-xyz".
Run `launchfile list` to see active deployments.

$ node dist/cli.js up --name=test-a --dry-run
No Launchfile found in the current directory.
Usage: launchfile up <slug|path>

$ node dist/cli.js --version
launchfile 0.9.0
```

The bare `--reveal` reaches dispatch and fails on the missing deployment, not on the flag. `--name=test-a` still parses. The root cause is unchanged and still observable in the helpers this PR deliberately did not alter:

```
$ node -e 'import("./dist/cli-args.js").then((m) => { ... })'
flagPresent([--reveal=false], reveal) = true     # would have revealed
hasFlag([--dry-run=true], dry-run)    = false    # would have deployed for real
hasFlag([--destroy=false], destroy)   = false    # would have left volumes intact
```

**Cited:** [P-11] · [D-62]

[P-11]: https://github.com/launchfile/launchfile/blob/main/spec/DESIGN.md#p-11-separate-intent-from-execution
[D-62]: https://github.com/launchfile/launchfile/blob/main/spec/DESIGN.md#d-62-a-sensitive-capture-is-masked-on-every-display-surface---reveal-on-the-invoking-command-is-the-explicit-act-that-shows-it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
