### PR TITLE
catalog: name the harness's storage volumes to match providers/docker

### DIFF
--- a/catalog/apps/vaultwarden/Launchfile
+++ b/catalog/apps/vaultwarden/Launchfile
@@ -5,7 +5,7 @@ description: "Self-hosted password manager — works with all Bitwarden apps and
 repository: https://github.com/dani-garcia/vaultwarden
 logo: https://raw.githubusercontent.com/dani-garcia/vaultwarden/main/resources/vaultwarden-icon.svg
 
-image: vaultwarden/server:latest
+image: vaultwarden/server:1.37.2
 provides:
   - name: web
     protocol: http

--- a/catalog/apps/vaultwarden/metadata.yaml
+++ b/catalog/apps/vaultwarden/metadata.yaml
@@ -1,15 +1,15 @@
 category: Passwords
-tagline: "Self-hosted password manager — works with all Bitwarden apps and browser extensions"
+tagline: Self-hosted password manager — works with all Bitwarden apps and browser extensions
 homepage: https://github.com/dani-garcia/vaultwarden
 test_results:
-  last_tested: 2026-04-06
-  pull_time_seconds: 3
+  last_tested: 2026-09-11
+  pull_time_seconds: 2
   startup_time_seconds: 61
-  total_disk_mb: 251
+  total_disk_mb: 83
   health_check_passed: true
   notes: ""
 images:
-  - name: vaultwarden/server:latest
-    size_mb: 251
+  - name: vaultwarden/server:1.37.2
+    size_mb: 83
     platform:
       - linux/arm64

--- a/catalog/test/src/launch-to-compose.test.ts
+++ b/catalog/test/src/launch-to-compose.test.ts
@@ -484,8 +484,8 @@ storage:
       const result = launchToCompose(readLaunch(MARKED), { storagePaths: { music: dir } });
       expect(result.storageRefusals).toEqual([]);
       expect(result.yaml).toContain(`${dir}:/music`);
-      // The unmarked volume keeps its anonymous-volume form.
-      expect(result.yaml).toContain("- /data");
+      // The unmarked volume is named, matching providers/docker's emission.
+      expect(result.yaml).toContain("- media-data:/data");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -565,6 +565,22 @@ components:
       for (const r of storageRefusals) refused.push(`${app} [${r.component}]: ${r.volume}`);
     }
     expect(refused).toEqual([]);
+  });
+});
+
+describe("unmarked storage volumes are named, matching providers/docker", () => {
+  it("names the service-list mount and declares it in the top-level volumes map (#466)", () => {
+    const result = launchToCompose(
+      readLaunch(`
+name: plain
+image: nginx
+storage:
+  data:
+    path: /data
+`),
+    );
+    expect(result.yaml).toContain("- plain-data:/data");
+    expect(result.yaml).toContain("volumes:\n  plain-data: {}");
   });
 });
 

--- a/catalog/test/src/launch-to-compose.ts
+++ b/catalog/test/src/launch-to-compose.ts
@@ -610,13 +610,15 @@ export function launchToCompose(launch: NormalizedLaunch, opts: ComposeOpts = {}
       service.healthcheck = translateHealth(component.health, component.provides);
     }
 
-    // Storage volumes — use anonymous volumes to preserve image filesystem ownership
-    // (named volumes mount as root, which breaks non-root containers). A
-    // `content: operator` volume (D-50) is instead bound to the supplied host
-    // path, mirroring the Docker provider's four states: path supplied →
-    // bind; no path → refused; path absent/unreadable → refused, never
-    // created; no marker → unchanged. A refused volume gets NO mount — an
-    // empty volume standing in for the operator's content is exactly the
+    // Storage volumes — name volumes to match `providers/docker`'s emission.
+    // Ownership is moot: every service in this harness runs as `user: "0:0"`
+    // (see above), so a root-mounted named volume breaks nothing. Nothing
+    // survives teardown either way — `test-app.ts` runs `docker compose down
+    // -v`. A `content: operator` volume (D-50) is instead bound to the
+    // supplied host path, mirroring the Docker provider's four states: path
+    // supplied → bind; no path → refused; path absent/unreadable → refused,
+    // never created; no marker → unchanged. A refused volume gets NO mount —
+    // an empty volume standing in for the operator's content is exactly the
     // fabrication whose health pass this harness must not certify.
     if (component.storage) {
       const svcVolumes: string[] = [];
@@ -650,7 +652,9 @@ export function launchToCompose(launch: NormalizedLaunch, opts: ComposeOpts = {}
           svcVolumes.push(`${bound.path}:${vol.path}`);
           continue;
         }
-        svcVolumes.push(vol.path);
+        const namedVolume = `${serviceName}-${volName}`;
+        svcVolumes.push(`${namedVolume}:${vol.path}`);
+        volumes[namedVolume] = {};
       }
       if (svcVolumes.length > 0) {
         service.volumes = svcVolumes;


### PR DESCRIPTION
Closes #466

## What changed

One commit (`catalog:`):

- `catalog/test/src/launch-to-compose.ts` — replace the anonymous-volume push (`svcVolumes.push(vol.path)`) for an unmarked storage volume with the docker provider's own three lines: name the volume `${serviceName}-${volName}`, push `name:path`, register it in the top-level `volumes` map. Delete the comment claiming named volumes "break non-root containers" and replace it with the true state: every harness service already runs `user: "0:0"`, so ownership is moot, and `docker compose down -v` removes the volume at teardown either way.
- `catalog/test/src/launch-to-compose.test.ts` — update the one existing assertion that pinned the old anonymous-volume string (`- /data` → `- media-data:/data`), and add a new test (`unmarked storage volumes are named, matching providers/docker`) asserting the named mount in the service's `volumes:` list and its declaration in the top-level `volumes:` map.
- `catalog/apps/vaultwarden/Launchfile` — pin `image: vaultwarden/server:1.37.2`.
- `catalog/apps/vaultwarden/metadata.yaml` — written by a fresh harness run (see Verification).

## Why

The steward's ACCEPT verdict on #466 binds this shape. `@launchfile/docker` mounts a named volume for `catalog/apps/vaultwarden/Launchfile`'s `storage.data`; the harness that stands in for that provider pushed the bare container path instead, which Docker renders anonymous — so the harness didn't test what the provider deploys. vaultwarden `1.37.2` refuses to start without a persistent volume, and the anonymous mount left it unfilled.

- No `persistent: true` gate: `providers/docker/src/compose-generator.ts` never checks `persistent` — it names every volume that isn't `content: operator`. A gate would make the harness disagree with the provider in the one case it could fire.
- The `test_env: I_REALLY_WANT_VOLATILE_STORAGE` route (the issue's option 2) is a no-op — that key isn't declared `required:` anywhere in vaultwarden's Launchfile, so `test_env` is never consulted for it. Making it work would need a `required:` env no real deployment wants, against [D-52].
- The image pin follows `catalog/CONTRIBUTING.md`'s rung 2: upstream (`vaultwarden/server`) publishes exact releases (1.30.0 … 1.37.2) but no maintained version channel, so `:latest` is the wrong rung. The floating tag is why the recorded pass rotted silently — `:latest` moved to `1.37.2`, which added the refusal, with nothing producing a diff.

Cited by the verdict: [D-52], [D-60].

## Verification

```
$ cd sdk && bun install && bun run build && bun run test
 Test Files  21 passed (21)
      Tests  522 passed (522)

$ cd catalog/test && bun install && bun run typecheck
(clean, no output)

$ cd catalog/test && bun run test
 Test Files  3 passed (3)
      Tests  58 passed (58)

$ cd catalog/test && bun run src/test-app.ts vaultwarden --url https://vaultwarden.example.test
=== Testing: vaultwarden ===
Images needed: 1
  - vaultwarden/server:1.37.2

Pulling images...
Pull completed in 2s
Total image disk: 83 MB

Starting containers...
Containers healthy in 61s

=== vaultwarden: PASS ===
  Pull time:    2s
  Startup time: 61s
  Disk usage:   83 MB

Metadata written: catalog/apps/vaultwarden/metadata.yaml
Tearing down...
Done.
```

`--url` is required post-[D-60] (the https-origin gate) to reach the volume path at all — unpatched, this same command fails at `[ERROR] No persistent volume!`; patched, it passes.

`catalog/test/src/validate-catalog.ts` also ran clean: `113 catalog Launchfile(s) validated — 0 error(s), 0 warning(s)`.

Providers/packages under `providers/*` and `packages/launchfile` are untouched by this change, so their own build/test wasn't run.

## Left out

- Widening `test_env:` or adding a `persistent`-gated rule (issue's options 2/3) — the verdict rejects both; see Why above.
- The catalog-wide `:latest` staleness (63/72 apps, most last tested 2026-04) — the verdict names this as a separate, larger question (see #480), out of scope here.
- `.github/workflows/` — untouched; this issue isn't about CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
