### PR TITLE
packages: one temp root instead of three sequential mkdtemp calls in the up-* tests

### DIFF
--- a/packages/launchfile/src/__tests__/up-failure.test.ts
+++ b/packages/launchfile/src/__tests__/up-failure.test.ts
@@ -6,7 +6,7 @@
  * real `~/.launchfile`, and nothing here talks to docker.
  */
 
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { dockerErrorKey, type DockerUpResult } from "@launchfile/docker";
@@ -39,9 +39,11 @@ let output: string[];
 let restore: (() => void) | null = null;
 
 beforeEach(async () => {
-	indexDir = await mkdtemp(join(tmpdir(), "lf-index-"));
-	recordDir = await mkdtemp(join(tmpdir(), "lf-records-"));
-	projectDir = await mkdtemp(join(tmpdir(), "lf-project-"));
+	const root = await mkdtemp(join(tmpdir(), "lf-failure-"));
+	indexDir = join(root, "index");
+	recordDir = join(root, "records");
+	projectDir = join(root, "project");
+	await Promise.all([mkdir(indexDir), mkdir(recordDir), mkdir(projectDir)]);
 	await writeFile(join(projectDir, "Launchfile"), "name: gov23\n");
 
 	output = [];

--- a/packages/launchfile/src/__tests__/up-name.test.ts
+++ b/packages/launchfile/src/__tests__/up-name.test.ts
@@ -8,7 +8,7 @@
  * and nothing talks to docker.
  */
 
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { DockerUpOpts, DockerUpResult } from "@launchfile/docker";
@@ -25,9 +25,11 @@ let output: string[];
 let restore: (() => void) | null = null;
 
 beforeEach(async () => {
-	indexDir = await mkdtemp(join(tmpdir(), "lf-name-index-"));
-	recordDir = await mkdtemp(join(tmpdir(), "lf-name-records-"));
-	projectDir = await mkdtemp(join(tmpdir(), "lf-name-project-"));
+	const root = await mkdtemp(join(tmpdir(), "lf-name-"));
+	indexDir = join(root, "index");
+	recordDir = join(root, "records");
+	projectDir = join(root, "project");
+	await Promise.all([mkdir(indexDir), mkdir(recordDir), mkdir(projectDir)]);
 	await writeFile(join(projectDir, "Launchfile"), "name: iso\n");
 
 	output = [];

--- a/packages/launchfile/src/__tests__/up-storage.test.ts
+++ b/packages/launchfile/src/__tests__/up-storage.test.ts
@@ -7,7 +7,7 @@
  * ~/.launchfile and nothing talks to docker.
  */
 
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { DockerUpOpts, DockerUpResult } from "@launchfile/docker";
@@ -26,9 +26,11 @@ let output: string[];
 let restore: (() => void) | null = null;
 
 beforeEach(async () => {
-	indexDir = await mkdtemp(join(tmpdir(), "lf-storage-index-"));
-	recordDir = await mkdtemp(join(tmpdir(), "lf-storage-records-"));
-	projectDir = await mkdtemp(join(tmpdir(), "lf-storage-project-"));
+	const root = await mkdtemp(join(tmpdir(), "lf-storage-"));
+	indexDir = join(root, "index");
+	recordDir = join(root, "records");
+	projectDir = join(root, "project");
+	await Promise.all([mkdir(indexDir), mkdir(recordDir), mkdir(projectDir)]);
 	await writeFile(join(projectDir, "Launchfile"), "name: stor\n");
 
 	output = [];


### PR DESCRIPTION
Closes #471

## What changed

- `packages: give the three up-* test suites one temp root, not three` — `up-failure.test.ts`, `up-name.test.ts`, `up-storage.test.ts` each collapse three sequential `await mkdtemp(...)` calls in `beforeEach` into one `mkdtemp` for a temp root plus three parallel `mkdir` calls (via `Promise.all`) for the `index`/`records`/`project` subdirectories.

## Why

The steward's ACCEPT verdict on #471 bound the fix to this exact shape and rejected the issue's own suggested fix:

- **No fake timers.** The verdict traced `up-failure.test.ts:113`'s "120s" to text inside an assertion message, not a duration anything sleeps for — `useFakeTimers`/`setTimeout`/`setInterval`/`sleep(` match nothing in `packages/launchfile/src/__tests__/`. The real cost was three sequential `mkdtemp` calls per test under Vitest's default unbounded thread pool inside the single `CLI` job (not cross-workflow contention, and not something a `concurrency:` group would fix).
- **No `testTimeout` change.** The verdict explicitly rules this out as a guess against a 1617–1868ms spread that a bigger ceiling doesn't move.
- No design principle governs this (P-1..P-14 govern the Launchfile descriptor format, not this project's own CI); the steward settled it directly per `governance/GOVERNANCE.md`'s process-change exemption, so no P-*/D-* citation applies.

## Verification

```
cd sdk && bun install && bun run build && bun run test
  → 522/522 passed

cd providers/docker && bun install && bun run build   (needed so packages/launchfile can resolve @launchfile/docker)
cd providers/aws && bun install && bun run build
cd providers/macos-dev && bun install && bun run build

cd packages/launchfile && bun install && bun run typecheck && bun run build && bun run test
  → typecheck: clean
  → build: clean
  → 105/105 passed, run 4 consecutive times with no failures
```

Per-test durations for the three previously-flaky tests (`--reporter=verbose`), all well under the 5000ms default timeout and below the 1617–1868ms baseline the verdict cites for passing runs:

```
✓ up-failure.test.ts > up, when the health gate never passes > exits non-zero, and leaves a deployment every remediation command can reach   144ms
✓ up-name.test.ts    > up --name reaches the docker provider > threads the label into the provider opts                                     141ms
✓ up-storage.test.ts > up --storage reaches the docker provider (D-50) > threads the volume-to-path map into the provider opts, keys as typed 141ms
```

No `.changeset/*.md` — per `RELEASING.md`: "When your change is internal-only (CI, refactor, docs, tests): Just commit normally. No changeset needed."

## Left out

- `providers/docker`, `providers/aws`, `providers/macos-dev` builds above were needed locally only to satisfy `packages/launchfile`'s workspace dependency on `@launchfile/docker` for typecheck/build — no source in those packages changed.
- The adjacent CI-ruleset naming defect the verdict flags (`ci.yml:301-306` vs. the live ruleset's required-check names) is explicitly out of this issue's scope per the verdict ("gets its own [issue]").
- Pre-existing biome formatting findings in the touched files (multi-line `expect(...)`/error-object literals at lines the diff doesn't touch) are unrelated to this change and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
