### PR TITLE
catalog: suffix udp ports with /udp in the compose harness

### DIFF
--- a/catalog/test/src/launch-to-compose.test.ts
+++ b/catalog/test/src/launch-to-compose.test.ts
@@ -8,8 +8,8 @@
  *
  * Regression anchor for the PR #104 fix (set_env was using a resource-props-only
  * stub, so $secrets/$storage/$app silently resolved to the raw "$ref") and the
- * $components.* context follow-up. catalog/test is not in the CI build order, so
- * run this manually: `cd catalog/test && bun install && bun run test`.
+ * $components.* context follow-up. The "Catalog" CI job runs this suite on
+ * every PR (`.github/workflows/ci.yml`).
  */
 
 import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
@@ -791,5 +791,31 @@ supports:
       for (const r of resourceRefusals) refused.push(`${app} [${r.component}]: ${r.entry}`);
     }
     expect(refused).toEqual([]);
+  });
+});
+
+describe("service.ports — protocol suffix (matches providers/docker/src/compose-generator.ts)", () => {
+  it("suffixes a udp exposed port with /udp and leaves the http port bare", () => {
+    const yaml = `
+name: wg-easy
+image: ghcr.io/wg-easy/wg-easy:15
+provides:
+  - name: web
+    protocol: http
+    port: 51821
+    exposed: true
+  - name: wg
+    protocol: udp
+    port: 51820
+    exposed: true
+`;
+    const result = launchToCompose(readLaunch(yaml));
+    const compose = parse(result.yaml) as {
+      services: Record<string, { ports?: string[] }>;
+    };
+    expect(compose.services["wg-easy"]!.ports).toEqual(
+      expect.arrayContaining(["0:51820/udp", "0:51821"]),
+    );
+    expect(compose.services["wg-easy"]!.ports).not.toContain("0:51820");
   });
 });

--- a/catalog/test/src/launch-to-compose.ts
+++ b/catalog/test/src/launch-to-compose.ts
@@ -487,7 +487,9 @@ export function launchToCompose(launch: NormalizedLaunch, opts: ComposeOpts = {}
 
     const allExposedPorts = [...directPorts, ...loopbackPorts];
     if (allExposedPorts.length > 0) {
-      service.ports = allExposedPorts.map((p) => `0:${p.port}`);
+      service.ports = allExposedPorts.map(
+        (p) => `0:${p.port}${p.protocol === "udp" ? "/udp" : ""}`,
+      );
     }
 
     // Register this component for $components.<name>.prop resolution, mirroring the


### PR DESCRIPTION
Closes #482

## What changed

- `catalog/test/src/launch-to-compose.ts:446` — `service.ports` now appends `/udp` when the endpoint's `protocol` is `udp`, matching `providers/docker/src/compose-generator.ts:1174`.
- `catalog/test/src/launch-to-compose.test.ts` — new regression test (`service.ports — protocol suffix`): a component with a `protocol: udp, exposed: true` endpoint and a sibling `protocol: http` endpoint asserts the compose output contains `0:51820/udp` and `0:51821` (no suffix), and explicitly asserts `0:51820` (the old, wrong form) is absent.
- `catalog/test/src/launch-to-compose.test.ts:1-11` — corrected the file docstring, which claimed catalog/test was outside the CI build order and had to be run manually. That stopped being true when the "Catalog" job was added to `.github/workflows/ci.yml` in `c6a66e1`.

One commit, prefixed `catalog:`.

## Why

Steward verdict on #482: **ACCEPT**. `launch-to-compose.ts:446` is the harness's only site that writes `service.ports`, and it built every port as `0:<port>` with no protocol suffix regardless of the endpoint's declared `protocol`. The harness exists to predict what the Docker provider produces; the provider's own mapping at `providers/docker/src/compose-generator.ts:1174` does append `/udp` for udp endpoints, so the two implementations disagreed. `protocol` describes the component's own listener ([D-59](https://github.com/launchfile/launchfile/blob/main/spec/DESIGN.md#d-59-providesprotocol-describes-the-components-own-listener)), so a harness that ignores it models a different app than the one declared — concretely, wg-easy's `wg` endpoint (`protocol: udp, exposed: true`) would predict a TCP publication instead of the UDP one Docker actually publishes.

wg-easy is the only catalog entry with both `protocol: udp` and `exposed: true`; pihole and syncthing declare `protocol: udp` but omit `exposed: true` ([D-27](https://github.com/launchfile/launchfile/blob/main/spec/DESIGN.md#d-27-exposed-false-by-default) defaults it to false), so they never reach line 446 and the bug is inert for them. The steward decided this directly rather than routing to the project Authors — it changes only the `catalog/test` harness, adds no field/syntax/decision, and one real app is enough motivation for a translator-bug fix (no new format surface to weigh against the 3-app bar in [GOVERNANCE.md](https://github.com/launchfile/launchfile/blob/main/governance/GOVERNANCE.md#1-proposal)).

**Left out, per the verdict:** the fix does not attempt host-port 1:1 publication (line 435's comment stands) — the provider only allocates `hostPort == containerPort` when that port is free on the live host at allocation time (`providers/docker/src/port-allocator.ts:170-173`), which a static compose file can't express. Matching that belongs to #230, which replaces this generator with the provider's own `launchToCompose`. The socat sidecar for loopback-bound ports (`launch-to-compose.ts:673-681`) has the same TCP-only gap, but no catalog entry declares a loopback-bound UDP endpoint today, so it also waits for #230.

## Verification

```
cd sdk && bun install && bun run build && bun run test
# Test Files  21 passed (21) / Tests  522 passed (522)

cd providers/docker && bun install && bun run typecheck && bun run build && bun run test
# typecheck: clean
# Test Files  32 passed (32) / Tests  469 passed (469)  — includes the Docker-daemon suites, ran successfully (Docker was available)

cd catalog/test && bun run typecheck && bun run test && bun run validate-catalog
# typecheck: clean
# Test Files  3 passed (3) / Tests  58 passed (58)  — includes the new udp/http fixture test
# validate-catalog: 113 catalog Launchfile(s) validated — 0 error(s), 0 warning(s)
```

Observed the new test's assertion directly (excerpt from the harness output for the fixture):

```
compose.services["wg-easy"].ports === ["0:51821", "0:51820/udp"]
```

`bun install` at the repo root regenerated `bun.lock` with version drift unrelated to this change (root lockfile is known-stale, tracked separately in #426 / PR #493). Restored `bun.lock` to be byte-identical to `origin/main` before committing — this PR's diff touches only the two `catalog/test` files.

No `.changeset/*.md` — `catalog/test` is not a published package (sdk, providers/*, packages/launchfile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
