### PR TITLE
chore: fix dependabot ecosystem gaps and document the security-PR runbook

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,11 @@
+# Security-update PRs (Dependabot's advisory path) key off the vulnerable
+# dependency's ecosystem, not the package-ecosystem set per entry below — so
+# `package-ecosystem: bun` never applies to them, and they land with
+# package.json bumped but bun.lock untouched, which fails CI's
+# frozen-lockfile install. Runbook: check out the PR's branch, run
+# `bun install` inside the changed directory, then commit and push the
+# regenerated bun.lock. Auto-merge is failing against the active ruleset
+# (#379), so these merge by hand regardless.
 version: 2
 updates:
   # Bun workspace root — covers sdk/, providers/*, and packages/*.
@@ -33,7 +41,7 @@ updates:
       # tsconfig — so `astro check` dies with "Cannot read properties of
       # undefined (reading 'fileExists')". @astrojs/check 0.9.10 is the newest
       # release and still pins language-server ^2.16.7, so there is no version
-      # to upgrade into. These two sites stay on TypeScript 6 until a
+      # to upgrade into. These sites stay on TypeScript 6 until a
       # language-server release supports the 7.x API; the workspace root is
       # unaffected because it runs `tsc` directly. Drop this once that lands.
       - dependency-name: typescript
@@ -60,7 +68,34 @@ updates:
       # tsconfig — so `astro check` dies with "Cannot read properties of
       # undefined (reading 'fileExists')". @astrojs/check 0.9.10 is the newest
       # release and still pins language-server ^2.16.7, so there is no version
-      # to upgrade into. These two sites stay on TypeScript 6 until a
+      # to upgrade into. These sites stay on TypeScript 6 until a
+      # language-server release supports the 7.x API; the workspace root is
+      # unaffected because it runs `tsc` directly. Drop this once that lands.
+      - dependency-name: typescript
+        update-types: ["version-update:semver-major"]
+    groups:
+      astro-ecosystem:
+        patterns: ["astro", "@astrojs/*"]
+      tailwind:
+        patterns: ["tailwindcss", "@tailwindcss/*"]
+      other:
+        patterns: ["*"]
+        exclude-patterns: ["astro", "@astrojs/*", "tailwindcss", "@tailwindcss/*"]
+
+  # www-shared (Astro layouts/components shared by www-dev and www-org)
+  - package-ecosystem: bun
+    directory: /www-shared
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    ignore:
+      # TypeScript 7 (the native port) exports no `ts.sys`, and
+      # @astrojs/language-server calls `ts.sys.fileExists` when it looks for a
+      # tsconfig — so `astro check` dies with "Cannot read properties of
+      # undefined (reading 'fileExists')". @astrojs/check 0.9.10 is the newest
+      # release and still pins language-server ^2.16.7, so there is no version
+      # to upgrade into. These sites stay on TypeScript 6 until a
       # language-server release supports the 7.x API; the workspace root is
       # unaffected because it runs `tsc` directly. Drop this once that lands.
       - dependency-name: typescript
@@ -75,7 +110,9 @@ updates:
         exclude-patterns: ["astro", "@astrojs/*", "tailwindcss", "@tailwindcss/*"]
 
   # Catalog test harness
-  - package-ecosystem: npm
+  # bun ecosystem so dependabot regenerates bun.lock — npm-ecosystem PRs only
+  # bumped package.json, which fails CI's frozen-lockfile install
+  - package-ecosystem: bun
     directory: /catalog/test
     schedule:
       interval: weekly


### PR DESCRIPTION
Closes #469

## What changed

One commit, `.github/dependabot.yml` only:

- `chore: fix dependabot ecosystem gaps and document the security-PR runbook`
  - Flip `/catalog/test` from `package-ecosystem: npm` to `bun` — `catalog/test/bun.lock` is tracked and `ci.yml:131` installs it frozen, so the npm-shaped config produced package.json-only bumps (PR #336) that can't merge as opened. Reason comment matches the wording the other bun entries already carry.
  - Add a `/www-shared` entry, same shape as `/www-org` (bun ecosystem, weekly schedule, the TypeScript-7/`ts.sys` ignore, the astro/tailwind/other groups) — `www-shared/bun.lock` is installed frozen in CI and in both `deploy-dev.yml` and `deploy-org.yml`, and previously had zero Dependabot coverage.
  - Add a header comment documenting the manual runbook for advisory-path PRs: Dependabot's security-update path keys off the vulnerable dependency's ecosystem, not the `package-ecosystem` set per directory, so `package-ecosystem: bun` never applies to it. Runbook: check out the branch, `bun install` in the changed directory, commit and push the regenerated `bun.lock`. Notes that auto-merge is failing against the active ruleset (#379), so these merge by hand regardless.

## Why

Implements exactly the shape the steward's ACCEPT verdict on #469 bound, no wider:

> 1. Change `/catalog/test` to `package-ecosystem: bun`... 2. Add a `/www-shared` entry in the same shape as `/www-org`... 4. Document the maintainer step... Say why in one sentence... and mention #379.

The verdict found no design principle applies here — per `governance/GOVERNANCE.md`, P-1 through P-14 govern the Launchfile format, not project/CI process — so no P-\*/D-\* citation attaches to this change.

## Verification

No `sdk`, `providers/*`, or `packages/launchfile` code changed, so the monorepo build/test/changeset steps don't apply — this is a `.github/` config file only, so no `.changeset/*.md` is needed either. Checked for docs describing the old `catalog/test` npm-ecosystem config or the missing `www-shared` entry (`grep -rli dependabot`/`catalog/test` across `*.md`); none exist, so no doc updates are required.

Ran the validation the task specified:

```
$ python3 -c 'import yaml,sys; yaml.safe_load(open(".github/dependabot.yml"))'
$ echo $?
0
```

I have no way to trigger or observe a live Dependabot run (scheduled or advisory) from this environment, so the actual "regenerates bun.lock on `/catalog/test` and `/www-shared`" behavior is unverified beyond YAML validity and shape-parity with the already-working `/www-dev` and `/www-org` entries — that parity is the basis for trusting the fix, not a live run.

## Left out

- Closing PR #336 and adding the "no principle applies" sentence to the #469 issue body — verdict items 3 and 5 — are explicitly the orchestrator's job (bot-authored GitHub writes), not this branch's.
- `www-shared`'s TypeScript-ignore and astro/tailwind groups are copied for shape-parity with `/www-org` per the verdict, even though `www-shared/package.json` has no direct `astro`, `tailwindcss`, or `typescript` dependency today — they're inert until/unless it gains one, same as an unmatched group pattern elsewhere in this file.
- Root `bun.lock` / `CI required` red-on-main (#426) is explicitly out of scope per the task and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
