### PR TITLE
providers: poll the NDJSON file in bootstrap-reveal.test.ts before asserting (#517)

### DIFF
--- a/providers/docker/src/__tests__/bootstrap-reveal.test.ts
+++ b/providers/docker/src/__tests__/bootstrap-reveal.test.ts
@@ -87,8 +87,39 @@ afterAll(async () => {
 	await rm(logDir, { recursive: true, force: true });
 });
 
-async function ndjson(): Promise<string> {
-	return readFile(LOG_FILE, "utf8").catch(() => "");
+/**
+ * Read the NDJSON file once it satisfies `ready`, polling up to `timeoutMs`.
+ *
+ * The file sink is asynchronous (`pino.destination` → sonic-boom with its
+ * default `sync: false`): `getLogger().debug()` queues the line and a later
+ * `fs.write` completion lands it on disk, so a read straight after the call
+ * can see an earlier chunk only. The poll is bounded: a line the provider
+ * never wrote still fails, it just fails after the deadline.
+ */
+async function ndjson(
+	ready: (log: string) => boolean = () => true,
+	timeoutMs = 3000,
+): Promise<string> {
+	const read = () => readFile(LOG_FILE, "utf8").catch(() => "");
+	const deadline = Date.now() + timeoutMs;
+	let log = await read();
+	while (!ready(log) && Date.now() < deadline) {
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		log = await read();
+	}
+	return log;
+}
+
+/** The `bootstrap command finished` records for one compose service, parsed. */
+function finishedRecords(
+	log: string,
+	composeService: string,
+): Array<Record<string, unknown>> {
+	return log
+		.split("\n")
+		.filter((l) => l.includes("bootstrap command finished"))
+		.map((l) => JSON.parse(l) as Record<string, unknown>)
+		.filter((l) => l.composeService === composeService);
 }
 
 describe("masked by default (SPEC.md § Command Capture, D-62)", () => {
@@ -183,26 +214,30 @@ describe.each([
 		});
 
 		it("keeps the value out of the NDJSON log on success and on failure", async () => {
-			await bootstrap.runBootstraps(plan(), {
+			// An app name unique to this test (it becomes the record's
+			// `composeService`), so the records asserted on are the two runs
+			// below and not an earlier test's.
+			const service = `acme-ndjson-${reveal ? "revealed" : "masked"}`;
+			const item = bootstrap.planBootstraps(
+				readLaunch(LAUNCHFILE.replace("name: acme", `name: ${service}`)),
+				{ hostPorts: {}, secrets: {} },
+			);
+			await bootstrap.runBootstraps(item, {
 				project: "lf-acme",
 				exec: fakeExec(0),
 				reveal,
 			});
-			await bootstrap.runBootstraps(plan(), {
+			await bootstrap.runBootstraps(item, {
 				project: "lf-acme",
 				exec: fakeExec(1),
 				reveal,
 			});
-			const log = await ndjson();
-			const lines = log
-				.split("\n")
-				.filter((l) => l.includes("bootstrap command finished"));
-			expect(lines.length).toBeGreaterThanOrEqual(2);
+			const log = await ndjson((l) => finishedRecords(l, service).length >= 2);
+			const records = finishedRecords(log, service);
+			expect(records.map((r) => r.exitCode)).toEqual([0, 1]);
 			expect(log).not.toContain(INVITE);
 			// The failing run's stderr echoed the link; it landed scrubbed.
-			const failed = lines
-				.map((l) => JSON.parse(l) as Record<string, unknown>)
-				.find((l) => l.exitCode === 1)!;
+			const failed = records[1]!;
 			expect(failed.stderr).toContain(redact.REDACTED);
 			expect(failed.captured).toEqual(["invite_link", "admin_user"]);
 		});


### PR DESCRIPTION
Closes #517

## What

`providers/docker/src/__tests__/bootstrap-reveal.test.ts` › "keeps the value out of the NDJSON log on success and on failure" read the log file straight after the second `runBootstraps` call. The file sink is asynchronous, so on a contended runner the read saw only the first chunk (runs 34652579167 and 34728721535: `expected 1 to be greater than or equal to 2`).

Test-only change, one file, no changeset:

- `ndjson()` now takes a readiness predicate and polls until it holds — 20 ms interval, 3000 ms deadline, matching `logger.test.ts:298-312`. A line the provider never wrote still fails, after the deadline.
- The test names its own two runs: a unique app name (`acme-ndjson-masked` / `acme-ndjson-revealed`) becomes the record's `composeService`, and `finishedRecords()` filters on it. The assertion is now `exitCode`s `[0, 1]` for exactly those two records, and the scrubbed-stderr check reads the second one — not "at least 2 lines in the whole file" and not whichever earlier test's exit-1 line `.find` hit first.

## How the verdict's shape was addressed

| Bound shape | Done |
|---|---|
| Test-only; `logger.ts` untouched, sink stays async | Yes — diff touches only the test file |
| `ndjson()` polls, 20 ms / 3000 ms | Yes |
| Assert on this test's own two runs, not the file's total | Yes — via the unique `composeService`, the verdict's second permitted form ("mark the two runs so their records can be told apart"). I chose it over the "count before, wait for +2" form because the `before` read is itself subject to the same lag: an undercounted `before` lets earlier tests' late lines satisfy `before + 2`. Filtering on a name this test alone uses has no such hole. |
| Keep asserting against the on-disk file | Yes — the header comment and the file-based `INVITE` check are unchanged |
| No `D-*` entry, no #471 bundling | Yes |
| Proof: ten consecutive local runs + green `Provider (docker)` job | Below; CI on this PR |

## Verification (observed)

**Mechanism, reproduced deterministically.** `pino.destination()` (`logger.ts:98-103`) builds a sonic-boom stream with its default `sync: false` (`sonic-boom/index.js:27`, `this.sync = sync || false`); `write()` calls `fs.write` asynchronously and buffers later lines until the callback fires. sonic-boom's `flush(cb)` is a no-op when `minLength <= 0` (`index.js:402-415`), so "await the sink's flush" was not an option. Prepending a shim that delays `fs.write`'s callback by 30 ms:

```
=== ORIGINAL test under 30ms fs.write lag ===
 FAIL  … (masked) > keeps the value out of the NDJSON log on success and on failure
 FAIL  … (revealed) > keeps the value out of the NDJSON log on success and on failure
AssertionError: expected 1 to be greater than or equal to 2
      Tests  2 failed | 13 passed (15)
=== FIXED test under 30ms fs.write lag ===
      Tests  15 passed (15)
```

Same assertion text as both CI failures. A probe that polled after the same two calls read `immediate=1 polled=2` three times out of three — `runBootstraps` writes both lines; the file lags.

**Ten consecutive runs** of the file (`bunx vitest run src/__tests__/bootstrap-reveal.test.ts`):

```
Tests  15 passed (15)   ×10
```

Also 30/30 passes of the file while four whole-suite `vitest run`s ran alongside as load (macOS did not reproduce the lag without the shim — the CI runner's disk contention is what the shim stands in for).

**Full provider suite** (`cd providers/docker && bun run test`): 36 files, 574 tests passed. `bun run typecheck` clean. `biome check` on the file: 0 errors, the same 10 pre-existing `noNonNullAssertion` warnings as `main`. `bun test` hits the repo's guard as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
