### PR TITLE
providers: make the macos-dev pid identity check symmetric

### DIFF
--- a/.changeset/macos-dev-identity-tolerance-symmetric.md
+++ b/.changeset/macos-dev-identity-tolerance-symmetric.md
@@ -1,0 +1,5 @@
+---
+"@launchfile/macos-dev": patch
+---
+
+Fixed `launch down` signalling a process whose live start time is *earlier* than the recorded spawn — the identity check now compares the absolute difference, so a recycled pid, a backward clock jump, or a state file from another run all read as a mismatch and the process group is left untouched.

--- a/providers/macos-dev/src/__tests__/process-stopper.test.ts
+++ b/providers/macos-dev/src/__tests__/process-stopper.test.ts
@@ -78,6 +78,41 @@ describe("checkIdentity", () => {
 		expect(await checkIdentity(rec, fns)).toBe("mismatch");
 	});
 
+	it("flags identity mismatch when the live process started much earlier than the record", async () => {
+		const recordedStart = new Date("2020-01-01T00:00:00.000Z");
+		const rec: RecordedProcess = {
+			pid: 100,
+			pgid: 100,
+			startedAt: recordedStart.toISOString(),
+			command: "app",
+		};
+		// The record claims a spawn a full day after the live process began, so
+		// it cannot be describing this pid — a clock jump or a foreign state file.
+		const fns = fakeSignals({
+			alive: new Set([100]),
+			startTimes: { 100: recordedStart.getTime() - 86_400_000 },
+		});
+		expect(await checkIdentity(rec, fns)).toBe("mismatch");
+	});
+
+	it("verifies a live pid reading slightly earlier than the record (ps lstart truncation)", async () => {
+		const recordedStart = new Date("2020-01-01T00:00:00.000Z");
+		const rec: RecordedProcess = {
+			pid: 100,
+			pgid: 100,
+			startedAt: recordedStart.toISOString(),
+			command: "app",
+		};
+		// `spawn()` forks before we timestamp, and `ps lstart` rounds down to
+		// whole seconds, so a genuine record reads sub-second earlier. This must
+		// stay inside the tolerance window.
+		const fns = fakeSignals({
+			alive: new Set([100]),
+			startTimes: { 100: recordedStart.getTime() - 1500 },
+		});
+		expect(await checkIdentity(rec, fns)).toBe("alive-verified");
+	});
+
 	it("treats a missing start time as alive-unverified", async () => {
 		const rec: RecordedProcess = {
 			pid: 100,
@@ -175,6 +210,29 @@ describe("stopProcess", () => {
 		expect(outcome).toEqual({ component: "web", result: "identity-mismatch" });
 		// Only the liveness probe (signal 0) may have been sent — never a real kill.
 		expect(fns.sent.every((s) => s.signal === 0)).toBe(true);
+	});
+
+	it("does NOT signal a process whose live start time precedes the record", async () => {
+		const recordedStart = new Date("2020-01-01T00:00:00.000Z");
+		const rec: RecordedProcess = {
+			pid: 450,
+			pgid: 450,
+			startedAt: recordedStart.toISOString(),
+			command: "app",
+		};
+		const fns = fakeSignals({
+			alive: new Set([450]),
+			startTimes: { 450: recordedStart.getTime() - 86_400_000 },
+		});
+		const outcome = await stopProcess("web", rec, fns, {
+			graceMs: 0,
+			sleep: noSleep,
+		});
+
+		expect(outcome).toEqual({ component: "web", result: "identity-mismatch" });
+		// Only the liveness probe (signal 0) may have been sent — never a real
+		// kill, and never against the group target.
+		expect(fns.sent).toEqual([{ pid: 450, signal: 0 }]);
 	});
 
 	it("reports already-dead and signals nothing for a dead pid", async () => {

--- a/providers/macos-dev/src/process-stopper.ts
+++ b/providers/macos-dev/src/process-stopper.ts
@@ -16,9 +16,12 @@
  *   1. **Liveness** — `process.kill(pid, 0)` throws ESRCH if no such process
  *      exists. If it's dead, we skip (already stopped).
  *   2. **Identity** — we compare the recorded spawn time against the live
- *      process's actual start time via `ps -o lstart= -p <pid>`. If the live
- *      process started meaningfully later than we recorded, the pid was
- *      recycled and we REFUSE to signal it.
+ *      process's actual start time via `ps -o lstart= -p <pid>`. If the two
+ *      are further apart than the tolerance window, in either direction, the
+ *      record does not describe this process and we REFUSE to signal it. A
+ *      later live start means the pid was recycled; an earlier one means the
+ *      record itself is untrustworthy (a backward clock jump between spawn and
+ *      `down`, or a state file carried over from another run).
  *
  * This is a best-effort guarantee, not a cryptographic one. Its honest limits:
  *   - `ps lstart` has ~1s resolution, so we allow a small tolerance window. A
@@ -65,10 +68,12 @@ export interface RecordedProcess {
 }
 
 /**
- * Identity tolerance: how much later than `startedAt` a live process may report
- * having started before we treat it as a recycled pid. `ps lstart` rounds to
- * whole seconds and there's scheduling slop between our `Date.now()` snapshot
- * and the kernel's recorded start, so we allow a few seconds of forward drift.
+ * Identity tolerance: how far a live process's reported start time may sit from
+ * `startedAt`, on either side, before we stop believing the record describes
+ * that process. `spawn()` forks before we timestamp the record and `ps lstart`
+ * rounds down to whole seconds, so a genuine record reads a second or so
+ * *earlier* than `startedAt`; scheduling slop covers the rest. The window is
+ * symmetric because a record can be wrong in either direction.
  */
 const START_TIME_TOLERANCE_MS = 3000;
 
@@ -109,7 +114,8 @@ function queryStartTime(pid: number): Promise<number | null> {
  *   - "alive-verified": process exists AND start time is consistent → safe to signal
  *   - "alive-unverified": process exists but start time couldn't be read → signal group only, cautiously
  *   - "dead": no such process (ESRCH) → already stopped, skip
- *   - "mismatch": process exists but started too late → recycled pid, DO NOT signal
+ *   - "mismatch": process exists but its start time is outside the tolerance
+ *     window on either side → the record does not describe it, DO NOT signal
  */
 export async function checkIdentity(
 	rec: RecordedProcess,
@@ -131,9 +137,12 @@ export async function checkIdentity(
 	const recordedStart = Date.parse(rec.startedAt);
 	if (Number.isNaN(recordedStart)) return "alive-unverified";
 
-	// If the live process started meaningfully *after* we recorded the spawn,
-	// the original exited and the pid was recycled. Refuse to signal it.
-	if (liveStart > recordedStart + START_TIME_TOLERANCE_MS) return "mismatch";
+	// The live start time must sit within tolerance of the record on both sides.
+	// Later than the record: the original exited and the pid was recycled.
+	// Earlier than the record: the record cannot be describing this process.
+	// Either way the pid is not ours to signal.
+	if (Math.abs(liveStart - recordedStart) > START_TIME_TOLERANCE_MS)
+		return "mismatch";
 
 	return "alive-verified";
 }

--- a/providers/macos-dev/src/provider.ts
+++ b/providers/macos-dev/src/provider.ts
@@ -836,7 +836,9 @@ export async function launchDown(opts: { destroy?: boolean; projectDir?: string 
 					console.log(`  ${o.component} was not running`);
 					break;
 				case "identity-mismatch":
-					console.log(`  Skipped ${o.component} (pid recycled — left untouched)`);
+					console.log(
+						`  Skipped ${o.component} (live process start time does not match the recorded one — left untouched)`,
+					);
 					break;
 				case "error":
 					console.log(`  Failed to stop ${o.component}: ${o.error}`);


### PR DESCRIPTION
Closes #442

## What changed

**`providers:` — make the macos-dev pid identity check symmetric** (`0c52c11`)

- `providers/macos-dev/src/process-stopper.ts:136` now reads
  `Math.abs(liveStart - recordedStart) > START_TIME_TOLERANCE_MS`, so a live
  start time outside the window on *either* side returns `"mismatch"`. The
  tolerance value is unchanged (3000ms).
- Rewrote the three comments the change falsifies: the module header's step 2,
  the `START_TIME_TOLERANCE_MS` doc block (which justified the window as
  "forward drift" only), and `checkIdentity`'s JSDoc line for `"mismatch"`.
- `provider.ts:839` printed `Skipped <component> (pid recycled — left
  untouched)`. A mismatch now has three possible causes, so the line reports
  what was observed: `Skipped <component> (live process start time does not
  match the recorded one — left untouched)`.
- Three tests in `src/__tests__/process-stopper.test.ts`: `checkIdentity` with
  a live process a day *earlier* than the record (expects `"mismatch"` — this
  returned `"alive-verified"` before), `checkIdentity` at ~1500ms earlier
  (expects `"alive-verified"` — the `ps lstart` truncation case), and
  `stopProcess` on the far-earlier delta asserting the `kill` spy saw exactly
  `[{ pid: 450, signal: 0 }]` — the liveness probe and nothing else.

**`chore:` — changeset** (`fd18324`)

- `.changeset/macos-dev-identity-tolerance-symmetric.md`, patch for
  `@launchfile/macos-dev`.

## Why

This is the shape the steward's ACCEPT verdict on #442 bound, item for item:
the `Math.abs` comparison, the three stale comments, the operator message, two
`checkIdentity` tests, one `stopProcess` test.

The one-sided test let anything not *later than* the record fall through to
`"alive-verified"` at line 138, and `stopProcess` then computes
`groupTarget = -rec.pgid` and sends SIGTERM (line 165) and SIGKILL (line 184)
with no further identity check. Two inputs reach the gap: a fabricated
far-future `startedAt` in `.launchfile/state.json`, and a backward clock jump
(NTP correction, manual change, VM suspend/resume) between the spawn record and
the `down` read. The second survives #261's input bound entirely — the two
fixes are defence in depth, which is why #261's review split them.

Genuine records are unaffected. `spawn()` forks before `process-manager.ts:159`
takes `new Date().toISOString()`, and `ps -o lstart=` rounds down to whole
seconds, so a real record reads roughly 0–1s on the earlier side — well inside
the 3000ms window. No existing test changes behaviour: every `alive-verified`
case uses a zero delta and the one `mismatch` case uses +86,400,000ms.

Provider conduct, not format — no schema, parser, field, or spec change, and no
new `D-*` entry. [D-20](https://github.com/launchfile/launchfile/blob/main/spec/DESIGN.md#d-20-running-instance-state-is-an-orchestrator-concern)
places recorded pids, pgids, and `startedAt` in orchestrator territory, and
[P-11](https://github.com/launchfile/launchfile/blob/main/spec/DESIGN.md#design-principles)
separates intent from execution.

## Verification

Run from the branch worktree. `sdk` first, then the touched package, then the
CLI that consumes the providers.

```
sdk/                  bun install && bun run build && bun run test
                      → Test Files 21 passed (21), Tests 522 passed (522)
providers/macos-dev/  bun install && bun run typecheck && bun run build && bun run test
                      → typecheck clean, build clean
                      → Test Files 26 passed (26), Tests 242 passed (242)
packages/launchfile/  bun install && bun run typecheck && bun run build && bun run test
                      → Test Files 11 passed (11), Tests 105 passed (105)
                      (needs providers/docker built first — pre-existing build order)
```

**The new tests fail against the old comparison.** Reverting only line 136 to
`liveStart > recordedStart + START_TIME_TOLERANCE_MS` and re-running:

```
 × flags identity mismatch when the live process started much earlier than the record 3ms
 × does NOT signal a process whose live start time precedes the record 2ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/__tests__/process-stopper.test.ts > stopProcess > does NOT signal a process whose live start time precedes the record
AssertionError: expected { component: 'web', result: 'stopped' } to deeply equal { component: 'web', …(1) }
 Test Files  1 failed | 25 passed (26)
      Tests  2 failed | 240 passed (242)
```

**Observed live, not just in unit tests.** A real detached `sh -c 'sleep 30'`
was spawned, recorded in a temp project's `.launchfile/state.json` with a
`startedAt` one hour in the future, and `launchDown({ projectDir })` was run
against it.

Before the fix — the unrelated live process group was killed:

```
live pid 84911; recorded startedAt 2026-09-11T18:49:42.877Z (1h in the future)
Stopping app processes...
  Stopped web
Stopped. Resources are still running (use --destroy to remove them).
pid 84911 still alive after down: false
```

After the fix — the same record is refused and the process survives:

```
live pid 83096; recorded startedAt 2026-09-11T18:49:35.044Z (1h in the future)
Stopping app processes...
  Skipped web (live process start time does not match the recorded one — left untouched)
Stopped. Resources are still running (use --destroy to remove them).
pid 83096 still alive after down: true
```

## Left out, deliberately

- **No `state.json` validation.** That is #261's scope; the verdict's scope
  fence keeps the two disjoint. Ordering against #261 is free.
- **`START_TIME_TOLERANCE_MS` is untouched** at 3000ms.
- **No docker-provider change.** It has no identity check because the Docker
  daemon owns container lifecycle.
- **No zero-delta or large-positive-delta tests re-added** — already covered in
  `process-stopper.test.ts` and `down-processes.test.ts`.
- **No doc change.** The only doc sentence describing this path,
  `spec/PROVIDERS.md:217` ("guarded against pid reuse"), stays true.
- **`bun.lock` is byte-identical to `origin/main`** (sha256
  `7a2654a…`). A local `bun install` rewrites it because main's root lockfile
  is stale (#426 → PR #493); it was restored before committing.
- **`bun run lint` (biome) is red across this package on `main` too** — 58
  errors over 56 files, from the absent root `biome.json`. CI does not run it.
  Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
