### PR TITLE
providers: carry an author-declared restart onto the AWS systemd unit

### DIFF
--- a/.changeset/aws-honor-declared-restart.md
+++ b/.changeset/aws-honor-declared-restart.md
@@ -1,0 +1,5 @@
+---
+"@launchfile/aws": patch
+---
+
+Carry an author-declared `restart:` onto the generated systemd unit. `translate` never read `component.restart` and wrote `Restart=always` into every unit, so a component declaring `restart: "no"` or `restart: on-failure` got an artifact that contradicts the file it was translated from — and the conformance ledger, which promises every field is mapped, gapped, or safely ignored, never mentioned the field at all. The three Launchfile values now map through an explicit table onto `Restart=always`, `Restart=on-failure`, and `Restart=no`, and the mapping is recorded on the ledger. A component that declares no `restart:` still gets `Restart=always`, now as a stated default; the cross-provider default for an undeclared `restart:` is decided in #234.

--- a/providers/aws/CONFORMANCE.md
+++ b/providers/aws/CONFORMANCE.md
@@ -4,9 +4,9 @@
 
 ## Summary
 
-- **84** Launchfile(s) translated
-- **163** field mappings
-- **90** gaps logged (never silently dropped)
+- **85** Launchfile(s) translated
+- **166** field mappings
+- **97** gaps logged (never silently dropped)
 - **8** specializations safely ignored
 
 ### Distinct gaps
@@ -15,8 +15,11 @@
 |---|---|---|---|
 | `image` | 🟡 workaround | prebuilt OCI image with no portable runtime+commands contract; this probe builds on EC2 from the contract, not a container host | add runtime+commands for a portable build path, or target a container provider |
 | `supports:postgres` | 🟢 nice-to-have | optional resources (supports) are not provisioned by this probe | provision behind a Terraform variable toggle |
+| `supports:certificate` | 🟢 nice-to-have | the app can serve TLS on its own listener 'web' with the certificate 'server-cert', and this probe has no way to place one in the task | mount the certificate into the task and supply cert_file/key_file, or terminate TLS at the ALB instead — a different arrangement, not this entry |
+| `supports:https-origin` | 🟢 nice-to-have | the app would use a public HTTPS origin in front of endpoint 'web', and this probe emits an http-only load balancer | terminate TLS at the ALB (aws_acm_certificate + an HTTPS listener) |
 | `requires:clickhouse` | 🟡 workaround | no managed AWS service mapping for resource type 'clickhouse' | model as a self-hosted component, or extend MANAGED_RESOURCES |
 | `requires:kafka` | 🟡 workaround | no managed AWS service mapping for resource type 'kafka' | model as a self-hosted component, or extend MANAGED_RESOURCES |
+| `requires:https-origin` | 🔴 blocker | the app requires a public HTTPS origin in front of endpoint 'web', and this probe emits an http-only load balancer | terminate TLS at the ALB (aws_acm_certificate + an HTTPS listener) before deploying this app |
 | `runtime` | 🔴 blocker | no runtime and no commands.start — nothing to build or run on EC2 | — |
 | `schedule` | 🟢 nice-to-have | cron schedule not mapped (no EventBridge Scheduler in this probe) | map to aws_scheduler_schedule |
 | `requires:host.container_runtime` | 🔴 blocker | component requires host capability container_runtime=docker; a bare EC2 target cannot grant it | use an ECS/container provider |
@@ -281,7 +284,7 @@
 
 ### gitea
 
-> Source: `catalog/apps/gitea/Launchfile` — 2 mapped, 1 gap(s), 0 ignored
+> Source: `catalog/apps/gitea/Launchfile` — 2 mapped, 2 gap(s), 0 ignored
 
 | Launchfile field | → Terraform | Component |
 |---|---|---|
@@ -290,6 +293,7 @@
 
 **Gaps**
 
+- 🟢 `supports:certificate`: the app can serve TLS on its own listener 'web' with the certificate 'server-cert', and this probe has no way to place one in the task — mount the certificate into the task and supply cert_file/key_file, or terminate TLS at the ALB instead — a different arrangement, not this entry
 - 🟡 `image` _(default)_: prebuilt OCI image with no portable runtime+commands contract; this probe builds on EC2 from the contract, not a container host — add runtime+commands for a portable build path, or target a container provider
 
 ### glance
@@ -330,7 +334,7 @@
 
 ### grafana
 
-> Source: `catalog/apps/grafana/Launchfile` — 1 mapped, 1 gap(s), 0 ignored
+> Source: `catalog/apps/grafana/Launchfile` — 1 mapped, 2 gap(s), 0 ignored
 
 | Launchfile field | → Terraform | Component |
 |---|---|---|
@@ -338,11 +342,12 @@
 
 **Gaps**
 
+- 🟢 `supports:certificate`: the app can serve TLS on its own listener 'web' with the certificate 'server-cert', and this probe has no way to place one in the task — mount the certificate into the task and supply cert_file/key_file, or terminate TLS at the ALB instead — a different arrangement, not this entry
 - 🟡 `image` _(default)_: prebuilt OCI image with no portable runtime+commands contract; this probe builds on EC2 from the contract, not a container host — add runtime+commands for a portable build path, or target a container provider
 
 ### grocy
 
-> Source: `catalog/apps/grocy/Launchfile` — 1 mapped, 1 gap(s), 0 ignored
+> Source: `catalog/apps/grocy/Launchfile` — 1 mapped, 2 gap(s), 0 ignored
 
 | Launchfile field | → Terraform | Component |
 |---|---|---|
@@ -350,6 +355,7 @@
 
 **Gaps**
 
+- 🟢 `supports:https-origin`: the app would use a public HTTPS origin in front of endpoint 'web', and this probe emits an http-only load balancer — terminate TLS at the ALB (aws_acm_certificate + an HTTPS listener)
 - 🟡 `image` _(default)_: prebuilt OCI image with no portable runtime+commands contract; this probe builds on EC2 from the contract, not a container host — add runtime+commands for a portable build path, or target a container provider
 
 ### hedgedoc
@@ -529,7 +535,7 @@
 
 ### miniflux
 
-> Source: `catalog/apps/miniflux/Launchfile` — 2 mapped, 1 gap(s), 0 ignored
+> Source: `catalog/apps/miniflux/Launchfile` — 2 mapped, 2 gap(s), 0 ignored
 
 | Launchfile field | → Terraform | Component |
 |---|---|---|
@@ -538,6 +544,7 @@
 
 **Gaps**
 
+- 🟢 `supports:certificate`: the app can serve TLS on its own listener 'web' with the certificate 'server-cert', and this probe has no way to place one in the task — mount the certificate into the task and supply cert_file/key_file, or terminate TLS at the ALB instead — a different arrangement, not this entry
 - 🟡 `image` _(default)_: prebuilt OCI image with no portable runtime+commands contract; this probe builds on EC2 from the contract, not a container host — add runtime+commands for a portable build path, or target a container provider
 
 ### monica
@@ -697,7 +704,7 @@
 
 ### privatebin
 
-> Source: `catalog/apps/privatebin/Launchfile` — 1 mapped, 1 gap(s), 0 ignored
+> Source: `catalog/apps/privatebin/Launchfile` — 1 mapped, 2 gap(s), 0 ignored
 
 | Launchfile field | → Terraform | Component |
 |---|---|---|
@@ -705,6 +712,7 @@
 
 **Gaps**
 
+- 🔴 `requires:https-origin`: the app requires a public HTTPS origin in front of endpoint 'web', and this probe emits an http-only load balancer — terminate TLS at the ALB (aws_acm_certificate + an HTTPS listener) before deploying this app
 - 🟡 `image` _(default)_: prebuilt OCI image with no portable runtime+commands contract; this probe builds on EC2 from the contract, not a container host — add runtime+commands for a portable build path, or target a container provider
 
 ### rallly
@@ -850,7 +858,7 @@
 
 ### vaultwarden
 
-> Source: `catalog/apps/vaultwarden/Launchfile` — 1 mapped, 2 gap(s), 0 ignored
+> Source: `catalog/apps/vaultwarden/Launchfile` — 1 mapped, 3 gap(s), 0 ignored
 
 | Launchfile field | → Terraform | Component |
 |---|---|---|
@@ -858,6 +866,7 @@
 
 **Gaps**
 
+- 🔴 `requires:https-origin`: the app requires a public HTTPS origin in front of endpoint 'web', and this probe emits an http-only load balancer — terminate TLS at the ALB (aws_acm_certificate + an HTTPS listener) before deploying this app
 - 🟢 `supports:postgres`: optional resources (supports) are not provisioned by this probe — provision behind a Terraform variable toggle
 - 🟡 `image` _(default)_: prebuilt OCI image with no portable runtime+commands contract; this probe builds on EC2 from the contract, not a container host — add runtime+commands for a portable build path, or target a container provider
 
@@ -937,13 +946,14 @@
 
 ### daily-sync
 
-> Source: `spec/examples/cron-job.yaml` — 4 mapped, 1 gap(s), 0 ignored
+> Source: `spec/examples/cron-job.yaml` — 5 mapped, 1 gap(s), 0 ignored
 
 | Launchfile field | → Terraform | Component |
 |---|---|---|
 | `requires:postgres` | `aws_db_instance` | — |
 | `runtime:node` | `aws_instance (cloud-init)` | default |
 | `commands.start` | `systemd unit (run slot)` | default |
+| `restart` | `systemd Restart=no` | default |
 | `env` | `aws_ssm_parameter` | default |
 
 **Gaps**
@@ -1064,15 +1074,28 @@
 - `build.dockerfile/target/args` _(backend)_: OCI specialization ignored — EC2 builds from the portable runtime+commands contract (D-40 / RFC C)
 - `build.dockerfile/target/args` _(frontend)_: OCI specialization ignored — EC2 builds from the portable runtime+commands contract (D-40 / RFC C)
 
+### media-server
+
+> Source: `spec/examples/operator-content.yaml` — 1 mapped, 1 gap(s), 0 ignored
+
+| Launchfile field | → Terraform | Component |
+|---|---|---|
+| `provides.exposed` | `aws_lb (ALB)` | — |
+
+**Gaps**
+
+- 🟡 `image` _(default)_: prebuilt OCI image with no portable runtime+commands contract; this probe builds on EC2 from the contract, not a container host — add runtime+commands for a portable build path, or target a container provider
+
 ### my-app
 
-> Source: `spec/examples/post-start-capture.yaml` — 7 mapped, 0 gap(s), 1 ignored
+> Source: `spec/examples/post-start-capture.yaml` — 8 mapped, 0 gap(s), 1 ignored
 
 | Launchfile field | → Terraform | Component |
 |---|---|---|
 | `provides:http:9999` | `aws_security_group ingress` | default |
 | `commands.start` | `aws_instance (cloud-init)` | default |
 | `commands.start` | `systemd unit (run slot)` | default |
+| `restart` | `systemd Restart=always` | default |
 | `env` | `aws_ssm_parameter` | default |
 | `health` | `aws_lb_target_group health_check` | default |
 | `provides.exposed` | `aws_lb (ALB)` | — |

--- a/providers/aws/src/__tests__/translate.test.ts
+++ b/providers/aws/src/__tests__/translate.test.ts
@@ -56,6 +56,54 @@ commands:
 	});
 });
 
+describe("translate — restart → systemd Restart= (P-11, D-52)", () => {
+	function unit(restart?: string) {
+		const declared = restart === undefined ? "" : `restart: ${restart}\n`;
+		return tf(`
+version: launch/v1
+name: my-app
+runtime: node
+${declared}commands:
+  start: "node server.js"
+`);
+	}
+
+	it("carries an author-declared restart: always onto the unit", () => {
+		expect(unit("always").hcl).toContain("Restart=always");
+	});
+
+	it("carries an author-declared restart: on-failure onto the unit", () => {
+		const { hcl } = unit("on-failure");
+		expect(hcl).toContain("Restart=on-failure");
+		expect(hcl).not.toContain("Restart=always");
+	});
+
+	it('carries an author-declared restart: "no" onto the unit', () => {
+		const { hcl } = unit('"no"');
+		expect(hcl).toContain("Restart=no");
+		expect(hcl).not.toContain("Restart=always");
+	});
+
+	it("falls back to Restart=always when the component declares no restart", () => {
+		expect(unit().hcl).toContain("Restart=always");
+	});
+
+	it("records the declared restart on the conformance ledger", () => {
+		const { conformance } = unit('"no"');
+		expect(conformance.mapped).toContainEqual({
+			field: "restart",
+			target: "systemd Restart=no",
+			component: "default",
+		});
+	});
+
+	it("records no restart mapping when the component declares none", () => {
+		const { conformance } = unit();
+		expect(conformance.mapped.some((m) => m.field === "restart")).toBe(false);
+		expect(conformance.gaps.some((g) => g.field === "restart")).toBe(false);
+	});
+});
+
 describe("translate — requires → managed services (P-1/P-11)", () => {
 	it("maps postgres to aws_db_instance and wires set_env to its connection url", () => {
 		const { hcl, conformance } = tf(`

--- a/providers/aws/src/translate.ts
+++ b/providers/aws/src/translate.ts
@@ -20,6 +20,7 @@ import {
 	type NormalizedLaunch,
 	type NormalizedRequirement,
 	type ResolverContext,
+	type RestartPolicy,
 	resolveExpression,
 	unsuppliedRequiredEnv,
 } from "@launchfile/sdk";
@@ -38,6 +39,28 @@ import {
 
 /** The backing-service type that declares the app's public HTTPS origin (D-60). */
 const HTTPS_ORIGIN = "https-origin";
+
+/**
+ * Launchfile `restart:` → the systemd `Restart=` directive on the generated unit.
+ *
+ * The two enums are separate vocabularies that happen to share spellings today,
+ * so the mapping is explicit: a value added to Launchfile's `restart:` fails to
+ * compile here rather than reaching a systemd directive unreviewed (P-13).
+ * All three are meaningful because the unit sets no `Type=`, so systemd applies
+ * `Type=simple`.
+ */
+const RESTART_DIRECTIVE: Record<RestartPolicy, string> = {
+	always: "always",
+	"on-failure": "on-failure",
+	no: "no",
+};
+
+/**
+ * The directive used when a component declares no `restart:`. A long-running
+ * service the file says nothing about stays supervised; the cross-provider
+ * default for an undeclared `restart:` is decided in #234, not here.
+ */
+const DEFAULT_RESTART_DIRECTIVE = "always";
 
 /** The `supports:` type a `provides` entry's `tls:` binds (D-61). */
 const CERTIFICATE = "certificate";
@@ -190,7 +213,9 @@ function cloudInit(
 	lines.push("WorkingDirectory=/opt/app");
 	lines.push("EnvironmentFile=-/etc/launchfile/" + serviceName + ".env");
 	lines.push(`ExecStart=/bin/bash -lc ${JSON.stringify(start)}`);
-	lines.push("Restart=always");
+	lines.push(
+		`Restart=${component.restart ? RESTART_DIRECTIVE[component.restart] : DEFAULT_RESTART_DIRECTIVE}`,
+	);
 	lines.push("");
 	lines.push("[Install]");
 	lines.push("WantedBy=multi-user.target");
@@ -932,6 +957,12 @@ function emitComponent(
 	);
 	if (comp.commands?.start)
 		c.map("commands.start", "systemd unit (run slot)", name);
+	if (comp.restart)
+		c.map(
+			"restart",
+			`systemd Restart=${RESTART_DIRECTIVE[comp.restart]}`,
+			name,
+		);
 	if (comp.commands?.build)
 		c.map("commands.build", "cloud-init (prepare slot)", name);
 	if (comp.commands?.release)


### PR DESCRIPTION
Closes #430

## What changed

**`providers: carry an author-declared restart onto the systemd unit`** (`913de03`)
- `providers/aws/src/translate.ts` — `cloudInit()` now reads `component.restart` and maps it onto `Restart=` through an explicit `Record<RestartPolicy, string>` table (`always` → `Restart=always`, `on-failure` → `Restart=on-failure`, `no` → `Restart=no`). A component that declares no `restart:` still gets `Restart=always`, now as a stated default written down in the code comment.
- `emitComponent` records `restart` on the conformance ledger beside the `commands.start` entry, with the resolved directive as the target (`systemd Restart=no`).
- Six tests in `providers/aws/src/__tests__/translate.test.ts`, asserting on the emitted `user_data`: the three declared values, the absent-value fallback, the ledger entry when declared, and the absence of any `restart` mapping *or gap* when undeclared.
- No `Type=`, no `RemainAfterExit`, no spec or schema file touched.

**`providers: regenerate the aws conformance report`** (`0d7a1ab`)
- `providers/aws/CONFORMANCE.md` regenerated with `bun run conformance`.

**`chore: changeset for the aws declared-restart fix`** (`af1ea04`)
- `.changeset/aws-honor-declared-restart.md` — patch on `@launchfile/aws`.

## Why

This is exactly the eight-item shape the steward's ACCEPT verdict on #430 bound, item for item: explicit lookup table (1), ledger entry + regen (2), `Restart=always` as a stated default when `restart:` is absent (3), no `Type=`/`RemainAfterExit` change (4), the four `user_data` assertions (5), no deploy transcript needed (6), no spec or schema file (7).

- **[P-1] / [P-11]** — `restart:` is app intent; `Restart=always` is an execution opinion. A provider chooses execution, never intent the author already declared.
- **[D-52]** — the precedent, one step milder: D-52 forbids a provider inventing a value the file does not supply. Here AWS was overwriting a value the file *does* supply.
- **[P-13]** — the mapping is an explicit table, not a pass-through, so a value added to Launchfile's `restart:` fails to compile here rather than reaching a systemd directive unreviewed. Launchfile's `restart:` and systemd's `Restart=` are separate enums that happen to share spellings today.
- **[D-51]** — `schedule:` stays a reported gap. All three `Restart=` values are meaningful because the unit sets no `Type=`, so systemd applies `Type=simple`; one-shot typing belongs with `schedule:` execution (#199).
- The module header at `providers/aws/src/translate.ts:10-12` promises every field lands on the ledger as mapped, gapped, or safely ignored, and `spec/PROVIDERS.md` §10 rule 8 requires it. `restart` was none of the three.

The cross-provider default for an **undeclared** `restart:` is not settled here — that is #234.

## Verification

Monorepo order, on the pushed tree:

```
sdk/                  bun install && bun run build && bun run test
                      → 21 test files, 520 passed / 520

providers/aws/        bun install && bun run typecheck && bun run build && bun run test
                      → typecheck clean, build clean
                      → 3 test files, 66 passed / 66  (6 new)

providers/docker/     bun install && bun run build          (build only — needed by the CLI package)

packages/launchfile/  bun run typecheck && bun run build && bun run test
                      → typecheck clean, build clean
                      → 11 test files, 105 passed / 105
```

`bun run lint` in `providers/aws` reports the same single pre-existing error as `main` (two `lint/style/useTemplate` infos on untouched `cloudInit` lines); this branch adds none.

**Observed run of the changed path.** Translating two spec examples through the built provider and printing the `[Service]` section of the emitted `user_data`:

```
=== spec/examples/cron-job.yaml ===        (declares restart: "no")
[Service]
WorkingDirectory=/opt/app
EnvironmentFile=-/etc/launchfile/daily-sync.env
ExecStart=/bin/bash -lc "node scripts/sync.js"
Restart=no

=== spec/examples/post-start-capture.yaml ===   (declares restart: always)
[Service]
WorkingDirectory=/opt/app
EnvironmentFile=-/etc/launchfile/my-app.env
ExecStart=/bin/bash -lc "node server.js"
Restart=always
```

And the ledger entry for `cron-job.yaml`:

```
ledger: [{"field":"restart","target":"systemd Restart=no","component":"default"}]
```

`bun run conformance --check` passes on this branch.

## Left out, and why

- **The regenerated `CONFORMANCE.md` also absorbs pre-existing staleness.** `bun run conformance --check` **already failed on `main`** before this change (observed: stashed this branch's `providers/aws` edits, ran `--check` on the `main` tree, got `CONFORMANCE.md is stale`). So the regen commit carries three gap rows that belong to the merged D-60/D-61 work (`supports:certificate`, `supports:https-origin`, `requires:https-origin`) plus one catalog app added since the last regeneration, alongside the two `restart` rows this PR adds. The report is generated wholesale — a partial regen is not possible — so the choice was to include the drift or leave the ledger stale. It is included and called out here.
- **An `image:`-only component still records no `restart` mapping.** `emitComponent` returns at the `image` gap before any per-component field is mapped, which is how `commands.start`, `env`, and `health` already behave there. Changing that is a different fix with a different blast radius, and the verdict scoped this one to the `c.map` beside `commands.start`.
- **No cross-provider default change.** docker's `unless-stopped` for an absent `restart:` is #234's call, not this PR's.
- **No deploy transcript.** AWS emits `.tf` and never runs `apply` (`translate.ts:7-8`), so the emitted string is the deliverable — as the verdict says in item 6.
- **`spec/examples/cron-job.yaml` remains only partly translatable on AWS.** After this fix AWS honors the `restart: "no"` half and still reports the `schedule:` half as a gap. Correct on both counts until #199 lands.

[P-1]: https://github.com/launchfile/launchfile/blob/main/spec/DESIGN.md#p-1-app-focused-not-infra-focused
[P-11]: https://github.com/launchfile/launchfile/blob/main/spec/DESIGN.md#p-11-separate-intent-from-execution
[P-13]: https://github.com/launchfile/launchfile/blob/main/spec/DESIGN.md#p-13-additive-extensibility
[D-51]: https://github.com/launchfile/launchfile/blob/main/spec/DESIGN.md#d-51-unexecuted-schedule-is-reported-loudly-not-silently-accepted
[D-52]: https://github.com/launchfile/launchfile/blob/main/spec/DESIGN.md#d-52-a-required-environment-variable-is-operator-supplied--providers-must-not-fabricate-one

🤖 Generated with [Claude Code](https://claude.com/claude-code)
