### PR TITLE
providers: check docker state.json at the load boundary and read launchfileHash

### DIFF
--- a/.changeset/docker-state-load-validation.md
+++ b/.changeset/docker-state-load-validation.md
@@ -1,0 +1,5 @@
+---
+"@launchfile/docker": patch
+---
+
+Check the docker provider's `state.json` at the load boundary instead of casting it, and read the `launchfileHash` it records. A hand-edited state file that lost its `ports` key used to load without complaint and then crash `launchfile status` and `launchfile list` with a TypeError naming neither the file nor the key; `loadState` now checks every field, drops only the malformed ones with a warning naming the state file and the key, defaults `ports` to empty, and keeps unknown keys so a field written by a newer provider version survives a round trip. `up` recompares the recorded Launchfile hash and warns when the file was edited in place — the source guard cannot see that — then continues, so the edit-then-redeploy cycle is unchanged.

--- a/providers/docker/src/__tests__/state.test.ts
+++ b/providers/docker/src/__tests__/state.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -7,10 +7,13 @@ import {
 	saveState,
 	loadState,
 	loadDockerSource,
+	hashLaunchfile,
 	stateDir,
 	composeProject,
 	type DockerState,
 } from "../state.js";
+import { dockerUp } from "../provider.js";
+import { logger } from "../logger.js";
 import { clearRegisteredSecrets, redactSecrets, REDACTED } from "../redact.js";
 
 // state.ts keys everything off homedir() → ~/.launchfile/docker/<slug>.
@@ -196,5 +199,289 @@ describe("docker state — composeProject slug guard", () => {
 		]) {
 			expect(() => composeProject(bad)).toThrow(/Invalid slug/);
 		}
+	});
+});
+
+/**
+ * Load-boundary validation (#441). `loadState` parses a file an operator can
+ * hand-edit, so every field is checked at run time. A bad key is dropped and
+ * the rest of the file is kept: the file records a deployment whose containers
+ * are still running, and discarding all of it would orphan them.
+ */
+describe("docker state — load-boundary validation (#441)", () => {
+	/** Write a raw state file for `slug`, bypassing `saveState`'s typing. */
+	function writeRawState(slug: string, body: unknown): string {
+		const dir = stateDir(slug);
+		mkdirSync(dir, { recursive: true });
+		const file = join(dir, "state.json");
+		writeFileSync(file, typeof body === "string" ? body : JSON.stringify(body, null, 2));
+		return file;
+	}
+
+	const wellFormed = {
+		version: 1,
+		slug: "app",
+		appName: "app",
+		composeProject: "launchfile-app",
+		launchfileHash: "deadbeefdeadbeef",
+		createdAt: "2024-01-01T00:00:00.000Z",
+		updatedAt: "2024-01-01T00:00:00.000Z",
+		secrets: { DB_PASSWORD: "s3cret" },
+		ports: { default: 3000 },
+	};
+
+	let warn: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined) as ReturnType<typeof vi.fn>;
+	});
+
+	afterEach(() => {
+		warn.mockRestore();
+		clearRegisteredSecrets();
+	});
+
+	/** The `key` field of every warning the load emitted. */
+	const warnedKeys = (): unknown[] =>
+		warn.mock.calls.map((call: unknown[]) => (call[0] as { key?: unknown } | undefined)?.key);
+
+	it("defaults a missing ports map to an empty object and warns", async () => {
+		const { ports: _dropped, ...noPorts } = wellFormed;
+		const file = writeRawState("app", noPorts);
+
+		const loaded = await loadState("app");
+		expect(loaded).not.toBeNull();
+		// This is the crash the issue reports: status/list read
+		// Object.keys(state.ports) with no guard.
+		expect(loaded!.ports).toEqual({});
+		expect(() => Object.keys(loaded!.ports)).not.toThrow();
+		expect(warnedKeys()).toContain("ports");
+		expect(warn.mock.calls[0]?.[0]).toMatchObject({ stateFile: file });
+	});
+
+	it("defaults a ports map that is not an object and warns", async () => {
+		writeRawState("app", { ...wellFormed, ports: "3000" });
+
+		const loaded = await loadState("app");
+		expect(loaded!.ports).toEqual({});
+		expect(warnedKeys()).toContain("ports");
+	});
+
+	it("drops a port entry that is not a number and keeps the rest", async () => {
+		writeRawState("app", { ...wellFormed, ports: { default: 3000, admin: "2368" } });
+
+		const loaded = await loadState("app");
+		expect(loaded!.ports).toEqual({ default: 3000 });
+		expect(warnedKeys()).toContain("ports.admin");
+	});
+
+	it("drops a secrets field that is not an object and keeps every other field", async () => {
+		writeRawState("app", { ...wellFormed, secrets: "DB_PASSWORD=s3cret" });
+
+		const loaded = await loadState("app");
+		expect(loaded).not.toBeNull();
+		expect(loaded!.secrets).toBeUndefined();
+		expect(loaded!.appName).toBe("app");
+		expect(loaded!.ports).toEqual({ default: 3000 });
+		expect(warnedKeys()).toContain("secrets");
+	});
+
+	it("drops a single non-string secret and keeps its siblings", async () => {
+		writeRawState("app", {
+			...wellFormed,
+			secrets: { DB_PASSWORD: "s3cret", PORT: 5432 },
+		});
+
+		const loaded = await loadState("app");
+		expect(loaded!.secrets).toEqual({ DB_PASSWORD: "s3cret" });
+		expect(warnedKeys()).toContain("secrets.PORT");
+	});
+
+	it("drops a single non-string resource password and keeps its siblings", async () => {
+		writeRawState("app", {
+			...wellFormed,
+			resourcePasswords: { "db.postgres": "pgpass", "cache.redis": null },
+		});
+
+		const loaded = await loadState("app");
+		expect(loaded!.resourcePasswords).toEqual({ "db.postgres": "pgpass" });
+		expect(loaded!.secrets).toEqual({ DB_PASSWORD: "s3cret" });
+		expect(warnedKeys()).toContain("resourcePasswords.cache.redis");
+	});
+
+	it("loads a file whose required appName is absent, warning about nothing else", async () => {
+		const { appName: _absent, ...noName } = wellFormed;
+		writeRawState("app", noName);
+
+		const loaded = await loadState("app");
+		expect(loaded).not.toBeNull();
+		expect(loaded!.appName).toBeUndefined();
+		// An absent field is not a malformed one — nothing is dropped.
+		expect(warn).not.toHaveBeenCalled();
+		expect(loaded!.slug).toBe("app");
+		expect(loaded!.ports).toEqual({ default: 3000 });
+	});
+
+	it("drops a required field of the wrong type and keeps the rest", async () => {
+		writeRawState("app", { ...wellFormed, appName: 42, version: "1" });
+
+		const loaded = await loadState("app");
+		expect(loaded!.appName).toBeUndefined();
+		expect(loaded!.version).toBeUndefined();
+		expect(loaded!.slug).toBe("app");
+		expect(warnedKeys()).toEqual(expect.arrayContaining(["appName", "version"]));
+	});
+
+	it("drops a malformed endpoint entry and keeps the well-formed one", async () => {
+		writeRawState("app", {
+			...wellFormed,
+			ports: { default: 3000, admin: 2368 },
+			endpoints: {
+				default: { component: "web", containerPort: 80, hostPort: 3000, protocol: "https" },
+				admin: { component: "web", containerPort: "2368", hostPort: 2368 },
+			},
+		});
+
+		const loaded = await loadState("app");
+		expect(Object.keys(loaded!.endpoints ?? {})).toEqual(["default"]);
+		expect(loaded!.endpoints?.default?.protocol).toBe("https");
+		expect(warnedKeys()).toContain("endpoints.admin");
+	});
+
+	it("keeps an unknown key through a load-and-save round trip", async () => {
+		// A field a newer provider version writes must survive an older one,
+		// which cannot know what it means (P-13).
+		writeRawState("app", { ...wellFormed, futureField: { nested: true } });
+
+		const loaded = await loadState("app");
+		expect((loaded as unknown as Record<string, unknown>).futureField).toEqual({
+			nested: true,
+		});
+
+		await saveState("app", loaded!);
+		const onDisk = JSON.parse(
+			readFileSync(join(stateDir("app"), "state.json"), "utf8"),
+		) as Record<string, unknown>;
+		expect(onDisk.futureField).toEqual({ nested: true });
+		expect(onDisk.slug).toBe("app");
+	});
+
+	it("returns null for a JSON document that is not an object", async () => {
+		writeRawState("app", "[1, 2, 3]");
+		expect(await loadState("app")).toBeNull();
+	});
+
+	it("returns null for unparseable bytes and for a missing file", async () => {
+		writeRawState("app", "{not json");
+		expect(await loadState("app")).toBeNull();
+		expect(await loadState("never-deployed")).toBeNull();
+	});
+
+	it("never throws on a malformed file", async () => {
+		for (const body of ["null", '"a string"', "{}", '{"ports": []}', '{"secrets": null}']) {
+			writeRawState("wild", body);
+			await expect(loadState("wild")).resolves.not.toThrow();
+		}
+	});
+
+	it("still registers reloaded secrets with the redactor after validation (D-18)", async () => {
+		const value = "d".repeat(64);
+		writeRawState("app", { ...wellFormed, secrets: { DB_PASSWORD: value, BAD: 7 } });
+
+		clearRegisteredSecrets();
+		await loadState("app");
+		expect(redactSecrets(`pw=${value}`)).toBe(`pw=${REDACTED}`);
+	});
+
+	it("still registers reloaded resource passwords with the redactor after validation (D-18)", async () => {
+		const value = "e".repeat(64);
+		writeRawState("app", {
+			...wellFormed,
+			resourcePasswords: { "db.postgres": value, BAD: 7 },
+		});
+
+		clearRegisteredSecrets();
+		await loadState("app");
+		expect(redactSecrets(`pw=${value}`)).toBe(`pw=${REDACTED}`);
+	});
+});
+
+/**
+ * The recorded `launchfileHash` is read on `up` (#441). It catches what the
+ * D-55 rule 3 source guard cannot see: a Launchfile edited in place at the
+ * same path. It warns and continues — refusing would break the
+ * edit-then-redeploy cycle D-49 relies on.
+ */
+describe("docker state — launchfileHash is read on up (#441)", () => {
+	const LAUNCHFILE = `version: launch/v1
+name: hashtest
+image: alpine:3.20
+commands:
+  start: sleep 300
+`;
+
+	let projectDir: string;
+	let warnings: string[];
+	let restore: (() => void) | null = null;
+
+	beforeEach(() => {
+		projectDir = mkdtempSync(join(tmpdir(), "lf-hash-app-"));
+		writeFileSync(join(projectDir, "Launchfile"), LAUNCHFILE);
+		warnings = [];
+		const log = console.log;
+		const err = console.error;
+		const wrn = console.warn;
+		console.log = () => undefined;
+		console.error = (...args: unknown[]) => warnings.push(args.join(" "));
+		console.warn = (...args: unknown[]) => warnings.push(args.join(" "));
+		restore = () => {
+			console.log = log;
+			console.error = err;
+			console.warn = wrn;
+		};
+	});
+
+	afterEach(() => {
+		restore?.();
+		restore = null;
+		rmSync(projectDir, { recursive: true, force: true });
+	});
+
+	it("hashes the Launchfile text it is given", () => {
+		expect(hashLaunchfile(LAUNCHFILE)).toBe(hashLaunchfile(LAUNCHFILE));
+		expect(hashLaunchfile(LAUNCHFILE)).not.toBe(hashLaunchfile(`${LAUNCHFILE}# edited\n`));
+		expect(hashLaunchfile(LAUNCHFILE)).toMatch(/^[0-9a-f]{16}$/);
+	});
+
+	it("warns and continues when the recorded hash differs from the current file", async () => {
+		const state = initState("hashtest", "hashtest", "name: something-else\n", {
+			sourceType: "local",
+			sourcePath: join(projectDir, "Launchfile"),
+		});
+		await saveState("hashtest", state);
+
+		// A dry run reaches the comparison and writes nothing.
+		const result = await dockerUp(projectDir, { dryRun: true });
+		expect(result.slug).toBe("hashtest");
+		const printed = warnings.join("\n");
+		expect(printed).toContain("differs from the one this deployment was created from");
+		expect(printed).toContain("hashtest");
+		expect(printed).toContain(hashLaunchfile(LAUNCHFILE));
+	});
+
+	it("stays silent when the Launchfile is unchanged", async () => {
+		const state = initState("hashtest", "hashtest", LAUNCHFILE, {
+			sourceType: "local",
+			sourcePath: join(projectDir, "Launchfile"),
+		});
+		await saveState("hashtest", state);
+
+		await dockerUp(projectDir, { dryRun: true });
+		expect(warnings.join("\n")).not.toContain("differs from the one");
+	});
+
+	it("stays silent on a first deployment, which has no recorded hash", async () => {
+		await dockerUp(projectDir, { dryRun: true });
+		expect(warnings.join("\n")).not.toContain("differs from the one");
 	});
 });

--- a/providers/docker/src/provider.ts
+++ b/providers/docker/src/provider.ts
@@ -25,6 +25,7 @@ import {
 	composeProject,
 	stateDir,
 	stateBaseDir,
+	hashLaunchfile,
 	type StateEndpoint,
 } from "./state.js";
 import { allocatePorts } from "./port-allocator.js";
@@ -478,6 +479,24 @@ export async function dockerUp(source: string, opts: DockerUpOpts = {}): Promise
 			state.sourceType = sourceInfo.sourceType;
 			if (sourceInfo.sourcePath !== undefined) state.sourcePath = sourceInfo.sourcePath;
 			if (sourceInfo.sourceUrl !== undefined) state.sourceUrl = sourceInfo.sourceUrl;
+
+			// The recorded Launchfile hash, re-read (#441). The foreign-source
+			// guard above (D-55 rule 3) compares where the source came from — a
+			// path or a URL — so it cannot see a Launchfile edited in place at
+			// the same path. The hash can. Different input, different action:
+			// that refuses, this warns and continues, because the
+			// edit-then-redeploy cycle D-49 needs in order to re-resolve
+			// derived values has to keep working. The recorded hash then
+			// follows the deployment this run produces.
+			const currentHash = hashLaunchfile(resolved.yaml);
+			if (state.launchfileHash !== undefined && state.launchfileHash !== currentHash) {
+				const message =
+					`the Launchfile for "${slug}" differs from the one this deployment was created from ` +
+					`(recorded ${state.launchfileHash}, current ${currentHash}) — redeploying with the current one.`;
+				log.warn({ slug, recordedHash: state.launchfileHash, currentHash }, message);
+				console.warn(`  Warning: ${message}`);
+			}
+			state.launchfileHash = currentHash;
 		}
 
 		// Publication context (#290), same preservation rule as the source info

--- a/providers/docker/src/state.ts
+++ b/providers/docker/src/state.ts
@@ -10,6 +10,7 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import { createHash } from "node:crypto";
 import { registerSecrets } from "./redact.js";
+import { getLogger } from "./logger.js";
 
 /** Where the Launchfile that produced this state came from. */
 export type DockerSourceType = "local" | "catalog" | "url";
@@ -37,6 +38,11 @@ export interface DockerState {
 	slug: string;
 	appName: string;
 	composeProject: string;
+	/**
+	 * Hash of the Launchfile text that produced the current deployment. `up`
+	 * recompares it and warns on a mismatch (see `provider.ts` `dockerUp`),
+	 * which is how an in-place edit of the same file becomes visible.
+	 */
 	launchfileHash: string;
 	createdAt: string;
 	updatedAt: string;
@@ -178,23 +184,166 @@ export function instanceSlug(baseSlug: string, label?: string): string {
 	return slug;
 }
 
-function hashContent(content: string): string {
+/**
+ * The digest recorded in `DockerState.launchfileHash`, over the Launchfile
+ * text a deployment was produced from. Truncated to 16 hex chars: this
+ * detects an edit, it does not authenticate one.
+ */
+export function hashLaunchfile(content: string): string {
 	return createHash("sha256").update(content).digest("hex").slice(0, 16);
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isType(value: unknown, expected: "string" | "number"): boolean {
+	return expected === "string" ? typeof value === "string" : typeof value === "number";
+}
+
+/**
+ * One warning per dropped key, naming the file it came from so an operator
+ * can find and repair it. Goes through pino to stderr — a load happens under
+ * every verb, including ones whose stdout is the answer (`status`, `list`).
+ */
+function warnDropped(file: string, key: string, expected: string): void {
+	getLogger().warn({ stateFile: file, key, expected }, "ignoring invalid key in state file");
+}
+
+/** Top-level fields that hold a string when present. */
+const STRING_FIELDS = [
+	"slug",
+	"appName",
+	"composeProject",
+	"launchfileHash",
+	"createdAt",
+	"updatedAt",
+	"sourceType",
+	"sourcePath",
+	"sourceUrl",
+	"appUrl",
+] as const;
+
+/**
+ * Drop the entries of a `Record<string, T>` field whose values are not `T`,
+ * and the whole field when it is not an object at all. Returns the surviving
+ * map, or undefined when the field is absent or was dropped.
+ */
+function checkValueMap(
+	parsed: Record<string, unknown>,
+	key: string,
+	file: string,
+	valueType: "string" | "number",
+): Record<string, unknown> | undefined {
+	const value = parsed[key];
+	if (value === undefined) return undefined;
+	if (!isPlainObject(value)) {
+		warnDropped(file, key, "object");
+		delete parsed[key];
+		return undefined;
+	}
+	for (const [entryKey, entryValue] of Object.entries(value)) {
+		if (!isType(entryValue, valueType)) {
+			warnDropped(file, `${key}.${entryKey}`, valueType);
+			delete value[entryKey];
+		}
+	}
+	return value;
+}
+
+function isStateEndpoint(value: unknown): boolean {
+	return (
+		isPlainObject(value) &&
+		typeof value.component === "string" &&
+		typeof value.containerPort === "number" &&
+		typeof value.hostPort === "number" &&
+		(value.name === undefined || typeof value.name === "string") &&
+		(value.protocol === undefined || typeof value.protocol === "string")
+	);
+}
+
+/**
+ * Check a parsed state file field by field, in place, and hand back what
+ * survived. A field that fails its check is dropped and every other field is
+ * kept — a state file is an operator's record of a running deployment, so
+ * discarding all of it over one bad key would orphan real containers.
+ *
+ * Keys this function does not know are left untouched, so a field written by
+ * a newer provider version survives a load-and-save round trip through an
+ * older one instead of being written out of existence (P-13).
+ *
+ * `ports` is the one field with a default: every consumer reads it
+ * unguarded (`Object.keys(state.ports)`), so an absent or malformed map has
+ * to become `{}` here or it becomes a TypeError with no file name in it.
+ */
+function validateState(parsed: Record<string, unknown>, file: string): DockerState {
+	if (parsed.version !== undefined && typeof parsed.version !== "number") {
+		warnDropped(file, "version", "number");
+		delete parsed.version;
+	}
+
+	for (const key of STRING_FIELDS) {
+		if (parsed[key] !== undefined && typeof parsed[key] !== "string") {
+			warnDropped(file, key, "string");
+			delete parsed[key];
+		}
+	}
+
+	checkValueMap(parsed, "secrets", file, "string");
+	checkValueMap(parsed, "resourcePasswords", file, "string");
+	checkValueMap(parsed, "generatedEnv", file, "string");
+
+	const portsPresent = parsed.ports !== undefined;
+	if (checkValueMap(parsed, "ports", file, "number") === undefined) {
+		// An absent map breaks the readers exactly as a malformed one does, so
+		// both end at `{}`. Only the absent case warns here — `checkValueMap`
+		// has already warned about a malformed one.
+		if (!portsPresent) warnDropped(file, "ports", "object");
+		parsed.ports = {};
+	}
+
+	const endpoints = parsed.endpoints;
+	if (endpoints !== undefined) {
+		if (!isPlainObject(endpoints)) {
+			warnDropped(file, "endpoints", "object");
+			delete parsed.endpoints;
+		} else {
+			for (const [entryKey, entryValue] of Object.entries(endpoints)) {
+				if (!isStateEndpoint(entryValue)) {
+					warnDropped(file, `endpoints.${entryKey}`, "endpoint");
+					delete endpoints[entryKey];
+				}
+			}
+		}
+	}
+
+	// Every field named in `DockerState` has now been checked or dropped. A
+	// required one the file never carried stays absent — callers that read it
+	// see undefined instead of a value invented here.
+	return parsed as unknown as DockerState;
+}
+
 export async function loadState(slug: string): Promise<DockerState | null> {
+	const file = statePath(slug);
+	let parsed: unknown;
 	try {
-		const raw = await readFile(statePath(slug), "utf8");
-		const state = JSON.parse(raw) as DockerState;
-		// Persisted secrets are reused across runs, so a value generated in an
-		// earlier process still has to be scrubbable in this one (D-18).
-		registerSecrets(Object.values(state.secrets ?? {}));
-		registerSecrets(Object.values(state.resourcePasswords ?? {}));
-		registerSecrets(Object.values(state.generatedEnv ?? {}));
-		return state;
+		parsed = JSON.parse(await readFile(file, "utf8"));
 	} catch {
 		return null;
 	}
+	// A document that is not a JSON object holds no field to keep, so there is
+	// nothing to salvage — the same answer as unreadable bytes.
+	if (!isPlainObject(parsed)) {
+		getLogger().warn({ stateFile: file }, "state file is not a JSON object");
+		return null;
+	}
+	const state = validateState(parsed, file);
+	// Persisted secrets are reused across runs, so a value generated in an
+	// earlier process still has to be scrubbable in this one (D-18).
+	registerSecrets(Object.values(state.secrets ?? {}));
+	registerSecrets(Object.values(state.resourcePasswords ?? {}));
+	registerSecrets(Object.values(state.generatedEnv ?? {}));
+	return state;
 }
 
 export interface InitStateSource {
@@ -215,7 +364,7 @@ export function initState(
 		slug,
 		appName,
 		composeProject: composeProject(slug),
-		launchfileHash: hashContent(launchfileContent),
+		launchfileHash: hashLaunchfile(launchfileContent),
 		createdAt: now,
 		updatedAt: now,
 		secrets: {},

--- a/spec/PROVIDERS.md
+++ b/spec/PROVIDERS.md
@@ -207,7 +207,7 @@ local watcher ← emit ← diff() ← fs change ────┘
 - **Flow:** build (from source) → release (one-shot `docker compose run --rm` per declaring component, in `depends_on` order; compose brings that component's backing resources up healthy first, and a non-zero exit fails the deploy) → start (`compose up`) → bootstrap.
 - **Sources:** local path, catalog slug, remote URL (with a confirmation prompt for remote, bypassable via `yes`).
 - **Storage:** resolves `$storage.<name>.path` to the bind-mounted container path (D-39).
-- **State:** `DockerState` per slug (compose project/path, allocated ports, source info) under the provider state dir.
+- **State:** `DockerState` per slug (compose project/path, allocated ports, source info) under the provider state dir. Checked field by field on load: a malformed key is dropped with a warning naming the state file and the key, every other key is kept, unknown keys survive a load-and-save round trip, and an absent or malformed `ports` map loads as empty. The recorded Launchfile hash is recompared on `up`; a mismatch warns, naming the deployment, and the deploy continues.
 - **Selection:** honors the component selector; the post-`up` summary reports only the started subset.
 
 ### `@launchfile/macos-dev` — source / native


### PR DESCRIPTION
Closes #441

## What changed

**`providers:` — `providers/docker/src/state.ts`, `provider.ts`, `__tests__/state.test.ts`**

- `loadState` checks every `DockerState` field at run time between `JSON.parse` and the `registerSecrets` calls, instead of casting with `as DockerState`. Checks are hand-written; no `zod`.
- A key that fails its check is dropped and every other key is kept. One `warn` per dropped key, carrying the state file path and the key name (`{ stateFile, key, expected }`).
- `ports` is the one field with a default: absent or malformed, it becomes `{}` with a warning. That is what stops the reported crash and keeps `allocatePorts` sound.
- Unknown keys pass through untouched, so a field written by a newer provider version survives a load-and-save round trip.
- `loadState` never throws. It still returns `null` only for a missing or unparseable file — plus a JSON document that is not an object, which holds no field to keep and so gets the same answer.
- `up` recomputes the Launchfile hash, compares it to the recorded `launchfileHash`, warns on a mismatch naming the deployment slug and both digests, then continues. The field is kept, and the recorded value follows the deployment this run produces. `hashContent` is exported as `hashLaunchfile`.
- 17 tests added beside the existing round-trip ones: `ports` missing, `ports` not an object, a non-number port entry, `secrets` not an object, a non-string secret entry, a required string absent, a required string of the wrong type, a malformed endpoint entry, an unknown key surviving a save, a non-object document, unparseable bytes, a never-throws sweep, secret re-registration after validation (D-18), and three on the hash read (mismatch warns, unchanged is silent, first deploy is silent).

**`spec:` — `spec/PROVIDERS.md`**

- The `@launchfile/docker` State line now describes the load behaviour and the hash warning.

**`chore:` — `.changeset/docker-state-load-validation.md`**

- `@launchfile/docker`: patch.

## Why

The shape is the one the steward's ACCEPT verdict on #441 binds: validate inside `loadState`, by hand; drop bad entries, never the file; never throw; one warning per dropped key naming file and key; keep unknown keys through a round trip; default `ports` to `{}`; keep `launchfileHash` and read it, warning on mismatch and continuing.

No field, no syntax, no parse rule changes and no existing Launchfile changes meaning — [P-13] is untouched. This is how the provider carries out a deployment, not what an app declares ([P-11]). [D-20] places running-instance state with the provider; [D-49] and [D-55] already set how a provider must behave with it, so no new `D-*` was needed.

The read site carries the [D-55] comment the verdict asked for: rule 3's foreign-source guard (`provider.ts`) compares *where the source came from* — a path or a URL — so it cannot see a Launchfile edited in place at the same path. The hash can. Different input, different action: that refuses, this warns and continues, because refusing would break the edit-then-redeploy cycle [D-49] needs to keep re-resolving derived values.

## Verification

Built and tested in monorepo order. Docker was available, so the real `up`/`down` suites ran rather than skipping.

```
sdk:                  bun install && bun run build && bun run test  →  21 files, 522 passed
providers/docker:     bun install && bun run typecheck && bun run build && bun run test
                                                                    →  32 files, 486 passed
packages/launchfile:  bun install && bun run typecheck && bun run build && bun run test
                                                                    →  11 files, 105 passed
```

One flake seen on the first docker run and not on the re-run: `env-generator-lifecycle.test.ts` hit `ForeignSourceError` from a `gov23-envgen` state directory an earlier session had left in the real `~/.launchfile`. That suite does not sandbox `$HOME`; it is unrelated to this change and passes on a clean home.

`bun run lint` fails repo-wide on `main` (60 errors over 49 files, formatter and `organizeImports`). The two files touched here report the same pre-existing classes and no new rule violation — `biome check` on `origin/main`'s `state.ts` reports the same format and import-order diagnostics.

**Observed, not just tested.** A state file missing `ports` (the exact defect the issue reports), loaded by the built provider under a sandboxed `$HOME`, with an unknown `futureField` added:

```
--- BEFORE (unvalidated cast, what main does) ---
CRASH: TypeError: Cannot convert undefined or null to object

--- AFTER (validated loadState) ---
WARN: ignoring invalid key in state file
    operation: "status"
    slug: "verify441"
    stateFile: "<HOME>/.launchfile/docker/verify441/state.json"
    key: "ports"
    expected: "object"
App: verify441 (verify441)
Created: 2026-01-01T00:00:00.000Z
  $ docker compose -p launchfile-verify441 -f <HOME>/.launchfile/docker/verify441/docker-compose.yml ps
INFO: span completed  (operation "status", durationMs 14)
```

`state.json` after that load and a `saveState` — the unknown key survived, `ports` materialised:

```json
{
  "version": 1,
  "slug": "verify441",
  ...
  "secrets": { "DB_PASSWORD": "hunter2" },
  "futureField": { "written_by": "a newer provider" },
  "ports": {}
}
```

And the hash read, on a `--dry-run up` whose state was recorded from an earlier version of the same file at the same path:

```
recorded: 4ac6adee99e35e38  current: 3e5b0e3244c4944a
  Warning: the Launchfile for "hashdemo" differs from the one this deployment was created from (recorded 4ac6adee99e35e38, current 3e5b0e3244c4944a) — redeploying with the current one.
```

## Left out, and why

- **`#261` is not waited on or borrowed from**, per the verdict — it has no PR, and `DockerState` has no counterpart to macos-dev's `resources`/`processes`.
- **`sourceType` is checked as a string, not against the `"local" | "catalog" | "url"` union.** The verdict binds it as an optional string; a tighter check would change what the foreign-source guard sees.
- **`appUrl` is checked (optional string) though the verdict's field list predates it.** It is a current `DockerState` field and the verdict says to check every field.
- **A required string the file never carried stays absent** rather than being given an invented default. Only `ports` defaults, because only `ports` is read unguarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Rebase addendum (2026-09-13)

- **Head:** `24bd48d` (merge-commit head, steward ACCEPT review posted there) → `02e2921` (rebased onto `main` at `f639474`). The old merge commit is gone; the branch is the same three commits (`providers:` / `spec:` / `chore:`) replayed on current `main`.
- **Conflict:** one file, `providers/docker/src/state.ts`. `main` (#353, resource-password namespace split) added `DockerState.resourcePasswords?: Record<string, string>` and a `registerSecrets(Object.values(state.resourcePasswords ?? {}))` call inside the `loadState` block this PR rewrites. Resolved by keeping the PR's `loadState` shape and folding `main`'s field in: `validateState` now checks `resourcePasswords` with the same `checkValueMap(..., "string")` rule as `secrets`, and the surviving values are re-registered with the redactor after validation, in the same order `main` uses (`secrets` → `resourcePasswords` → `generatedEnv`). Two tests added for it in `state.test.ts`: a non-string entry is dropped with a warning naming `resourcePasswords.<key>` while its siblings survive, and the surviving values are scrubbable after a reload (D-18). `provider.ts`, `state.test.ts`, `spec/PROVIDERS.md` and the changeset auto-merged. Interdiff of the PR's net change before vs after the rebase shows only those additions.
- **D-number:** none — the PR adds no `D-*` entry (the #441 verdict said none was needed); `git grep -i d-next` on the branch is empty. Nothing on `main` (D-59 – D-65) touches the docker state file, so no decision text needed re-checking beyond D-55 rule 3, which the PR's comment still describes correctly.
- **Tests run (worktree, `$HOME` sandboxed):** sdk `bun run test` 25 files / 641; providers/docker `typecheck` + `build` + `bun run test` 36 files / 593 (Docker present, real `up`/`down` suites ran); packages/launchfile `typecheck` + `build` + `bun run test` 12 files / 137. `bun test` hits the vitest guard in all three, as CI expects.
- **CI on `02e2921`:** 14 of 17 checks green. `Provider (docker)` failed in `setup-bun` on a GitHub 500 (`Failed to fetch url https://api.github.com/repos/oven-sh/bun/git/refs/tags`) before checking out the tree, which cascaded to `CI required` (fail) and `CLI` (skipped); one CodeQL `Analyze (javascript-typescript)` matrix job failed while uploading its SARIF (not a required check, the other matrix job passed). Infra, not the branch — the job needs a re-run, no code change. The full suite was run locally at this head instead (above).
- **Steward re-review on `02e2921`:** full pipeline re-run (intake → dossier → verdict) as `launchfile-steward[bot]`. Verdict **ACCEPT**, no blockers — https://github.com/launchfile/launchfile/pull/498#pullrequestreview-5190322597. `steward/review` check 103702721725 concluded `success` on this head. Two non-blocking notes in the review: `sourceType`/`version` are checked by `typeof` only (as the #441 verdict bound), and `stateDir(slug)` carries no slug guard of its own (pre-existing; card filed at `.rclaude/project/open/docker-statedir-slug-guard-placement.md`).
